### PR TITLE
[4x6 Matrix] Add NET-JavaScript v3 yaml 

### DIFF
--- a/build/yaml/dotnetHost2JavascriptV3Skill.yml
+++ b/build/yaml/dotnetHost2JavascriptV3Skill.yml
@@ -1,0 +1,165 @@
+#
+# Build a C# Host bot. Optionally deploy it and a V3 Js Skill bot and run functional tests.
+#
+
+# "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
+name: $(Build.BuildId)
+trigger: none
+pr: none
+
+variables:
+  BuildConfiguration: 'Debug'
+  BuildPlatform: 'any cpu'
+  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
+  # AzureSubscription: define in Azure
+  # BotBuilderPackageVersionHost: (optional) define in Azure
+  # BotBuilderPackageVersionSkill: (optional) define in Azure
+  # DeleteResourceGroup: (optional) define in Azure
+  # DotNetJsV3HostAppId: define in Azure
+  # DotNetJsV3HostAppSecret: define in Azure
+  # DotNetJsV3HostBotName: define in Azure
+  # DotNetJsV3SkillAppId: define in Azure
+  # DotNetJsV3SkillAppSecret: define in Azure
+  # DotNetJsV3SkillBotName: define in Azure
+  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
+  # NetCoreSdkVersionHost: define in Azure
+  # NextBuild: define in Azure and set to either a build name or an empty string
+  # TriggeredBy: define in Azure and set to an empty string
+
+pool:
+  vmImage: 'windows-2019'
+
+stages:
+- stage: Prepare
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  jobs:
+    - job: Delete_Preexisting_Resources
+      variables:
+        HostBotName: $(DotNetJsV3HostBotName)
+        SkillBotName: $(DotNetJsV3SkillBotName)
+      steps:
+      - template: cleanResourcesStep.yml
+
+- stage: Build
+  condition: always()
+  jobs:
+    - job: Validate_Host_NetCore_Version
+      variables:
+        Parameters.netCoreSdkVersion: $(NetCoreSdkVersionHost)
+      steps:
+      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
+        inputs:
+          tags: |
+            TriggeredReason=$(TriggeredReason)
+            $(TriggeredBy)
+            NextBuild=$(NextBuild)
+        continueOnError: true
+
+      - template: dotnetValidateNetCoreSdkVersion.yml
+
+    - job: Build_Host_Bot
+      dependsOn: Validate_Host_NetCore_Version
+      variables:
+        BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
+        Parameters.solution: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.sln'
+        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
+      steps:
+      - template: dotnetInstallPackagesSteps.yml
+      - template: dotnetBuildSteps.yml
+
+- stage: Deploy
+  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  jobs:
+    - job: Deploy_Host
+      variables:
+        BotName: $(DotNetJsV3HostBotName)
+        DeployAppId: $(DotNetJsV3HostAppId)
+        DeployAppSecret: $(DotNetJsV3HostAppSecret)
+        BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
+        ProjectName: SimpleHostBot
+        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
+        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
+      steps:
+      - powershell: |
+         # Set values in appsettings.json file.
+         $file = "$(System.DefaultWorkingDirectory)\SkillsFunctionalTests\dotnet\$(NetCoreSdkVersionHost)\host\appsettings.json"
+         $content = Get-Content -Raw $file | ConvertFrom-Json;
+         $content.SkillHostEndpoint = "https://$(DotNetJsV3HostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
+
+         # Create Skill Class
+         class Skill{[String] $Id; [String] $AppId; [String] $SkillEndpoint;};
+
+         # Create list of botframework skills
+         $botFrameworkSkills = New-Object -TypeName System.Collections.Generic.List[Skill];
+
+         # Create Skill object
+         $dotnetSkill = New-Object -TypeName Skill;
+         $dotnetSkill.Id = "EchoSkillBot";
+         $dotnetSkill.AppId = "$(DotNetJsV3SkillAppId)";
+         $dotnetSkill.SkillEndpoint = "https://$(DotNetJsV3SkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
+
+         # Add skill to botframework skill list
+         $botFrameworkSkills.Add($dotnetSkill);
+         $content.BotFrameworkSkills = $botFrameworkSkills;
+         $content | ConvertTo-Json | Set-Content $file;
+        displayName: 'Set Host appsettings.json file.'
+
+      - template: dotnetDeploySteps.yml
+
+    - job: Deploy_Skill
+      variables:
+        BotName: $(DotNetJsV3SkillBotName)
+        DeployAppId: $(DotNetJsV3SkillAppId)
+        DeployAppSecret: $(DotNetJsV3SkillAppSecret)
+        BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
+        Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/v3/skill'
+        TemplateLocation: 'SkillsFunctionalTests/javascript/skill/DeploymentTemplates/template-with-new-rg.json'
+      steps:
+      - template: javascriptDeploySteps.yml
+
+- stage: Test
+  dependsOn: Deploy
+  jobs:
+    - job: Run_Functional_Test
+      variables:
+        HostBotName: $(DotNetJsV3HostBotName)
+        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+      steps:
+      - template: functionalTestSteps.yml
+
+- stage: Cleanup
+  dependsOn:
+  - Deploy
+  - Test
+  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  jobs:
+    - job: Delete_RG
+      steps:
+      - task: AzureCLI@1
+        displayName: 'Delete Resource Group'
+        inputs:
+          azureSubscription: $(AzureSubscription)
+          scriptLocation: inlineScript
+          inlineScript: |
+           call az group delete -n "$(DotNetJsV3HostBotName)-RG" --yes
+           call az group delete -n "$(DotNetJsV3SkillBotName)-RG" --yes
+        condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
+
+- stage: QueueNext
+  condition: and(always(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
+  jobs:
+    - job: TriggerBuild
+      steps:
+      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
+        displayName: 'Trigger build $(NextBuild)'
+        inputs:
+          buildDefinition: '$(NextBuild)'
+          queueBuildForUserThatTriggeredBuild: true
+          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
+          password: '$(ExecutePipelinesPersonalAccessToken)'
+          enableBuildInQueueCondition: true
+          blockingBuildsList: '$(NextBuild)'
+        continueOnError: true
+        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))


### PR DESCRIPTION
## Description
Add the YAML file to run tests between a .NET Host and a Javascript v3 Skill.

## Details
Added the dotnetHost2JavascriptV3Skill.yml. This allows to run a functional test between a .NET Host bot, and a JS Skill bot that is using the version 3 of BotBuilder-JS SDK.

Deploy against .NET Core 3.1 and 2.1 host bots has worked and functional tests have passed.

![image](https://user-images.githubusercontent.com/20074735/80749076-4f986300-8afc-11ea-9202-79fa08577dab.png)
