### PR TITLE
Add TriggeredReason=BuildRunner to conditionals for deploying.

### DIFF
--- a/build/yaml/dotnetHost2JavascriptSkill.yml
+++ b/build/yaml/dotnetHost2JavascriptSkill.yml
@@ -31,7 +31,7 @@ pool:
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -69,7 +69,7 @@ stages:
       - template: dotnetBuildSteps.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Deploy_Host
       variables:
@@ -146,7 +146,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_RG
       steps:

--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -33,7 +33,7 @@ pool:
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -71,7 +71,7 @@ stages:
       - template: dotnetBuildSteps.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Deploy_Host
       variables:
@@ -150,7 +150,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_RG
       steps:

--- a/build/yaml/dotnetHost2dotnetSkill.yml
+++ b/build/yaml/dotnetHost2dotnetSkill.yml
@@ -32,7 +32,7 @@ pool:
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -86,7 +86,7 @@ stages:
       - template: dotnetBuildSteps.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Deploy_Host
       variables:
@@ -164,7 +164,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_RG
       steps:

--- a/build/yaml/javascriptHost2DotnetSkill.yml
+++ b/build/yaml/javascriptHost2DotnetSkill.yml
@@ -31,7 +31,7 @@ pool:
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -69,7 +69,7 @@ stages:
       - template: dotnetBuildSteps.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Deploy_Host
       variables:
@@ -136,7 +136,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_RG
       steps:

--- a/build/yaml/javascriptHost2JavascriptSkill.yml
+++ b/build/yaml/javascriptHost2JavascriptSkill.yml
@@ -30,7 +30,7 @@ pool:
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -54,7 +54,7 @@ stages:
         continueOnError: true
        
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Deploy_Host
       variables:
@@ -120,7 +120,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(always(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(always(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_RG
       steps:

--- a/build/yaml/javascriptHost2PythonSkill.yml
+++ b/build/yaml/javascriptHost2PythonSkill.yml
@@ -32,7 +32,7 @@ pool:
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -56,7 +56,7 @@ stages:
         continueOnError: true
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Deploy_Host
       variables:
@@ -124,7 +124,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(always(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(always(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_RG
       steps:

--- a/build/yaml/pythonHost2DotnetSkill.yml
+++ b/build/yaml/pythonHost2DotnetSkill.yml
@@ -33,7 +33,7 @@ pool:
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -71,7 +71,7 @@ stages:
       - template: dotnetBuildSteps.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Deploy_Host
       pool:
@@ -138,7 +138,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_RG
       steps:

--- a/build/yaml/pythonHost2JavascriptSkill.yml
+++ b/build/yaml/pythonHost2JavascriptSkill.yml
@@ -32,7 +32,7 @@ pool:
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -56,7 +56,7 @@ stages:
         continueOnError: true
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Deploy_Host
       pool:
@@ -122,7 +122,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(always(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(always(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_RG
       steps:

--- a/build/yaml/pythonHost2PythonSkill.yml
+++ b/build/yaml/pythonHost2PythonSkill.yml
@@ -32,7 +32,7 @@ pool:
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -56,7 +56,7 @@ stages:
         continueOnError: true
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   pool:
     vmImage: 'ubuntu-latest'
   jobs:
@@ -122,7 +122,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(always(), in(variables['TriggeredReason'], 'Schedule', 'Manual'))
+  condition: and(always(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Delete_RG
       steps:


### PR DESCRIPTION
This allows the BuildRunners to trigger groups of builds with deploying and testing as they were originally designed to do, but using the current build chaining instead of the old pattern of waiting and taking up an extra build agent.