### PR TITLE
[JS v4 Skill Bot] Fix OAuth switch case

### DIFF
--- a/SkillsFunctionalTests/javascript/skill/bot.js
+++ b/SkillsFunctionalTests/javascript/skill/bot.js
@@ -38,6 +38,7 @@ class EchoBot extends ActivityHandler {
                 // Run the Dialog with the new message Activity.
                 await this.dialog.run(context, this.dialogState);
                 await next();
+                break;
             case 'end':
             case 'stop':
                 await context.sendActivity({


### PR DESCRIPTION
### Description
This PR adds a _break_ in the _onMessage_ switch of the JS v4 Skill bot for the OAuth case (auth, yes or no). Without the break, the bot was sending an _end of conversation_  right after the OAuth, making the test fail by sending the _end of conversation_ before ending the login.

### Changes made
Added a break statement in the `bot.js` class of the JS v4 Skill bot for the auth case in the _onMessage_ switch.

### Testing
In the images below, you can see some examples of pipelines running after the implementation of this change.
![image](https://user-images.githubusercontent.com/38112957/81592028-b4bd4580-9393-11ea-9fc2-65865aae5572.png)