### PR TITLE
Remove Ubuntu vm image

### DIFF
--- a/build/yaml/pythonHost2PythonSkill.yml
+++ b/build/yaml/pythonHost2PythonSkill.yml
@@ -57,8 +57,6 @@ stages:
 
 - stage: Deploy
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
-  pool:
-    vmImage: 'ubuntu-latest'
   jobs:
     - job: Deploy_Host
       variables:
@@ -84,8 +82,6 @@ stages:
       - template: pythonDeploySteps.yml
 
     - job: Deploy_Skill
-      pool:
-        vmImage: 'ubuntu-latest'
       variables:
         BotName: $(PyPySkillBotName)
         DeployAppId: $(PyPySkillAppId)


### PR DESCRIPTION
When running in Ubuntu, the task Configure OAuth fails. Removing the constraint to allow the task to run in Windows.