### PR TITLE
[4x6 Matrix][Fix JS v3 Skill] Increase delay before Read Bot Messages

### DIFF
--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/Bot/TestBotClient.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/Bot/TestBotClient.cs
@@ -162,14 +162,14 @@ namespace SkillFunctionalTests.Bot
 
             while (!cancellationToken.IsCancellationRequested && !maxCancellation.IsCancellationRequested)
             {
+                await Task.Delay(TimeSpan.FromSeconds(3));
+                
                 var activities = await ReadBotMessagesAsync(cancellationToken);
 
                 if (activities != null && activities.Any())
                 {
                     return activities;
                 }
-
-                await Task.Delay(TimeSpan.FromMilliseconds(100));
             }
 
             throw new Exception("No activities received");


### PR DESCRIPTION
Note: This PR doesn't require any extra configuration in the existing pipelines.

## Description
This PR increases the delay before fetching the bot's messages to give the bot enough time to answer to the tests.
Fixes the issue found with JS v3 Skill bots after skipping the OAuth test.

### Detailed Changes
- Updated **_ReadBotMessagesAsync_** method in the _TestBotClient_ class to wait 3 seconds before fetching for the bot messages. This way the bot has time to answer to the test.

### Testing
The next images show the **Dotnet Host - JS V3 Skill**, the **JS Host - JS V3 Skill**, and the **Python Host - JS V3 Skill** pipelines running successfully after the change.

![image](https://user-images.githubusercontent.com/44245136/81703863-81d28a80-9443-11ea-9d5b-536e6cc4653b.png)