### PR TITLE
[C# Skills Functional Tests] Change bots targets to NET Core 3.1

### DIFF
--- a/SkillsFunctionalTests/dotnet/host/Program.cs
+++ b/SkillsFunctionalTests/dotnet/host/Program.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot
 {
@@ -14,16 +14,19 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot
         /// <param name="args">The command line args.</param>
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="WebHost"/> class with pre-configured defaults.
+        /// Creates a new instance of the <see cref="HostBuilder"/> class with pre-configured defaults.
         /// </summary>
         /// <param name="args">The command line args.</param>
-        /// <returns>The initialized <see cref="IWebHostBuilder"/>.</returns>
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+        /// <returns>The initialized <see cref="IHostBuilder"/>.</returns>
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/SkillsFunctionalTests/dotnet/host/SimpleHostBot.csproj
+++ b/SkillsFunctionalTests/dotnet/host/SimpleHostBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UserSecretsId>6310bd04-2272-4a74-82fa-6791f5c7e115</UserSecretsId>
     <AssemblyName>Microsoft.BotFrameworkFunctionalTests.SimpleHostBot</AssemblyName>
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.7.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0-rc1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SkillsFunctionalTests/dotnet/host/Startup.cs
+++ b/SkillsFunctionalTests/dotnet/host/Startup.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
@@ -13,6 +12,7 @@ using Microsoft.Bot.Connector.Authentication;
 using Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Authentication;
 using Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Bots;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot
 {
@@ -24,7 +24,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot
         /// <param name="services">The collection of services to add to the container.</param>
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            services.AddControllers().AddNewtonsoftJson();
 
             // Configure credentials
             services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
@@ -60,22 +60,21 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot
         /// </summary>
         /// <param name="app">The application request pipeline to be configured.</param>
         /// <param name="env">The web hosting environment.</param>
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }
-            else
-            {
-                app.UseHsts();
-            }
 
-            app.UseDefaultFiles();
-            app.UseStaticFiles();
-
-            // app.UseHttpsRedirection();
-            app.UseMvc();
+            app.UseDefaultFiles()
+                .UseStaticFiles()
+                .UseRouting()
+                .UseAuthorization()
+                .UseEndpoints(endpoints =>
+                {
+                    endpoints.MapControllers();
+                });
         }
     }
 }

--- a/SkillsFunctionalTests/dotnet/skill/EchoSkillBot.csproj
+++ b/SkillsFunctionalTests/dotnet/skill/EchoSkillBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UserSecretsId>f94e58a2-e019-4a0c-a6c2-59ecb1115b80</UserSecretsId>
     <AssemblyName>Microsoft.BotFrameworkFunctionalTests.EchoSkillBot</AssemblyName>
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.7.2" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0-rc1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SkillsFunctionalTests/dotnet/skill/Program.cs
+++ b/SkillsFunctionalTests/dotnet/skill/Program.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot
 {
@@ -14,16 +14,19 @@ namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot
         /// <param name="args">The command line args.</param>
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="WebHost"/> class with pre-configured defaults.
+        /// Creates a new instance of the <see cref="HostBuilder"/> class with pre-configured defaults.
         /// </summary>
         /// <param name="args">The command line args.</param>
-        /// <returns>The initialized <see cref="IWebHostBuilder"/>.</returns>
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+        /// <returns>The initialized <see cref="IHostBuilder"/>.</returns>
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/SkillsFunctionalTests/dotnet/skill/Startup.cs
+++ b/SkillsFunctionalTests/dotnet/skill/Startup.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
@@ -12,6 +11,7 @@ using Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.Authentication;
 using Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.Bots;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot
 {
@@ -23,7 +23,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot
         /// <param name="services"></param>
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            services.AddControllers().AddNewtonsoftJson();
 
             // Configure credentials
             services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
@@ -43,22 +43,21 @@ namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot
         /// </summary>
         /// <param name="app">The application request pipeline to be configured.</param>
         /// <param name="env">The web hosting environment.</param>
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }
-            else
-            {
-                app.UseHsts();
-            }
 
-            app.UseDefaultFiles();
-            app.UseStaticFiles();
-
-            // app.UseHttpsRedirection();
-            app.UseMvc();
+            app.UseDefaultFiles()
+                .UseStaticFiles()
+                .UseRouting()
+                .UseAuthorization()
+                .UseEndpoints(endpoints =>
+                {
+                    endpoints.MapControllers();
+                });
         }
     }
 }

--- a/build/yaml/dotnetBuildSteps.yml
+++ b/build/yaml/dotnetBuildSteps.yml
@@ -7,6 +7,11 @@ steps:
   inputs:
     version: 2.1.x
 
+- task: UseDotNet@2
+  displayName: 'Use .Net Core sdk 3.1.x'
+  inputs:
+    version: 3.1.x
+
 - task: NuGetToolInstaller@0
   displayName: 'Use NuGet 4.9.1'
   inputs:


### PR DESCRIPTION
## Description
Changed the target of Host and Skill bots to point to NET Core 3.1 instead of NET Core 2.1. Also modified the pipeline YAML files accordingly.

## Details
Changed the projects' target to point to NET Core 3.1. 
- Changed the **Microsoft.Bot.Builder.Integration.AspNet.Core** dependency from **4.7.0** to **4.8.0-preview**. 
- Added the **Microsoft.AspNetCore.Mvc.NewtonsoftJson** dependency.
- Changed the _dotnetBuildSteps.yml_  template to add a step for installing NET Core 3.1 along with 2.1.
