### PR TITLE
[Py-Py][Py-Js] Attach BotBuilder to 4.7.1 version

### DIFF
--- a/SkillsFunctionalTests/python/host/requirements.txt
+++ b/SkillsFunctionalTests/python/host/requirements.txt
@@ -1,3 +1,3 @@
-botbuilder-core>=4.7.1
+botbuilder-core==4.7.1
 python-dotenv
 aiohttp


### PR DESCRIPTION
## Description
This pull request updates the Python host bot to attach the BotBuilder packages to the 4.7.1 version. 

This is a hotfix for the issue reported:
```
From failing PythonPythonSkillBotFunctionalTest:
NightlyPyPyHostBot | Test in Web Chat does not respond.
NightlyPyPySkillBot | Test in Web Chat responds: “Echo <whatever I typed>”

From failing PyJsSkillBotFunctionalTest:
NightlyPyJsHostBot | Test in Web Chat does not respond.
NightlyPyJsSkillBot | Test in Web Chat responds "Echo <what I typed>".
``` 

## Changes made

We ran both pipelines the PythonPythonSkillBotFunctionalTest and the PyJsSkillBotFunctionalTest. They are running as expected.

**PythonPythonSkillBotFunctionalTest** 
![image](https://user-images.githubusercontent.com/37461749/77094367-222fa400-69eb-11ea-9f89-15bc13b652f7.png)

**PyJsSkillBotFunctionalTest**
![image](https://user-images.githubusercontent.com/37461749/77100864-1648df80-69f5-11ea-80d5-9f17dbd74911.png)