### PR TITLE
Double timeout to 2 minutes

### DIFF
--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/OAuthSkillTest.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/OAuthSkillTest.cs
@@ -24,7 +24,7 @@ namespace FunctionalTests
         public async Task Skill_OAuthCard_SignInSuccessful()
         {
             // If the test takes more than one minute, declare failure.
-            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(2));
 
             var testBot = new TestBotClient(new EnvironmentBotTestConfiguration());
 


### PR DESCRIPTION
This avoids test cancellation timeout errors which mask more useful error reporting in builds like this one:
JsPySkillBotFunctionalTest/127904
X Skill_OAuthCard_SignInSuccessful [1m]
  Error Message:
   Test method FunctionalTests.OAuthSkillTest.Skill_OAuthCard_SignInSuccessful threw exception: 
System.OperationCanceledException: The operation was canceled.