### PR TITLE
[Skill Functional Tests][.Net] Remove duplicated script in DotNet Host Bot yamls

### DIFF
--- a/build/yaml/dotnetHost2DotnetV3Skill.yml
+++ b/build/yaml/dotnetHost2DotnetV3Skill.yml
@@ -81,6 +81,9 @@ stages:
   jobs:
     - job: Deploy_Host
       variables:
+        HostBotName: $(DotNetDotNetV3HostBotName)
+        SkillBotName: $(DotNetDotNetV3SkillBotName)
+        SkillAppId: $(DotNetDotNetV3SkillAppId)
         BotName: $(DotNetDotNetV3HostBotName)
         DeployAppId: $(DotNetDotNetV3HostAppId)
         DeployAppSecret: $(DotNetDotNetV3HostAppSecret)
@@ -88,30 +91,7 @@ stages:
         Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
         TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
-      - powershell: |
-         # Set values in appsettings.json file.
-         $file = "$(System.DefaultWorkingDirectory)\SkillsFunctionalTests\dotnet\$(NetCoreSdkVersionHost)\host\appsettings.json";
-         $content = Get-Content -Raw $file | ConvertFrom-Json;
-         $content.SkillHostEndpoint = "https://$(DotNetDotNetV3HostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
-
-         # Create Skill Class
-         class Skill{[String] $Id; [String] $AppId; [String] $SkillEndpoint;};
-
-         # Create list of botframework skills
-         $botFrameworkSkills = New-Object -TypeName System.Collections.Generic.List[Skill];
-
-         # Create Skill object
-         $dotnetSkill = New-Object -TypeName Skill;
-         $dotnetSkill.Id = "EchoSkillBot";
-         $dotnetSkill.AppId = "$(DotNetDotNetV3SkillAppId)";
-         $dotnetSkill.SkillEndpoint = "https://$(DotNetDotNetV3SkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
-
-         # Add skill to botframework skill list
-         $botFrameworkSkills.Add($dotnetSkill);
-         $content.BotFrameworkSkills = $botFrameworkSkills;
-         $content | ConvertTo-Json | Set-Content $file;
-        displayName: 'Set Host appsettings.json file.'
-
+      - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 
     - job: Deploy_Skill

--- a/build/yaml/dotnetHost2JavascriptSkill.yml
+++ b/build/yaml/dotnetHost2JavascriptSkill.yml
@@ -20,7 +20,7 @@ variables:
   # DotNetJsHostBotName: define in Azure
   # DotNetJsSkillAppId: define in Azure
   # DotNetJsSkillAppSecret: define in Azure
-  # DotNetJsSkillBotName: define in Azure  
+  # DotNetJsSkillBotName: define in Azure
   # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
   # NetCoreSdkVersionHost: define in Azure
   # NextBuild: define in Azure and set to either a build name or an empty string
@@ -74,6 +74,9 @@ stages:
   jobs:
     - job: Deploy_Host
       variables:
+        HostBotName: $(DotNetJsHostBotName)
+        SkillBotName: $(DotNetJsSkillBotName)
+        SkillAppId: $(DotNetJsSkillAppId)
         BotName: $(DotNetJsHostBotName)
         DeployAppId: $(DotNetJsHostAppId)
         DeployAppSecret: $(DotNetJsHostAppSecret)
@@ -82,30 +85,7 @@ stages:
         Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
         TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
-      - powershell: |
-         # Set values in appsettings.json file.
-         $file = "$(System.DefaultWorkingDirectory)\SkillsFunctionalTests\dotnet\$(NetCoreSdkVersionHost)\host\appsettings.json"
-         $content = Get-Content -Raw $file | ConvertFrom-Json;
-         $content.SkillHostEndpoint = "https://$(DotNetJsHostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
-
-         # Create Skill Class
-         class Skill{[String] $Id; [String] $AppId; [String] $SkillEndpoint;};
-
-         # Create list of botframework skills
-         $botFrameworkSkills = New-Object -TypeName System.Collections.Generic.List[Skill];
-
-         # Create Skill object
-         $dotnetSkill = New-Object -TypeName Skill;
-         $dotnetSkill.Id = "EchoSkillBot";
-         $dotnetSkill.AppId = "$(DotNetJsSkillAppId)";
-         $dotnetSkill.SkillEndpoint = "https://$(DotNetJsSkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
-
-         # Add skill to botframework skill list
-         $botFrameworkSkills.Add($dotnetSkill);
-         $content.BotFrameworkSkills = $botFrameworkSkills;
-         $content | ConvertTo-Json | Set-Content $file;
-        displayName: 'Set Host appsettings.json file.'
-
+      - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 
     - job: Deploy_Skill

--- a/build/yaml/dotnetHost2JavascriptV3Skill.yml
+++ b/build/yaml/dotnetHost2JavascriptV3Skill.yml
@@ -74,6 +74,9 @@ stages:
   jobs:
     - job: Deploy_Host
       variables:
+        HostBotName: $(DotNetJsV3HostBotName)
+        SkillBotName: $(DotNetJsV3SkillBotName)
+        SkillAppId: $(DotNetJsV3SkillAppId)
         BotName: $(DotNetJsV3HostBotName)
         DeployAppId: $(DotNetJsV3HostAppId)
         DeployAppSecret: $(DotNetJsV3HostAppSecret)
@@ -82,30 +85,7 @@ stages:
         Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
         TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
-      - powershell: |
-         # Set values in appsettings.json file.
-         $file = "$(System.DefaultWorkingDirectory)\SkillsFunctionalTests\dotnet\$(NetCoreSdkVersionHost)\host\appsettings.json"
-         $content = Get-Content -Raw $file | ConvertFrom-Json;
-         $content.SkillHostEndpoint = "https://$(DotNetJsV3HostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
-
-         # Create Skill Class
-         class Skill{[String] $Id; [String] $AppId; [String] $SkillEndpoint;};
-
-         # Create list of botframework skills
-         $botFrameworkSkills = New-Object -TypeName System.Collections.Generic.List[Skill];
-
-         # Create Skill object
-         $dotnetSkill = New-Object -TypeName Skill;
-         $dotnetSkill.Id = "EchoSkillBot";
-         $dotnetSkill.AppId = "$(DotNetJsV3SkillAppId)";
-         $dotnetSkill.SkillEndpoint = "https://$(DotNetJsV3SkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
-
-         # Add skill to botframework skill list
-         $botFrameworkSkills.Add($dotnetSkill);
-         $content.BotFrameworkSkills = $botFrameworkSkills;
-         $content | ConvertTo-Json | Set-Content $file;
-        displayName: 'Set Host appsettings.json file.'
-
+      - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 
     - job: Deploy_Skill

--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -22,7 +22,7 @@ variables:
   # DotNetPyHostBotName: define in Azure
   # DotNetPySkillAppId: define in Azure
   # DotNetPySkillAppSecret: define in Azure
-  # DotNetPySkillBotName: define in Azure  
+  # DotNetPySkillBotName: define in Azure
   # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
   # NetCoreSdkVersionHost: define in Azure
   # NextBuild: define in Azure and set to either a build name or an empty string
@@ -42,7 +42,7 @@ stages:
         SkillBotName: $(DotNetPySkillBotName)
       steps:
       - template: cleanResourcesStep.yml
-        
+
 - stage: Build
   condition: succeededOrFailed()
   jobs:
@@ -76,6 +76,9 @@ stages:
   jobs:
     - job: Deploy_Host
       variables:
+        HostBotName: $(DotNetPyHostBotName)
+        SkillBotName: $(DotNetPySkillBotName)
+        SkillAppId: $(DotNetPySkillAppId)
         BotName: $(DotNetPyHostBotName)
         DeployAppId: $(DotNetPyHostAppId)
         DeployAppSecret: $(DotNetPyHostAppSecret)
@@ -84,30 +87,7 @@ stages:
         Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
         TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
-      - powershell: |
-         # Set values in appsettings.json file.
-         $file = "$(System.DefaultWorkingDirectory)\SkillsFunctionalTests\dotnet\$(NetCoreSdkVersionHost)\host\appsettings.json";
-         $content = Get-Content -Raw $file | ConvertFrom-Json;
-         $content.SkillHostEndpoint = "https://$(DotNetPyHostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
-
-         # Create Skill Class
-         class Skill{[String] $Id; [String] $AppId; [String] $SkillEndpoint;};
-
-         # Create list of botframework skills
-         $botFrameworkSkills = New-Object -TypeName System.Collections.Generic.List[Skill];
-
-         # Create Skill object
-         $dotnetSkill = New-Object -TypeName Skill;
-         $dotnetSkill.Id = "EchoSkillBot";
-         $dotnetSkill.AppId = "$(DotNetPySkillAppId)";
-         $dotnetSkill.SkillEndpoint = "https://$(DotNetPySkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
-
-         # Add skill to botframework skill list
-         $botFrameworkSkills.Add($dotnetSkill);
-         $content.BotFrameworkSkills = $botFrameworkSkills;
-         $content | ConvertTo-Json | Set-Content $file;
-        displayName: 'Set Host appsettings.json file.'
-
+      - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 
     - job: Deploy_Skill

--- a/build/yaml/dotnetHost2dotnetSkill.yml
+++ b/build/yaml/dotnetHost2dotnetSkill.yml
@@ -13,7 +13,7 @@ variables:
   TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
-  # BotBuilderPackageVersionSkill: (optional) define in Azure  
+  # BotBuilderPackageVersionSkill: (optional) define in Azure
   # DeleteResourceGroup: (optional) define in Azure
   # DotNetDotNetHostAppId: define in Azure
   # DotNetDotNetHostAppSecret: define in Azure
@@ -91,6 +91,9 @@ stages:
   jobs:
     - job: Deploy_Host
       variables:
+        HostBotName: $(DotNetDotNetHostBotName)
+        SkillBotName: $(DotNetDotNetSkillBotName)
+        SkillAppId: $(DotNetDotNetSkillAppId)
         BotName: $(DotNetDotNetHostBotName)
         DeployAppId: $(DotNetDotNetHostAppId)
         DeployAppSecret: $(DotNetDotNetHostAppSecret)
@@ -99,30 +102,7 @@ stages:
         Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
         TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
-      - powershell: |
-         # Set values in appsettings.json file.
-         $file = "$(System.DefaultWorkingDirectory)\SkillsFunctionalTests\dotnet\$(NetCoreSdkVersionHost)\host\appsettings.json";
-         $content = Get-Content -Raw $file | ConvertFrom-Json;
-         $content.SkillHostEndpoint = "https://$(DotNetDotNetHostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
-
-         # Create Skill Class
-         class Skill{[String] $Id; [String] $AppId; [String] $SkillEndpoint;};
-
-         # Create list of botframework skills
-         $botFrameworkSkills = New-Object -TypeName System.Collections.Generic.List[Skill];
-
-         # Create Skill object
-         $dotnetSkill = New-Object -TypeName Skill;
-         $dotnetSkill.Id = "EchoSkillBot";
-         $dotnetSkill.AppId = "$(DotNetDotNetSkillAppId)";
-         $dotnetSkill.SkillEndpoint = "https://$(DotNetDotNetSkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
-
-         # Add skill to botframework skill list
-         $botFrameworkSkills.Add($dotnetSkill);
-         $content.BotFrameworkSkills = $botFrameworkSkills;
-         $content | ConvertTo-Json | Set-Content $file;
-        displayName: 'Set Host appsettings.json file.'
-
+      - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 
     - job: Deploy_Skill

--- a/build/yaml/dotnetSetConfigFileSteps.yml
+++ b/build/yaml/dotnetSetConfigFileSteps.yml
@@ -1,0 +1,24 @@
+steps:
+- powershell: |
+   # Set values in appsettings.json file.
+   $file = "$(System.DefaultWorkingDirectory)\SkillsFunctionalTests\dotnet\$(NetCoreSdkVersionHost)\host\appsettings.json";
+   $content = Get-Content -Raw $file | ConvertFrom-Json;
+   $content.SkillHostEndpoint = "https://$(HostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
+
+   # Create Skill Class
+   class Skill{[String] $Id; [String] $AppId; [String] $SkillEndpoint;};
+
+   # Create list of botframework skills
+   $botFrameworkSkills = New-Object -TypeName System.Collections.Generic.List[Skill];
+
+   # Create Skill object
+   $dotnetSkill = New-Object -TypeName Skill;
+   $dotnetSkill.Id = "EchoSkillBot";
+   $dotnetSkill.AppId = "$(SkillAppId)";
+   $dotnetSkill.SkillEndpoint = "https://$(SkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
+
+   # Add skill to botframework skill list
+   $botFrameworkSkills.Add($dotnetSkill);
+   $content.BotFrameworkSkills = $botFrameworkSkills;
+   $content | ConvertTo-Json | Set-Content $file;
+  displayName: 'Set Host appsettings.json file.'


### PR DESCRIPTION
Note: This PR doesn't require any extra configuration in the existing pipelines.

## Description
This PR removes the duplicated script that updates the Host Bot's configuration file for DotNet Bots.

## Details
- Added the _dotnetSetConfigFileSteps_ template with the PowerShell step to configure the appsettings.json file of the Host Bot.
- Updated the following yaml files to use the new template:
     - dotnetHost2DotnetSkill
     - dotnetHost2DotnetV3Skill
     - dotnetHost2JavascriptSkill
     - dotnetHost2JavascriptV3Skill
     - dotnetHost2PythonSkill

Pipelines were run for all of the YAMLs, successfully, also using both 3.1 and 2.1 .NET bots