### PR TITLE
Fix BOTBUILDERPACKAGEVERSION var checking 

### DIFF
--- a/build/yaml/dotnetInstallPackagesSteps.yml
+++ b/build/yaml/dotnetInstallPackagesSteps.yml
@@ -9,7 +9,7 @@ steps:
     arguments: 'package Microsoft.Bot.Builder.Integration.AspNet.Core'
 
 - powershell: |
-    if ($null -eq $env:BotBuilderPackageVersion -or '' -eq $env:BotBuilderPackageVersion) {
+    if ([string]::IsNullOrWhiteSpace($env:BotBuilderPackageVersion)) {
         $Response = Invoke-WebRequest -URI https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/registration1/Microsoft.Bot.Builder/index.json | ConvertFrom-Json;
         $LastPackage = $Response.items | Select-Object -Last 1
         $latest_version = $lastpackage.upper

--- a/build/yaml/javascriptDeploySteps.yml
+++ b/build/yaml/javascriptDeploySteps.yml
@@ -7,7 +7,7 @@ steps:
     inlineScript: 'call az bot prepare-deploy --code-dir "$(Parameters.sourceLocation)" --lang Javascript'
 
 - powershell: |   
-   if(-Not ($env:BotBuilderPackageVersion -eq $null))
+   if(-Not [string]::IsNullOrWhiteSpace($env:BotBuilderPackageVersion))
    {
       Add-Content $(Parameters.sourceLocation)/deployment-scripts/.deployment "`nBOT_BUILDER_PACKAGE_VERSION = $(BotBuilderPackageVersion)"
    }   

--- a/build/yaml/pythonDeploySteps.yml
+++ b/build/yaml/pythonDeploySteps.yml
@@ -8,7 +8,7 @@ steps:
      az deployment create --name "$(BotName)-RG" --template-file "$(System.DefaultWorkingDirectory)/$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotName)-RG" groupLocation="westus" newAppServicePlanLocation="westus"
 
 - powershell: |
-    if(-Not ($null -eq $env:BOTBUILDERPACKAGEVERSION))
+    if(-Not [string]::IsNullOrWhiteSpace($env:BOTBUILDERPACKAGEVERSION))
     {
         Write-Host "Botbuilder version variable found."
 
@@ -25,7 +25,7 @@ steps:
             #matchinfo marks the line number from 1 instead of 0
             $content[$matchinfo.LineNumber - 1] = "botbuilder-integration-aiohttp"
         }
-        elseif ($env:BOTBUILDERPACKAGEVERSION -eq "")
+        elseif ($env:BOTBUILDERPACKAGEVERSION -eq 'latest')
         {
             Write-Host "Installing latest preview version."
 
@@ -43,7 +43,7 @@ steps:
         }
         else #specific version value set
         {
-            Write-Host "Installing version $env:BOTBUILDERPACKAGEVERSION"
+            Write-Host "Installing version [$env:BOTBUILDERPACKAGEVERSION]"
 
             #Add the test.pypi source at the beginning of requirements
             $content = Get-Content $file


### PR DESCRIPTION
...so empty, null, and space values are treated the same.

This fixes "ERROR: Could not find a version" in the Git bot deployment step in the Py-Py build [128898](https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=128898&view=logs&j=fdf599f1-1c98-5568-8e4f-1b3d59f5b689&t=52c75953-f34c-59b0-7898-aebdaf9b828c).
The effect of the fix is demonstrated in build [128911](https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=128911&view=logs&j=fdf599f1-1c98-5568-8e4f-1b3d59f5b689&t=52c75953-f34c-59b0-7898-aebdaf9b828c).