### PR TITLE
Functional tests: enable oauth in dotnet 2 test

### DIFF
--- a/SkillsFunctionalTests/dotnet/2.1/skill/Bots/EchoBot.cs
+++ b/SkillsFunctionalTests/dotnet/2.1/skill/Bots/EchoBot.cs
@@ -1,15 +1,27 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
+using Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.OAuth;
 
 namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.Bots
 {
     public class EchoBot : ActivityHandler
     {
+        private readonly LoginDialog loginDialog;
+        private readonly ConversationState conversationState;
+
+        public EchoBot(ConversationState conversationState, LoginDialog loginDialog)
+        {
+            this.conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
+            this.loginDialog = loginDialog ?? throw new ArgumentNullException(nameof(loginDialog));
+        }
+
         /// <summary>
         /// Processes a message activity.
         /// </summary>
@@ -18,7 +30,14 @@ namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.Bots
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
-            if (turnContext.Activity.Text.Contains("end") || turnContext.Activity.Text.Contains("stop"))
+            if (turnContext.Activity.Text.Contains("auth") || turnContext.Activity.Text.Contains("logout") || turnContext.Activity.Text.Contains("Yes") || turnContext.Activity.Text.Contains("No"))
+            {
+                await loginDialog.RunAsync(turnContext, conversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
+
+                // Save any state changes that might have occurred during the turn.
+                await conversationState.SaveChangesAsync(turnContext, false, cancellationToken);
+            }
+            else if (turnContext.Activity.Text.Contains("end") || turnContext.Activity.Text.Contains("stop"))
             {
                 // Send End of conversation at the end.
                 await turnContext.SendActivityAsync(MessageFactory.Text($"ending conversation from the skill..."), cancellationToken);
@@ -45,6 +64,12 @@ namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.Bots
             // avoided as the conversation may have been deleted.
             // Perform cleanup of resources if needed.
             return Task.CompletedTask;
+        }
+
+        protected override async Task OnTokenResponseEventAsync(ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)
+        {
+            // Run the Dialog with the new Token Response Event Activity.
+            await loginDialog.RunAsync(turnContext, conversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
         }
     }
 }

--- a/SkillsFunctionalTests/dotnet/2.1/skill/EchoSkillBot.csproj
+++ b/SkillsFunctionalTests/dotnet/2.1/skill/EchoSkillBot.csproj
@@ -15,12 +15,17 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.7.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="OAuth\" />
   </ItemGroup>
 
 </Project>

--- a/SkillsFunctionalTests/dotnet/2.1/skill/OAuth/LoginDialog.cs
+++ b/SkillsFunctionalTests/dotnet/2.1/skill/OAuth/LoginDialog.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.OAuth
+{
+    public class LoginDialog : LogoutDialog
+    {
+        private readonly ILogger logger;
+
+        public LoginDialog(IConfiguration configuration, ILogger<LoginDialog> logger)
+            : base(nameof(LoginDialog), configuration["ConnectionName"])
+        { 
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            AddDialog(new OAuthPrompt(
+                nameof(OAuthPrompt),
+                new OAuthPromptSettings
+                {
+                    ConnectionName = ConnectionName,
+                    Text = "Please Sign In",
+                    Title = "Sign In",
+                    Timeout = 300000, // User has 5 minutes to login (1000 * 60 * 5)
+                }));
+
+            AddDialog(new ConfirmPrompt(nameof(ConfirmPrompt)));
+
+            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
+            {
+                PromptStepAsync,
+                LoginStepAsync,
+                DisplayTokenPhase1Async,
+                DisplayTokenPhase2Async,
+            }));
+
+            // The initial child Dialog to run.
+            InitialDialogId = nameof(WaterfallDialog);
+        }
+
+        private async Task<DialogTurnResult> PromptStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            return await stepContext.BeginDialogAsync(nameof(OAuthPrompt), null, cancellationToken);
+        }
+
+        private async Task<DialogTurnResult> LoginStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            // Get the token from the previous step. Note that we could also have gotten the
+            // token directly from the prompt itself. There is an example of this in the next method.
+            var tokenResponse = (TokenResponse)stepContext.Result;
+            if (tokenResponse != null)
+            {
+                await stepContext.Context.SendActivityAsync(MessageFactory.Text("You are now logged in."), cancellationToken);
+                return await stepContext.PromptAsync(nameof(ConfirmPrompt), new PromptOptions { Prompt = MessageFactory.Text("Would you like to view your token?") }, cancellationToken);
+            }
+
+            await stepContext.Context.SendActivityAsync(MessageFactory.Text("Login was not successful please try again."), cancellationToken);
+            return await stepContext.EndDialogAsync(cancellationToken: cancellationToken);
+        }
+
+        private async Task<DialogTurnResult> DisplayTokenPhase1Async(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            await stepContext.Context.SendActivityAsync(MessageFactory.Text("Thank you."), cancellationToken);
+
+            var result = (bool)stepContext.Result;
+            if (result)
+            {
+                // Call the prompt again because we need the token. The reasons for this are:
+                // 1. If the user is already logged in we do not need to store the token locally in the bot and worry
+                // about refreshing it. We can always just call the prompt again to get the token.
+                // 2. We never know how long it will take a user to respond. By the time the
+                // user responds the token may have expired. The user would then be prompted to login again.
+                //
+                // There is no reason to store the token locally in the bot because we can always just call
+                // the OAuth prompt to get the token or get a new token if needed.
+                return await stepContext.BeginDialogAsync(nameof(OAuthPrompt), cancellationToken: cancellationToken);
+            }
+
+            return await stepContext.EndDialogAsync(cancellationToken: cancellationToken);
+        }
+
+        private async Task<DialogTurnResult> DisplayTokenPhase2Async(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var tokenResponse = (TokenResponse)stepContext.Result;
+            if (tokenResponse != null)
+            {
+                await stepContext.Context.SendActivityAsync(MessageFactory.Text($"Here is your token {tokenResponse.Token}"), cancellationToken);
+            }
+
+            return await stepContext.EndDialogAsync(cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/SkillsFunctionalTests/dotnet/2.1/skill/OAuth/LogoutDialog.cs
+++ b/SkillsFunctionalTests/dotnet/2.1/skill/OAuth/LogoutDialog.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.OAuth
+{
+    public class LogoutDialog : ComponentDialog
+    {
+        public LogoutDialog(string id, string connectionName)
+            : base(id)
+        {
+            ConnectionName = connectionName;
+        }
+
+        protected string ConnectionName { get; }
+
+        protected override async Task<DialogTurnResult> OnBeginDialogAsync(DialogContext innerDc, object options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var result = await InterruptAsync(innerDc, cancellationToken);
+            if (result != null)
+            {
+                return result;
+            }
+
+            return await base.OnBeginDialogAsync(innerDc, options, cancellationToken);
+        }
+
+        protected override async Task<DialogTurnResult> OnContinueDialogAsync(DialogContext innerDc, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var result = await InterruptAsync(innerDc, cancellationToken);
+            if (result != null)
+            {
+                return result;
+            }
+
+            return await base.OnContinueDialogAsync(innerDc, cancellationToken);
+        }
+
+        private async Task<DialogTurnResult> InterruptAsync(DialogContext innerDc, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (innerDc.Context.Activity.Type == ActivityTypes.Message)
+            {
+                var text = innerDc.Context.Activity.Text.ToLowerInvariant();
+
+                if (text == "logout")
+                {
+                    // The bot adapter encapsulates the authentication processes.
+                    var botAdapter = (BotFrameworkAdapter)innerDc.Context.Adapter;
+                    await botAdapter.SignOutUserAsync(innerDc.Context, ConnectionName, null, cancellationToken);
+                    await innerDc.Context.SendActivityAsync(MessageFactory.Text("You have been signed out."), cancellationToken);
+                    return await innerDc.CancelAllDialogsAsync(cancellationToken);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/SkillsFunctionalTests/dotnet/2.1/skill/Startup.cs
+++ b/SkillsFunctionalTests/dotnet/2.1/skill/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.Authentication;
 using Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.Bots;
+using Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.OAuth;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -27,6 +28,10 @@ namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot
 
             // Configure credentials
             services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
+
+            // Configuration for OAuth
+            services.AddSingleton<LoginDialog>();
+            services.AddSingleton<ConversationState>((s) => new ConversationState(new MemoryStorage()));
 
             // Register AuthConfiguration to enable custom claim validation.
             services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedCallersClaimsValidator(sp.GetService<IConfiguration>()) });

--- a/SkillsFunctionalTests/dotnet/2.1/skill/appsettings.json
+++ b/SkillsFunctionalTests/dotnet/2.1/skill/appsettings.json
@@ -1,5 +1,6 @@
 {
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
-  "AllowedCallers": []
+  "AllowedCallers": [],
+  "ConnectionName": "TestOAuthProvider"
 }


### PR DESCRIPTION
Unfortunately at this point we have different skill code for dotnet 2 and 3, so here we port the skill oauth changes to the dotnet 2 skill bot. In the future there are opportunities for reuse and reduce code duplication, but not full reuse since there ar esome fundamental differences. However a core library could have 95% of the code.
