### PR TITLE
Add timeout parameter, test for null, minor refactor.

### DIFF
--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector.DirectLine;
 using Microsoft.VisualStudio.TestTools.UnitTesting;


### PR DESCRIPTION
Test execution fails. See from log:

Test method FunctionalTests.SimpleHostBotToEchoSkillTest.ShouldReceiveDotNetSkillAnswerAsync threw exception: 
System.NullReferenceException: Object reference not set to an instance of an object.
Stack Trace:
at FunctionalTests.SimpleHostBotToEchoSkillTest.ReadBotMessagesAsync(DirectLineClient client, String conversationId) in D:\a\1\s\SkillsFunctionalTests\tests\SkillFunctionalTests\SimpleHostBotToEchoSkillTest.cs:line 95
at FunctionalTests.SimpleHostBotToEchoSkillTest.SendMessagesToBotAsync(String user, List`1 messages) in D:\a\1\s\SkillsFunctionalTests\tests\SkillFunctionalTests\SimpleHostBotToEchoSkillTest.cs:line 66
at FunctionalTests.SimpleHostBotToEchoSkillTest.ShouldReceiveDotNetSkillAnswerAsync() in D:\a\1\s\SkillsFunctionalTests\tests\SkillFunctionalTests\SimpleHostBotToEchoSkillTest.cs:line 33