### PR TITLE
[Python-HostBot] Fix forward to Activity

### DIFF
--- a/SkillsFunctionalTests/python/host/bots/host_bot.py
+++ b/SkillsFunctionalTests/python/host/bots/host_bot.py
@@ -43,9 +43,7 @@ class HostBot(ActivityHandler):
 
             if active_skill:
                 # If there is an active skill, forward the Activity to it.
-                await self.__send_to_skill(
-                    turn_context, self._skills_config.SKILLS[active_skill]
-                )
+                await self.__send_to_skill(turn_context, active_skill)
                 return
 
         await super().on_turn(turn_context)


### PR DESCRIPTION
### Description
This pull request fixes how the host checks if there is an active skill and forward the activity to it. This was causing an error after the first echo from the skill when requesting a new echo or trying to end the connection.

### Testing
In the following images, you can see the error occurring before this change, and the bot working properly after the change.
![image](https://user-images.githubusercontent.com/38112957/78710431-be164680-78eb-11ea-91db-3b5273e241eb.png)