### PR TITLE
Javascript host: Fixing EOC catching

### DIFF
--- a/SkillsFunctionalTests/javascript/host/hostBot.js
+++ b/SkillsFunctionalTests/javascript/host/hostBot.js
@@ -55,7 +55,7 @@ class HostBot extends ActivityHandler {
             await next();
         });
 
-        this.onUnrecognizedActivityType(async (context, next) => {
+        this.onEndOfConversation(async (context, next) => {
             // Handle EndOfConversation returned by the skill.
             if (context.activity.type === ActivityTypes.EndOfConversation) {
                 // Stop forwarding activities to Skill.


### PR DESCRIPTION
Host bot was never sending end of conversation receipt to the host bot, because the registration was wrong / outdated.