### PR TITLE
[4x6 Matrix] Add Javascript-JavascriptV3 yaml

### DIFF
--- a/build/yaml/javascriptHost2JavascriptV3Skill.yml
+++ b/build/yaml/javascriptHost2JavascriptV3Skill.yml
@@ -1,0 +1,139 @@
+#
+# Optionally deploy a Js Host bot and a v3 Js Skill bot and run functional tests. (No build stage.)
+#
+
+# "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
+name: $(Build.BuildId)
+trigger: none
+pr: none
+
+variables:
+  BuildConfiguration: 'Debug'
+  BuildPlatform: 'any cpu'
+  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
+  # AzureSubscription: define in Azure
+  # BotBuilderPackageVersionHost: (optional) define in Azure
+  # BotBuilderPackageVersionSkill: (optional) define in Azure
+  # DeleteResourceGroup: (optional) define in Azure
+  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
+  # JsJsV3HostAppId: define in Azure 
+  # JsJsV3HostAppSecret: define in Azure
+  # JsJsV3HostBotName: define in Azure
+  # JsJsV3SkillAppId: define in Azure
+  # JsJsV3SkillAppSecret: define in Azure
+  # JsJsV3SkillBotName: define in Azure
+  # NextBuild: define in Azure and set to either a build name or an empty string
+  # TriggeredBy: define in Azure and set to an empty string
+
+pool:
+  vmImage: 'windows-2019'
+
+stages:
+- stage: Prepare
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  jobs:
+    - job: Delete_Preexisting_Resources
+      variables:
+        HostBotName: $(JsJsV3HostBotName)
+        SkillBotName: $(JsJsV3SkillBotName)
+      steps:
+      - template: cleanResourcesStep.yml
+
+- stage: Tag
+  condition: always()
+  jobs:
+    - job: Tag
+      steps:
+      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
+        inputs:
+          tags: |
+            TriggeredReason=$(TriggeredReason)
+            $(TriggeredBy)
+            NextBuild=$(NextBuild)
+        continueOnError: true
+       
+- stage: Deploy
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  jobs:
+    - job: Deploy_Host
+      variables:
+        BotName: $(JsJsV3HostBotName)
+        DeployAppId: $(JsJsV3HostAppId)
+        DeployAppSecret: $(JsJsV3HostAppSecret)
+        BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
+        Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/host'
+        TemplateLocation: 'SkillsFunctionalTests/javascript/host/DeploymentTemplates/template-with-new-rg.json'
+      steps:
+      - powershell: |
+         Write-host "Setting values in .env file"
+         $file = "$(System.DefaultWorkingDirectory)/SkillsFunctionalTests/javascript/host/.env";
+         $content = Get-Content -Raw $file | ConvertFrom-StringData;
+
+         $content.SkillHostEndpoint = "https://$(JsJsV3HostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
+         $content.SkillId = "EchoSkillBot";
+         $content.SkillAppId = "$(JsJsV3SkillAppId)";
+         $content.SkillEndpoint = "https://$(JsJsV3SkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
+
+         Clear-Content $file;
+         foreach ($key in $content.keys) { Add-Content $file "$key=$($content.$key)" };
+        displayName: 'Update .env file'
+
+      - template: javascriptDeploySteps.yml
+
+    - job: Deploy_Skill
+      variables:
+        BotName: $(JsJsV3SkillBotName)
+        DeployAppId: $(JsJsV3SkillAppId)
+        DeployAppSecret: $(JsJsV3SkillAppSecret)
+        BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
+        Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/v3/skill'
+        TemplateLocation: 'SkillsFunctionalTests/javascript/v3/skill/DeploymentTemplates/template-with-new-rg.json'
+      steps:
+      - template: javascriptDeploySteps.yml
+
+- stage: Test
+  dependsOn: Deploy
+  jobs:
+    - job: Run_Functional_Test
+      variables:
+        HostBotName: $(JsJsV3HostBotName)
+        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+      steps:
+      - template: functionalTestSteps.yml
+
+- stage: Cleanup
+  dependsOn:
+  - Deploy
+  - Test
+  condition: and(always(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  jobs:
+    - job: Delete_RG
+      steps:
+      - task: AzureCLI@1
+        displayName: 'Delete Resource Group'
+        inputs:
+          azureSubscription: $(AzureSubscription)
+          scriptLocation: inlineScript
+          inlineScript: |
+           call az group delete -n "$(JsJsV3HostBotName)-RG" --yes
+           call az group delete -n "$(JsJsV3SkillBotName)-RG" --yes
+        condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
+
+- stage: QueueNext
+  condition: and(always(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
+  jobs:
+    - job: TriggerBuild
+      steps:
+      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
+        displayName: 'Trigger build $(NextBuild)'
+        inputs:
+          buildDefinition: '$(NextBuild)'
+          queueBuildForUserThatTriggeredBuild: true
+          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
+          password: '$(ExecutePipelinesPersonalAccessToken)'
+          enableBuildInQueueCondition: true
+          blockingBuildsList: '$(NextBuild)'
+        continueOnError: true
+        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))


### PR DESCRIPTION
**NOTE: This PR requires the v3 bot created in PR #66 and depends on it being merged first.**

## Description
Add the YAML file to run tests between a Javascript Host and a Javascript v3 Skill.

## Details
Added the javascriptHost2JavascriptV3Skill.yml. This allows running a functional test between a JS Host bot, and a JS Skill bot that is using the version 3 of BotBuilder-Dotnet SDK.