### PR TITLE
[Skill Functional Tests][Python] Remove duplicated script in Host Bot yamls

### DIFF
--- a/build/yaml/pythonHost2DotnetSkill.yml
+++ b/build/yaml/pythonHost2DotnetSkill.yml
@@ -42,7 +42,7 @@ stages:
         SkillBotName: $(PyDotNetSkillBotName)
       steps:
       - template: cleanResourcesStep.yml
-        
+
 - stage: Build
   condition: succeededOrFailed()
   jobs:
@@ -78,6 +78,9 @@ stages:
       pool:
         vmImage: 'ubuntu-latest'
       variables:
+        HostBotName: $(PyDotNetHostBotName)
+        SkillBotName: $(PyDotNetSkillBotName)
+        SkillAppId: $(PyDotNetSkillAppId)
         BotName: $(PyDotNetHostBotName)
         DeployAppId: $(PyDotNetHostAppId)
         DeployAppSecret: $(PyDotNetHostAppSecret)
@@ -85,18 +88,7 @@ stages:
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
         TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
       steps:
-      - powershell: |
-         Write-host "Setting config file"
-         $file = "$(System.DefaultWorkingDirectory)/$(Parameters.sourceLocation)/.env";
-         $content = Get-Content -Raw $file | ConvertFrom-StringData;
-         $content.SKILL_BOT_APP_ID = "$(PyDotNetSkillAppId)";
-         $content.SKILL_BOT_ENDPOINT = "https://$(PyDotNetSkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
-         $content.SKILL_HOST_ENDPOINT = "https://$(PyDotNetHostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
-
-         Clear-Content $file;
-         foreach ($key in $content.keys) { Add-Content $file "$key=$($content.$key)" };
-        displayName: 'Update .env file'
-
+      - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
 
     - job: Deploy_Skill

--- a/build/yaml/pythonHost2DotnetV3Skill.yml
+++ b/build/yaml/pythonHost2DotnetV3Skill.yml
@@ -73,6 +73,9 @@ stages:
       pool:
         vmImage: 'ubuntu-latest'
       variables:
+        HostBotName: $(PyDotNetV3HostBotName)
+        SkillBotName: $(PyDotNetV3SkillBotName)
+        SkillAppId: $(PyDotNetV3SkillAppId)
         BotName: $(PyDotNetV3HostBotName)
         DeployAppId: $(PyDotNetV3HostAppId)
         DeployAppSecret: $(PyDotNetV3HostAppSecret)
@@ -80,18 +83,7 @@ stages:
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
         TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
       steps:
-      - powershell: |
-         Write-host "Setting config file"
-         $file = "$(System.DefaultWorkingDirectory)/$(Parameters.sourceLocation)/.env";
-         $content = Get-Content -Raw $file | ConvertFrom-StringData;
-         $content.SKILL_BOT_APP_ID = "$(PyDotNetV3SkillAppId)";
-         $content.SKILL_BOT_ENDPOINT = "https://$(PyDotNetV3SkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
-         $content.SKILL_HOST_ENDPOINT = "https://$(PyDotNetV3HostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
-
-         Clear-Content $file;
-         foreach ($key in $content.keys) { Add-Content $file "$key=$($content.$key)" };
-        displayName: 'Update .env file'
-
+      - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
 
     - job: Deploy_Skill

--- a/build/yaml/pythonHost2JavascriptSkill.yml
+++ b/build/yaml/pythonHost2JavascriptSkill.yml
@@ -41,7 +41,7 @@ stages:
         SkillBotName: $(PyJsSkillBotName)
       steps:
       - template: cleanResourcesStep.yml
-        
+
 - stage: Tag
   condition: succeededOrFailed()
   jobs:
@@ -63,6 +63,9 @@ stages:
       pool:
         vmImage: 'ubuntu-latest'
       variables:
+        HostBotName: $(PyJsHostBotName)
+        SkillBotName: $(PyJsSkillBotName)
+        SkillAppId: $(PyJsSkillAppId)
         BotName: $(PyJsHostBotName)
         DeployAppId: $(PyJsHostAppId)
         DeployAppSecret: $(PyJsHostAppSecret)
@@ -70,18 +73,7 @@ stages:
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
         TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
       steps:
-      - powershell: |
-         Write-host "Setting config file"
-         $file = "$(System.DefaultWorkingDirectory)/$(Parameters.sourceLocation)/.env";
-         $content = Get-Content -Raw $file | ConvertFrom-StringData;
-         $content.SKILL_BOT_APP_ID = "$(PyJsSkillAppId)";
-         $content.SKILL_BOT_ENDPOINT = "https://$(PyJsSkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
-         $content.SKILL_HOST_ENDPOINT = "https://$(PyJsHostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
-
-         Clear-Content $file;
-         foreach ($key in $content.keys) { Add-Content $file "$key=$($content.$key)" };
-        displayName: 'Update .env file'
-
+      - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
 
     - job: Deploy_Skill

--- a/build/yaml/pythonHost2JavascriptV3Skill.yml
+++ b/build/yaml/pythonHost2JavascriptV3Skill.yml
@@ -63,6 +63,9 @@ stages:
       pool:
         vmImage: 'ubuntu-latest'
       variables:
+        HostBotName: $(PyJsV3HostBotName)
+        SkillBotName: $(PyJsV3SkillBotName)
+        SkillAppId: $(PyJsV3SkillAppId)
         BotName: $(PyJsV3HostBotName)
         DeployAppId: $(PyJsV3HostAppId)
         DeployAppSecret: $(PyJsV3HostAppSecret)
@@ -70,16 +73,7 @@ stages:
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
         TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
       steps:
-      - powershell: |
-         Write-host "Setting config file"
-         $file = "$(System.DefaultWorkingDirectory)/$(Parameters.sourceLocation)/.env";
-         $content = Get-Content -Raw $file | ConvertFrom-StringData;
-         $content.SKILL_BOT_APP_ID = "$(PyJsV3SkillAppId)";
-         $content.SKILL_BOT_ENDPOINT = "https://$(PyJsV3SkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
-         $content.SKILL_HOST_ENDPOINT = "https://$(PyJsV3HostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
-         Clear-Content $file;
-         foreach ($key in $content.keys) { Add-Content $file "$key=$($content.$key)" };
-        displayName: 'Update .env file'
+      - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
 
     - job: Deploy_Skill

--- a/build/yaml/pythonHost2PythonSkill.yml
+++ b/build/yaml/pythonHost2PythonSkill.yml
@@ -41,7 +41,7 @@ stages:
         SkillBotName: $(PyPySkillBotName)
       steps:
       - template: cleanResourcesStep.yml
-        
+
 - stage: Tag
   condition: succeededOrFailed()
   jobs:
@@ -61,6 +61,9 @@ stages:
   jobs:
     - job: Deploy_Host
       variables:
+        HostBotName: $(PyPyHostBotName)
+        SkillBotName: $(PyPySkillBotName)
+        SkillAppId: $(PyPySkillAppId)
         BotName: $(PyPyHostBotName)
         DeployAppId: $(PyPyHostAppId)
         DeployAppSecret: $(PyPyHostAppSecret)
@@ -68,18 +71,7 @@ stages:
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
         TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
       steps:
-      - powershell: |
-         Write-host "Setting config file"
-         $file = "$(System.DefaultWorkingDirectory)/$(Parameters.sourceLocation)/.env";
-         $content = Get-Content -Raw $file | ConvertFrom-StringData;
-         $content.SKILL_BOT_APP_ID = "$(PyPySkillAppId)";
-         $content.SKILL_BOT_ENDPOINT = "https://$(PyPySkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
-         $content.SKILL_HOST_ENDPOINT = "https://$(PyPyHostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
-
-         Clear-Content $file;
-         foreach ($key in $content.keys) { Add-Content $file "$key=$($content.$key)" };
-        displayName: 'Update .env file'
-
+      - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
 
     - job: Deploy_Skill

--- a/build/yaml/pythonSetConfigFileSteps.yml
+++ b/build/yaml/pythonSetConfigFileSteps.yml
@@ -1,0 +1,12 @@
+steps:
+- powershell: |
+   Write-host "Setting config file"
+   $file = "$(System.DefaultWorkingDirectory)/$(Parameters.sourceLocation)/.env";
+   $content = Get-Content -Raw $file | ConvertFrom-StringData;
+   $content.SKILL_BOT_APP_ID = "$(SkillAppId)";
+   $content.SKILL_BOT_ENDPOINT = "https://$(SkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
+   $content.SKILL_HOST_ENDPOINT = "https://$(HostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
+
+   Clear-Content $file;
+   foreach ($key in $content.keys) { Add-Content $file "$key=$($content.$key)" };
+  displayName: 'Update .env file'


### PR DESCRIPTION
Note: This PR doesn't require any extra configuration in the existing pipelines.

## Description
This PR removes the duplicated script that updates the Host Bot's configuration file for Python Bots.

## Details
- Added the _pythonSetConfigFileSteps_ template with the PowerShell step to configure the .env file of the Host Bot.
- Updated the following yaml files to use the new template:
     - pythonHost2DotnetSkill
     - pythonHost2DotnetV3Skill
     - pythonHost2JavascriptSkill
     - pythonHost2JavascriptV3Skill
     - pythonHost2PythonSkill