### PR TITLE
[Skills Functional Tests][Fix] Python failing pipelines

### DIFF
--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -94,8 +94,6 @@ stages:
       - template: dotnetDeploySteps.yml
 
     - job: Deploy_Skill
-      pool:
-        vmImage: 'ubuntu-latest'
       variables:
         BotName: $(DotNetPySkillBotName)
         DeployAppId: $(DotNetPySkillAppId)

--- a/build/yaml/javascriptHost2PythonSkill.yml
+++ b/build/yaml/javascriptHost2PythonSkill.yml
@@ -77,8 +77,6 @@ stages:
       - template: javascriptDeploySteps.yml
 
     - job: Deploy_Skill
-      pool:
-        vmImage: 'ubuntu-latest'
       variables:
         BotName: $(JsPySkillBotName)
         DeployAppId: $(JsPySkillAppId)

--- a/build/yaml/pythonHost2DotnetSkill.yml
+++ b/build/yaml/pythonHost2DotnetSkill.yml
@@ -77,8 +77,6 @@ stages:
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Deploy_Host
-      pool:
-        vmImage: 'ubuntu-latest'
       variables:
         HostBotName: $(PyDotNetHostBotName)
         SkillBotName: $(PyDotNetSkillBotName)

--- a/build/yaml/pythonHost2DotnetV3Skill.yml
+++ b/build/yaml/pythonHost2DotnetV3Skill.yml
@@ -72,8 +72,6 @@ stages:
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Deploy_Host
-      pool:
-        vmImage: 'ubuntu-latest'
       variables:
         HostBotName: $(PyDotNetV3HostBotName)
         SkillBotName: $(PyDotNetV3SkillBotName)

--- a/build/yaml/pythonHost2JavascriptSkill.yml
+++ b/build/yaml/pythonHost2JavascriptSkill.yml
@@ -61,8 +61,6 @@ stages:
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Deploy_Host
-      pool:
-        vmImage: 'ubuntu-latest'
       variables:
         HostBotName: $(PyJsHostBotName)
         SkillBotName: $(PyJsSkillBotName)

--- a/build/yaml/pythonHost2JavascriptV3Skill.yml
+++ b/build/yaml/pythonHost2JavascriptV3Skill.yml
@@ -61,8 +61,6 @@ stages:
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
   jobs:
     - job: Deploy_Host
-      pool:
-        vmImage: 'ubuntu-latest'
       variables:
         HostBotName: $(PyJsV3HostBotName)
         SkillBotName: $(PyJsV3SkillBotName)


### PR DESCRIPTION
_Note: This PR doesn't require any extra pipeline configuration._

## Proposed Changes
This PR removes the Ubuntu image in the yaml files that deploy python bots. 
As Azure CLI tasks [only supports Powershell scripts on windows based agents](https://github.com/microsoft/azure-pipelines-tasks/issues/9094), the new step _Validate Git Deployment_ was failing.

### Detailed changes
Updated the following yaml files to remove the Ubuntu image in the Deploy step.
  - dotnetHost2PythonSkill
  - javascriptHost2PythonSkill
  - pythonHost2DotnetSkill
  - pythonHost2DotnetV3Skill
  - pythonHost2JavascriptSkill
  - pythonHost2JavascriptV3Skill

### Testing
The following images show the pipelines running successfully after the changes made.

![image](https://user-images.githubusercontent.com/44245136/82341265-92947a80-99c6-11ea-9828-605c2e54a2df.png)

