### PR TITLE
Reverse workaround for invalid template errors and apply fix

### DIFF
--- a/SkillsFunctionalTests/dotnet/2.1/host/DeploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/dotnet/2.1/host/DeploymentTemplates/template-with-new-rg.json
@@ -84,8 +84,7 @@
             "type": "Microsoft.Resources/resourceGroups",
             "apiVersion": "2018-05-01",
             "location": "[parameters('groupLocation')]",
-            "properties": {
-            }
+            "properties": {}
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -97,36 +96,96 @@
             ],
             "properties": {
                 "mode": "Incremental",
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "parameters": {
+                    "appIdForTemplate": {
+                        "value": "[parameters('appId')]"
+                    },
+                    "appServicePlanNameForTemplate": {
+                        "value": "[variables('appServicePlanName')]"
+                    },
+                    "appSecretForTemplate": {
+                        "value": "[parameters('appSecret')]"
+                    },
+                    "botEndPointForTemplate": {
+                        "value": "[variables('botEndpoint')]"
+                    },
+                    "botIdForTemplate": {
+                        "value": "[parameters('botId')]"
+                    },
+                    "botSkuForTemplate": {
+                        "value": "[parameters('botSku')]"
+                    },
+                    "resourcesLocationForTemplate": {
+                        "value": "[variables('resourcesLocation')]"
+                    },
+                    "newAppServicePlanSkuForTemplate": {
+                        "value": "[parameters('newAppServicePlanSku')]"
+                    },
+                    "webAppNameForTemplate": {
+                        "value": "[variables('webAppName')]"
+                    }
+                },
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                    "parameters": {},
+                    "parameters": {
+                        "appIdForTemplate": {
+                            "type": "string"
+                        },
+                        "appServicePlanNameForTemplate": {
+                            "type": "string"
+                        },
+                        "appSecretForTemplate": {
+                            "type": "string"
+                        },
+                        "botEndPointForTemplate": {
+                            "type": "string"
+                        },
+                        "botIdForTemplate": {
+                            "type": "string"
+                        },
+                        "botSkuForTemplate": {
+                            "type": "string"
+                        },
+                        "resourcesLocationForTemplate": {
+                            "type": "string"
+                        },
+                        "newAppServicePlanSkuForTemplate": {
+                            "type": "object"
+                        },
+                        "webAppNameForTemplate": {
+                            "type": "string"
+                        }
+                    },
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new App Service Plan",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[variables('appServicePlanName')]",
+                            "name": "[parameters('appServicePlanNameForTemplate')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[variables('resourcesLocation')]",
-                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
                             "properties": {
-                                "name": "[variables('appServicePlanName')]"
+                                "name": "[parameters('appServicePlanNameForTemplate')]"
                             }
                         },
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[variables('resourcesLocation')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
                             ],
-                            "name": "[variables('webAppName')]",
+                            "name": "[parameters('webAppNameForTemplate')]",
                             "properties": {
-                                "name": "[variables('webAppName')]",
-                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "name": "[parameters('webAppNameForTemplate')]",
+                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
@@ -135,11 +194,11 @@
                                         },
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appId')]"
+                                            "value": "[parameters('appIdForTemplate')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecret')]"
+                                            "value": "[parameters('appSecretForTemplate')]"
                                         }
                                     ],
                                     "cors": {
@@ -155,24 +214,24 @@
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botId')]",
+                            "name": "[parameters('botIdForTemplate')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSku')]"
+                                "name": "[parameters('botSkuForTemplate')]"
                             },
                             "properties": {
-                                "name": "[parameters('botId')]",
-                                "displayName": "[parameters('botId')]",
-                                "endpoint": "[variables('botEndpoint')]",
-                                "msaAppId": "[parameters('appId')]",
+                                "name": "[parameters('botIdForTemplate')]",
+                                "displayName": "[parameters('botIdForTemplate')]",
+                                "endpoint": "[parameters('botEndpointForTemplate')]",
+                                "msaAppId": "[parameters('appIdForTemplate')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/dotnet/2.1/skill/DeploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/dotnet/2.1/skill/DeploymentTemplates/template-with-new-rg.json
@@ -84,8 +84,7 @@
             "type": "Microsoft.Resources/resourceGroups",
             "apiVersion": "2018-05-01",
             "location": "[parameters('groupLocation')]",
-            "properties": {
-            }
+            "properties": {}
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -97,36 +96,96 @@
             ],
             "properties": {
                 "mode": "Incremental",
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "parameters": {
+                    "appIdForTemplate": {
+                        "value": "[parameters('appId')]"
+                    },
+                    "appServicePlanNameForTemplate": {
+                        "value": "[variables('appServicePlanName')]"
+                    },
+                    "appSecretForTemplate": {
+                        "value": "[parameters('appSecret')]"
+                    },
+                    "botEndPointForTemplate": {
+                        "value": "[variables('botEndpoint')]"
+                    },
+                    "botIdForTemplate": {
+                        "value": "[parameters('botId')]"
+                    },
+                    "botSkuForTemplate": {
+                        "value": "[parameters('botSku')]"
+                    },
+                    "resourcesLocationForTemplate": {
+                        "value": "[variables('resourcesLocation')]"
+                    },
+                    "newAppServicePlanSkuForTemplate": {
+                        "value": "[parameters('newAppServicePlanSku')]"
+                    },
+                    "webAppNameForTemplate": {
+                        "value": "[variables('webAppName')]"
+                    }
+                },
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                    "parameters": {},
+                    "parameters": {
+                        "appIdForTemplate": {
+                            "type": "string"
+                        },
+                        "appServicePlanNameForTemplate": {
+                            "type": "string"
+                        },
+                        "appSecretForTemplate": {
+                            "type": "string"
+                        },
+                        "botEndPointForTemplate": {
+                            "type": "string"
+                        },
+                        "botIdForTemplate": {
+                            "type": "string"
+                        },
+                        "botSkuForTemplate": {
+                            "type": "string"
+                        },
+                        "resourcesLocationForTemplate": {
+                            "type": "string"
+                        },
+                        "newAppServicePlanSkuForTemplate": {
+                            "type": "object"
+                        },
+                        "webAppNameForTemplate": {
+                            "type": "string"
+                        }
+                    },
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new App Service Plan",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[variables('appServicePlanName')]",
+                            "name": "[parameters('appServicePlanNameForTemplate')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[variables('resourcesLocation')]",
-                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
                             "properties": {
-                                "name": "[variables('appServicePlanName')]"
+                                "name": "[parameters('appServicePlanNameForTemplate')]"
                             }
                         },
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[variables('resourcesLocation')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
                             ],
-                            "name": "[variables('webAppName')]",
+                            "name": "[parameters('webAppNameForTemplate')]",
                             "properties": {
-                                "name": "[variables('webAppName')]",
-                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "name": "[parameters('webAppNameForTemplate')]",
+                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
@@ -135,11 +194,11 @@
                                         },
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appId')]"
+                                            "value": "[parameters('appIdForTemplate')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecret')]"
+                                            "value": "[parameters('appSecretForTemplate')]"
                                         }
                                     ],
                                     "cors": {
@@ -155,24 +214,24 @@
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botId')]",
+                            "name": "[parameters('botIdForTemplate')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSku')]"
+                                "name": "[parameters('botSkuForTemplate')]"
                             },
                             "properties": {
-                                "name": "[parameters('botId')]",
-                                "displayName": "[parameters('botId')]",
-                                "endpoint": "[variables('botEndpoint')]",
-                                "msaAppId": "[parameters('appId')]",
+                                "name": "[parameters('botIdForTemplate')]",
+                                "displayName": "[parameters('botIdForTemplate')]",
+                                "endpoint": "[parameters('botEndpointForTemplate')]",
+                                "msaAppId": "[parameters('appIdForTemplate')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/dotnet/3.1/host/DeploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/dotnet/3.1/host/DeploymentTemplates/template-with-new-rg.json
@@ -84,8 +84,7 @@
             "type": "Microsoft.Resources/resourceGroups",
             "apiVersion": "2018-05-01",
             "location": "[parameters('groupLocation')]",
-            "properties": {
-            }
+            "properties": {}
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -97,36 +96,96 @@
             ],
             "properties": {
                 "mode": "Incremental",
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "parameters": {
+                    "appIdForTemplate": {
+                        "value": "[parameters('appId')]"
+                    },
+                    "appServicePlanNameForTemplate": {
+                        "value": "[variables('appServicePlanName')]"
+                    },
+                    "appSecretForTemplate": {
+                        "value": "[parameters('appSecret')]"
+                    },
+                    "botEndPointForTemplate": {
+                        "value": "[variables('botEndpoint')]"
+                    },
+                    "botIdForTemplate": {
+                        "value": "[parameters('botId')]"
+                    },
+                    "botSkuForTemplate": {
+                        "value": "[parameters('botSku')]"
+                    },
+                    "resourcesLocationForTemplate": {
+                        "value": "[variables('resourcesLocation')]"
+                    },
+                    "newAppServicePlanSkuForTemplate": {
+                        "value": "[parameters('newAppServicePlanSku')]"
+                    },
+                    "webAppNameForTemplate": {
+                        "value": "[variables('webAppName')]"
+                    }
+                },
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                    "parameters": {},
+                    "parameters": {
+                        "appIdForTemplate": {
+                            "type": "string"
+                        },
+                        "appServicePlanNameForTemplate": {
+                            "type": "string"
+                        },
+                        "appSecretForTemplate": {
+                            "type": "string"
+                        },
+                        "botEndPointForTemplate": {
+                            "type": "string"
+                        },
+                        "botIdForTemplate": {
+                            "type": "string"
+                        },
+                        "botSkuForTemplate": {
+                            "type": "string"
+                        },
+                        "resourcesLocationForTemplate": {
+                            "type": "string"
+                        },
+                        "newAppServicePlanSkuForTemplate": {
+                            "type": "object"
+                        },
+                        "webAppNameForTemplate": {
+                            "type": "string"
+                        }
+                    },
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new App Service Plan",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[variables('appServicePlanName')]",
+                            "name": "[parameters('appServicePlanNameForTemplate')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[variables('resourcesLocation')]",
-                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
                             "properties": {
-                                "name": "[variables('appServicePlanName')]"
+                                "name": "[parameters('appServicePlanNameForTemplate')]"
                             }
                         },
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[variables('resourcesLocation')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
                             ],
-                            "name": "[variables('webAppName')]",
+                            "name": "[parameters('webAppNameForTemplate')]",
                             "properties": {
-                                "name": "[variables('webAppName')]",
-                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "name": "[parameters('webAppNameForTemplate')]",
+                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
@@ -135,11 +194,11 @@
                                         },
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appId')]"
+                                            "value": "[parameters('appIdForTemplate')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecret')]"
+                                            "value": "[parameters('appSecretForTemplate')]"
                                         }
                                     ],
                                     "cors": {
@@ -155,24 +214,24 @@
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botId')]",
+                            "name": "[parameters('botIdForTemplate')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSku')]"
+                                "name": "[parameters('botSkuForTemplate')]"
                             },
                             "properties": {
-                                "name": "[parameters('botId')]",
-                                "displayName": "[parameters('botId')]",
-                                "endpoint": "[variables('botEndpoint')]",
-                                "msaAppId": "[parameters('appId')]",
+                                "name": "[parameters('botIdForTemplate')]",
+                                "displayName": "[parameters('botIdForTemplate')]",
+                                "endpoint": "[parameters('botEndpointForTemplate')]",
+                                "msaAppId": "[parameters('appIdForTemplate')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/dotnet/3.1/skill/DeploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/dotnet/3.1/skill/DeploymentTemplates/template-with-new-rg.json
@@ -84,8 +84,7 @@
             "type": "Microsoft.Resources/resourceGroups",
             "apiVersion": "2018-05-01",
             "location": "[parameters('groupLocation')]",
-            "properties": {
-            }
+            "properties": {}
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -97,36 +96,96 @@
             ],
             "properties": {
                 "mode": "Incremental",
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "parameters": {
+                    "appIdForTemplate": {
+                        "value": "[parameters('appId')]"
+                    },
+                    "appServicePlanNameForTemplate": {
+                        "value": "[variables('appServicePlanName')]"
+                    },
+                    "appSecretForTemplate": {
+                        "value": "[parameters('appSecret')]"
+                    },
+                    "botEndPointForTemplate": {
+                        "value": "[variables('botEndpoint')]"
+                    },
+                    "botIdForTemplate": {
+                        "value": "[parameters('botId')]"
+                    },
+                    "botSkuForTemplate": {
+                        "value": "[parameters('botSku')]"
+                    },
+                    "resourcesLocationForTemplate": {
+                        "value": "[variables('resourcesLocation')]"
+                    },
+                    "newAppServicePlanSkuForTemplate": {
+                        "value": "[parameters('newAppServicePlanSku')]"
+                    },
+                    "webAppNameForTemplate": {
+                        "value": "[variables('webAppName')]"
+                    }
+                },
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                    "parameters": {},
+                    "parameters": {
+                        "appIdForTemplate": {
+                            "type": "string"
+                        },
+                        "appServicePlanNameForTemplate": {
+                            "type": "string"
+                        },
+                        "appSecretForTemplate": {
+                            "type": "string"
+                        },
+                        "botEndPointForTemplate": {
+                            "type": "string"
+                        },
+                        "botIdForTemplate": {
+                            "type": "string"
+                        },
+                        "botSkuForTemplate": {
+                            "type": "string"
+                        },
+                        "resourcesLocationForTemplate": {
+                            "type": "string"
+                        },
+                        "newAppServicePlanSkuForTemplate": {
+                            "type": "object"
+                        },
+                        "webAppNameForTemplate": {
+                            "type": "string"
+                        }
+                    },
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new App Service Plan",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[variables('appServicePlanName')]",
+                            "name": "[parameters('appServicePlanNameForTemplate')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[variables('resourcesLocation')]",
-                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
                             "properties": {
-                                "name": "[variables('appServicePlanName')]"
+                                "name": "[parameters('appServicePlanNameForTemplate')]"
                             }
                         },
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[variables('resourcesLocation')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
                             ],
-                            "name": "[variables('webAppName')]",
+                            "name": "[parameters('webAppNameForTemplate')]",
                             "properties": {
-                                "name": "[variables('webAppName')]",
-                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "name": "[parameters('webAppNameForTemplate')]",
+                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
@@ -135,11 +194,11 @@
                                         },
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appId')]"
+                                            "value": "[parameters('appIdForTemplate')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecret')]"
+                                            "value": "[parameters('appSecretForTemplate')]"
                                         }
                                     ],
                                     "cors": {
@@ -155,24 +214,24 @@
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botId')]",
+                            "name": "[parameters('botIdForTemplate')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSku')]"
+                                "name": "[parameters('botSkuForTemplate')]"
                             },
                             "properties": {
-                                "name": "[parameters('botId')]",
-                                "displayName": "[parameters('botId')]",
-                                "endpoint": "[variables('botEndpoint')]",
-                                "msaAppId": "[parameters('appId')]",
+                                "name": "[parameters('botIdForTemplate')]",
+                                "displayName": "[parameters('botIdForTemplate')]",
+                                "endpoint": "[parameters('botEndpointForTemplate')]",
+                                "msaAppId": "[parameters('appIdForTemplate')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/dotnet/v3/skill/DeploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/dotnet/v3/skill/DeploymentTemplates/template-with-new-rg.json
@@ -84,8 +84,7 @@
             "type": "Microsoft.Resources/resourceGroups",
             "apiVersion": "2018-05-01",
             "location": "[parameters('groupLocation')]",
-            "properties": {
-            }
+            "properties": {}
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -97,36 +96,96 @@
             ],
             "properties": {
                 "mode": "Incremental",
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "parameters": {
+                    "appIdForTemplate": {
+                        "value": "[parameters('appId')]"
+                    },
+                    "appServicePlanNameForTemplate": {
+                        "value": "[variables('appServicePlanName')]"
+                    },
+                    "appSecretForTemplate": {
+                        "value": "[parameters('appSecret')]"
+                    },
+                    "botEndPointForTemplate": {
+                        "value": "[variables('botEndpoint')]"
+                    },
+                    "botIdForTemplate": {
+                        "value": "[parameters('botId')]"
+                    },
+                    "botSkuForTemplate": {
+                        "value": "[parameters('botSku')]"
+                    },
+                    "resourcesLocationForTemplate": {
+                        "value": "[variables('resourcesLocation')]"
+                    },
+                    "newAppServicePlanSkuForTemplate": {
+                        "value": "[parameters('newAppServicePlanSku')]"
+                    },
+                    "webAppNameForTemplate": {
+                        "value": "[variables('webAppName')]"
+                    }
+                },
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                    "parameters": {},
+                    "parameters": {
+                        "appIdForTemplate": {
+                            "type": "string"
+                        },
+                        "appServicePlanNameForTemplate": {
+                            "type": "string"
+                        },
+                        "appSecretForTemplate": {
+                            "type": "string"
+                        },
+                        "botEndPointForTemplate": {
+                            "type": "string"
+                        },
+                        "botIdForTemplate": {
+                            "type": "string"
+                        },
+                        "botSkuForTemplate": {
+                            "type": "string"
+                        },
+                        "resourcesLocationForTemplate": {
+                            "type": "string"
+                        },
+                        "newAppServicePlanSkuForTemplate": {
+                            "type": "object"
+                        },
+                        "webAppNameForTemplate": {
+                            "type": "string"
+                        }
+                    },
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new App Service Plan",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[variables('appServicePlanName')]",
+                            "name": "[parameters('appServicePlanNameForTemplate')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[variables('resourcesLocation')]",
-                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
                             "properties": {
-                                "name": "[variables('appServicePlanName')]"
+                                "name": "[parameters('appServicePlanNameForTemplate')]"
                             }
                         },
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[variables('resourcesLocation')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
                             ],
-                            "name": "[variables('webAppName')]",
+                            "name": "[parameters('webAppNameForTemplate')]",
                             "properties": {
-                                "name": "[variables('webAppName')]",
-                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "name": "[parameters('webAppNameForTemplate')]",
+                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
@@ -135,11 +194,11 @@
                                         },
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appId')]"
+                                            "value": "[parameters('appIdForTemplate')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecret')]"
+                                            "value": "[parameters('appSecretForTemplate')]"
                                         }
                                     ],
                                     "cors": {
@@ -155,24 +214,24 @@
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botId')]",
+                            "name": "[parameters('botIdForTemplate')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSku')]"
+                                "name": "[parameters('botSkuForTemplate')]"
                             },
                             "properties": {
-                                "name": "[parameters('botId')]",
-                                "displayName": "[parameters('botId')]",
-                                "endpoint": "[variables('botEndpoint')]",
-                                "msaAppId": "[parameters('appId')]",
+                                "name": "[parameters('botIdForTemplate')]",
+                                "displayName": "[parameters('botIdForTemplate')]",
+                                "endpoint": "[parameters('botEndpointForTemplate')]",
+                                "msaAppId": "[parameters('appIdForTemplate')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/javascript/v3/skill/deploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/javascript/v3/skill/deploymentTemplates/template-with-new-rg.json
@@ -97,36 +97,97 @@
             ],
             "properties": {
                 "mode": "Incremental",
+				"expressionEvaluationOptions": {
+					"scope": "inner"
+				},
+				"parameters": {
+					"appIdForTemplate": {
+						"value": "[parameters('appId')]"
+					},
+					"appServicePlanNameForTemplate": {
+						"value": "[variables('appServicePlanName')]"
+					},
+					"appSecretForTemplate": {
+						"value": "[parameters('appSecret')]"
+					},
+					"botEndPointForTemplate": {
+						"value": "[variables('botEndpoint')]"
+					},
+					"botIdForTemplate": {
+						"value": "[parameters('botId')]"
+					},
+					"botSkuForTemplate": {
+						"value": "[parameters('botSku')]"
+					},
+					"resourcesLocationForTemplate": {
+						"value": "[variables('resourcesLocation')]"
+					},
+					"newAppServicePlanSkuForTemplate":{
+						"value": "[parameters('newAppServicePlanSku')]"
+					},
+					"webAppNameForTemplate": {
+						"value": "[variables('webAppName')]"
+					}
+				},
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                    "parameters": {},
+					"parameters": {
+						"appIdForTemplate": {
+							"type": "string"
+						},
+						"appServicePlanNameForTemplate": {
+							"type": "string"
+						},
+						"appSecretForTemplate": {
+							"type": "string"
+						},
+						"botEndPointForTemplate": {
+							"type": "string"
+						},
+						"botIdForTemplate": {
+							"type": "string"
+						},
+						"botSkuForTemplate": {
+							"type": "string"
+						},
+						"resourcesLocationForTemplate": {
+							"type": "string"
+						},
+						"newAppServicePlanSkuForTemplate": {
+							"type": "object"
+						},
+						"webAppNameForTemplate": {
+							"type": "string"
+						}
+							
+					},
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new App Service Plan",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[variables('appServicePlanName')]",
+                            "name": "[parameters('appServicePlanNameForTemplate')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[variables('resourcesLocation')]",
-                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
                             "properties": {
-                                "name": "[variables('appServicePlanName')]"
+                                "name": "[parameters('appServicePlanNameForTemplate')]"
                             }
                         },
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[variables('resourcesLocation')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
                             ],
-                            "name": "[variables('webAppName')]",
+                            "name": "[parameters('webAppNameForTemplate')]",
                             "properties": {
-                                "name": "[variables('webAppName')]",
-                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "name": "[parameters('webAppNameForTemplate')]",
+                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
@@ -135,11 +196,11 @@
                                         },
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appId')]"
+                                            "value": "[parameters('appIdForTemplate')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecret')]"
+                                            "value": "[parameters('appSecretForTemplate')]"
                                         }
                                     ],
                                     "cors": {
@@ -154,24 +215,24 @@
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botId')]",
+                            "name": "[parameters('botIdForTemplate')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSku')]"
+                                "name": "[parameters('botSkuForTemplate')]"
                             },
                             "properties": {
-                                "name": "[parameters('botId')]",
-                                "displayName": "[parameters('botId')]",
-                                "endpoint": "[variables('botEndpoint')]",
-                                "msaAppId": "[parameters('appId')]",
+                                "name": "[parameters('botIdForTemplate')]",
+                                "displayName": "[parameters('botIdForTemplate')]",
+                                "endpoint": "[parameters('botEndpointForTemplate')]",
+                                "msaAppId": "[parameters('appIdForTemplate')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json
@@ -127,6 +127,9 @@
                     },
                     "webAppNameForTemplate": {
                         "value": "[variables('webAppName')]"
+                    },
+                    "publishingUsernameForTemplate": {
+                        "value": "[variables('publishingUsername')]"
                     }
                 },
                 "template": {
@@ -158,6 +161,9 @@
                             "type": "object"
                         },
                         "webAppNameForTemplate": {
+                            "type": "string"
+                        },
+                        "publishingUsernameForTemplate": {
                             "type": "string"
                         }
                     },
@@ -194,12 +200,12 @@
                                 "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
                                 "hostNameSslStates": [
                                     {
-                                        "name": "[concat(parameters('newWebAppName'), '.azurewebsites.net')]",
+                                        "name": "[concat(parameters('webAppNameForTemplate'), '.azurewebsites.net')]",
                                         "sslState": "Disabled",
                                         "hostType": "Standard"
                                     },
                                     {
-                                        "name": "[concat(parameters('newWebAppName'), '.scm.azurewebsites.net')]",
+                                        "name": "[concat(parameters('webAppNameForTemplate'), '.scm.azurewebsites.net')]",
                                         "sslState": "Disabled",
                                         "hostType": "Repository"
                                     }
@@ -227,10 +233,10 @@
                         {
                             "type": "Microsoft.Web/sites/config",
                             "apiVersion": "2016-08-01",
-                            "name": "[concat(variables('webAppName'), '/web')]",
-                            "location": "[variables('resourcesLocation')]",
+                            "name": "[concat(parameters('webAppNameForTemplate'), '/web')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites', variables('webAppName'))]"
+                                "[resourceId('Microsoft.Web/sites', parameters('webAppNameForTemplate'))]"
                             ],
                             "properties": {
                                 "numberOfWorkers": 1,
@@ -256,7 +262,7 @@
                                 "httpLoggingEnabled": true,
                                 "logsDirectorySizeLimit": 35,
                                 "detailedErrorLoggingEnabled": false,
-                                "publishingUsername": "[variables('publishingUsername')]",
+                                "publishingUsername": "[parameters('publishingUsernameForTemplate')]",
                                 "scmType": "None",
                                 "use32BitWorkerProcess": true,
                                 "webSocketsEnabled": false,

--- a/SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json
@@ -85,8 +85,7 @@
             "type": "Microsoft.Resources/resourceGroups",
             "apiVersion": "2018-05-01",
             "location": "[parameters('groupLocation')]",
-            "properties": {
-            }
+            "properties": {}
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -98,22 +97,82 @@
             ],
             "properties": {
                 "mode": "Incremental",
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "parameters": {
+                    "appIdForTemplate": {
+                        "value": "[parameters('appId')]"
+                    },
+                    "appServicePlanNameForTemplate": {
+                        "value": "[variables('appServicePlanName')]"
+                    },
+                    "appSecretForTemplate": {
+                        "value": "[parameters('appSecret')]"
+                    },
+                    "botEndPointForTemplate": {
+                        "value": "[variables('botEndpoint')]"
+                    },
+                    "botIdForTemplate": {
+                        "value": "[parameters('botId')]"
+                    },
+                    "botSkuForTemplate": {
+                        "value": "[parameters('botSku')]"
+                    },
+                    "resourcesLocationForTemplate": {
+                        "value": "[variables('resourcesLocation')]"
+                    },
+                    "newAppServicePlanSkuForTemplate": {
+                        "value": "[parameters('newAppServicePlanSku')]"
+                    },
+                    "webAppNameForTemplate": {
+                        "value": "[variables('webAppName')]"
+                    }
+                },
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                    "parameters": {},
+                    "parameters": {
+                        "appIdForTemplate": {
+                            "type": "string"
+                        },
+                        "appServicePlanNameForTemplate": {
+                            "type": "string"
+                        },
+                        "appSecretForTemplate": {
+                            "type": "string"
+                        },
+                        "botEndPointForTemplate": {
+                            "type": "string"
+                        },
+                        "botIdForTemplate": {
+                            "type": "string"
+                        },
+                        "botSkuForTemplate": {
+                            "type": "string"
+                        },
+                        "resourcesLocationForTemplate": {
+                            "type": "string"
+                        },
+                        "newAppServicePlanSkuForTemplate": {
+                            "type": "object"
+                        },
+                        "webAppNameForTemplate": {
+                            "type": "string"
+                        }
+                    },
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new Linux App Service Plan if no existing App Service Plan name was passed in.",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[variables('appServicePlanName')]",
+                            "name": "[parameters('appServicePlanNameForTemplate')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[variables('resourcesLocation')]",
-                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
                             "kind": "linux",
                             "properties": {
-                                "name": "[variables('appServicePlanName')]",
+                                "name": "[parameters('appServicePlanNameForTemplate')]",
                                 "perSiteScaling": false,
                                 "reserved": true,
                                 "targetWorkerCount": 0,
@@ -124,14 +183,15 @@
                             "comments": "Create a Web App using a Linux App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[variables('resourcesLocation')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
                             "kind": "app,linux",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
                             ],
-                            "name": "[variables('webAppName')]",
+                            "name": "[parameters('webAppNameForTemplate')]",
                             "properties": {
-                                "name": "[variables('webAppName')]",
+                                "name": "[parameters('webAppNameForTemplate')]",
+                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
                                 "hostNameSslStates": [
                                     {
                                         "name": "[concat(parameters('newWebAppName'), '.azurewebsites.net')]",
@@ -144,16 +204,15 @@
                                         "hostType": "Repository"
                                     }
                                 ],
-                                "serverFarmId": "[variables('appServicePlanName')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appId')]"
+                                            "value": "[parameters('appIdForTemplate')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecret')]"
+                                            "value": "[parameters('appSecretForTemplate')]"
                                         }
                                     ],
                                     "cors": {
@@ -166,89 +225,89 @@
                             }
                         },
                         {
-                          "type": "Microsoft.Web/sites/config",
-                          "apiVersion": "2016-08-01",
-                          "name": "[concat(variables('webAppName'), '/web')]",
-                          "location": "[variables('resourcesLocation')]",
-                          "dependsOn": [
-                              "[resourceId('Microsoft.Web/sites', variables('webAppName'))]"
-                          ],
-                          "properties": {
-                              "numberOfWorkers": 1,
-                              "defaultDocuments": [
-                                  "Default.htm",
-                                  "Default.html",
-                                  "Default.asp",
-                                  "index.htm",
-                                  "index.html",
-                                  "iisstart.htm",
-                                  "default.aspx",
-                                  "index.php",
-                                  "hostingstart.html"
-                              ],
-                              "netFrameworkVersion": "v4.0",
-                              "phpVersion": "",
-                              "pythonVersion": "",
-                              "nodeVersion": "",
-                              "linuxFxVersion": "PYTHON|3.7",
-                              "requestTracingEnabled": false,
-                              "remoteDebuggingEnabled": false,
-                              "remoteDebuggingVersion": "VS2017",
-                              "httpLoggingEnabled": true,
-                              "logsDirectorySizeLimit": 35,
-                              "detailedErrorLoggingEnabled": false,
-                              "publishingUsername": "[variables('publishingUsername')]",
-                              "scmType": "None",
-                              "use32BitWorkerProcess": true,
-                              "webSocketsEnabled": false,
-                              "alwaysOn": false,
-                              "appCommandLine": "gunicorn --bind 0.0.0.0 --worker-class aiohttp.worker.GunicornWebWorker --timeout 600 app:APP",
-                              "managedPipelineMode": "Integrated",
-                              "virtualApplications": [
-                                  {
-                                      "virtualPath": "/",
-                                      "physicalPath": "site\\wwwroot",
-                                      "preloadEnabled": false,
-                                      "virtualDirectories": null
-                                  }
-                              ],
-                              "winAuthAdminState": 0,
-                              "winAuthTenantState": 0,
-                              "customAppPoolIdentityAdminState": false,
-                              "customAppPoolIdentityTenantState": false,
-                              "loadBalancing": "LeastRequests",
-                              "routingRules": [],
-                              "experiments": {
-                                  "rampUpRules": []
-                              },
-                              "autoHealEnabled": false,
-                              "vnetName": "",
-                              "minTlsVersion": "1.2",
-                              "ftpsState": "AllAllowed",
-                              "reservedInstanceCount": 0
-                          }
+                            "type": "Microsoft.Web/sites/config",
+                            "apiVersion": "2016-08-01",
+                            "name": "[concat(variables('webAppName'), '/web')]",
+                            "location": "[variables('resourcesLocation')]",
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Web/sites', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "numberOfWorkers": 1,
+                                "defaultDocuments": [
+                                    "Default.htm",
+                                    "Default.html",
+                                    "Default.asp",
+                                    "index.htm",
+                                    "index.html",
+                                    "iisstart.htm",
+                                    "default.aspx",
+                                    "index.php",
+                                    "hostingstart.html"
+                                ],
+                                "netFrameworkVersion": "v4.0",
+                                "phpVersion": "",
+                                "pythonVersion": "",
+                                "nodeVersion": "",
+                                "linuxFxVersion": "PYTHON|3.7",
+                                "requestTracingEnabled": false,
+                                "remoteDebuggingEnabled": false,
+                                "remoteDebuggingVersion": "VS2017",
+                                "httpLoggingEnabled": true,
+                                "logsDirectorySizeLimit": 35,
+                                "detailedErrorLoggingEnabled": false,
+                                "publishingUsername": "[variables('publishingUsername')]",
+                                "scmType": "None",
+                                "use32BitWorkerProcess": true,
+                                "webSocketsEnabled": false,
+                                "alwaysOn": false,
+                                "appCommandLine": "gunicorn --bind 0.0.0.0 --worker-class aiohttp.worker.GunicornWebWorker --timeout 600 app:APP",
+                                "managedPipelineMode": "Integrated",
+                                "virtualApplications": [
+                                    {
+                                        "virtualPath": "/",
+                                        "physicalPath": "site\\wwwroot",
+                                        "preloadEnabled": false,
+                                        "virtualDirectories": null
+                                    }
+                                ],
+                                "winAuthAdminState": 0,
+                                "winAuthTenantState": 0,
+                                "customAppPoolIdentityAdminState": false,
+                                "customAppPoolIdentityTenantState": false,
+                                "loadBalancing": "LeastRequests",
+                                "routingRules": [],
+                                "experiments": {
+                                    "rampUpRules": []
+                                },
+                                "autoHealEnabled": false,
+                                "vnetName": "",
+                                "minTlsVersion": "1.2",
+                                "ftpsState": "AllAllowed",
+                                "reservedInstanceCount": 0
+                            }
                         },
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botId')]",
+                            "name": "[parameters('botIdForTemplate')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSku')]"
+                                "name": "[parameters('botSkuForTemplate')]"
                             },
                             "properties": {
-                                "name": "[parameters('botId')]",
-                                "displayName": "[parameters('botId')]",
-                                "endpoint": "[variables('botEndpoint')]",
-                                "msaAppId": "[parameters('appId')]",
+                                "name": "[parameters('botIdForTemplate')]",
+                                "displayName": "[parameters('botIdForTemplate')]",
+                                "endpoint": "[parameters('botEndpointForTemplate')]",
+                                "msaAppId": "[parameters('appIdForTemplate')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json
@@ -127,6 +127,9 @@
                     },
                     "webAppNameForTemplate": {
                         "value": "[variables('webAppName')]"
+                    },
+                    "publishingUsernameForTemplate": {
+                        "value": "[variables('publishingUsername')]"
                     }
                 },
                 "template": {
@@ -158,6 +161,9 @@
                             "type": "object"
                         },
                         "webAppNameForTemplate": {
+                            "type": "string"
+                        },
+                        "publishingUsernameForTemplate": {
                             "type": "string"
                         }
                     },
@@ -194,12 +200,12 @@
                                 "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
                                 "hostNameSslStates": [
                                     {
-                                        "name": "[concat(parameters('newWebAppName'), '.azurewebsites.net')]",
+                                        "name": "[concat(parameters('webAppNameForTemplate'), '.azurewebsites.net')]",
                                         "sslState": "Disabled",
                                         "hostType": "Standard"
                                     },
                                     {
-                                        "name": "[concat(parameters('newWebAppName'), '.scm.azurewebsites.net')]",
+                                        "name": "[concat(parameters('webAppNameForTemplate'), '.scm.azurewebsites.net')]",
                                         "sslState": "Disabled",
                                         "hostType": "Repository"
                                     }
@@ -227,10 +233,10 @@
                         {
                             "type": "Microsoft.Web/sites/config",
                             "apiVersion": "2016-08-01",
-                            "name": "[concat(variables('webAppName'), '/web')]",
-                            "location": "[variables('resourcesLocation')]",
+                            "name": "[concat(parameters('webAppNameForTemplate'), '/web')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites', variables('webAppName'))]"
+                                "[resourceId('Microsoft.Web/sites', parameters('webAppNameForTemplate'))]"
                             ],
                             "properties": {
                                 "numberOfWorkers": 1,
@@ -256,7 +262,7 @@
                                 "httpLoggingEnabled": true,
                                 "logsDirectorySizeLimit": 35,
                                 "detailedErrorLoggingEnabled": false,
-                                "publishingUsername": "[variables('publishingUsername')]",
+                                "publishingUsername": "[parameters('publishingUsernameForTemplate')]",
                                 "scmType": "None",
                                 "use32BitWorkerProcess": true,
                                 "webSocketsEnabled": false,

--- a/SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json
@@ -85,8 +85,7 @@
             "type": "Microsoft.Resources/resourceGroups",
             "apiVersion": "2018-05-01",
             "location": "[parameters('groupLocation')]",
-            "properties": {
-            }
+            "properties": {}
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -98,22 +97,82 @@
             ],
             "properties": {
                 "mode": "Incremental",
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "parameters": {
+                    "appIdForTemplate": {
+                        "value": "[parameters('appId')]"
+                    },
+                    "appServicePlanNameForTemplate": {
+                        "value": "[variables('appServicePlanName')]"
+                    },
+                    "appSecretForTemplate": {
+                        "value": "[parameters('appSecret')]"
+                    },
+                    "botEndPointForTemplate": {
+                        "value": "[variables('botEndpoint')]"
+                    },
+                    "botIdForTemplate": {
+                        "value": "[parameters('botId')]"
+                    },
+                    "botSkuForTemplate": {
+                        "value": "[parameters('botSku')]"
+                    },
+                    "resourcesLocationForTemplate": {
+                        "value": "[variables('resourcesLocation')]"
+                    },
+                    "newAppServicePlanSkuForTemplate": {
+                        "value": "[parameters('newAppServicePlanSku')]"
+                    },
+                    "webAppNameForTemplate": {
+                        "value": "[variables('webAppName')]"
+                    }
+                },
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                    "parameters": {},
+                    "parameters": {
+                        "appIdForTemplate": {
+                            "type": "string"
+                        },
+                        "appServicePlanNameForTemplate": {
+                            "type": "string"
+                        },
+                        "appSecretForTemplate": {
+                            "type": "string"
+                        },
+                        "botEndPointForTemplate": {
+                            "type": "string"
+                        },
+                        "botIdForTemplate": {
+                            "type": "string"
+                        },
+                        "botSkuForTemplate": {
+                            "type": "string"
+                        },
+                        "resourcesLocationForTemplate": {
+                            "type": "string"
+                        },
+                        "newAppServicePlanSkuForTemplate": {
+                            "type": "object"
+                        },
+                        "webAppNameForTemplate": {
+                            "type": "string"
+                        }
+                    },
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new Linux App Service Plan if no existing App Service Plan name was passed in.",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[variables('appServicePlanName')]",
+                            "name": "[parameters('appServicePlanNameForTemplate')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[variables('resourcesLocation')]",
-                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
                             "kind": "linux",
                             "properties": {
-                                "name": "[variables('appServicePlanName')]",
+                                "name": "[parameters('appServicePlanNameForTemplate')]",
                                 "perSiteScaling": false,
                                 "reserved": true,
                                 "targetWorkerCount": 0,
@@ -124,14 +183,15 @@
                             "comments": "Create a Web App using a Linux App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[variables('resourcesLocation')]",
+                            "location": "[parameters('resourcesLocationForTemplate')]",
                             "kind": "app,linux",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
                             ],
-                            "name": "[variables('webAppName')]",
+                            "name": "[parameters('webAppNameForTemplate')]",
                             "properties": {
-                                "name": "[variables('webAppName')]",
+                                "name": "[parameters('webAppNameForTemplate')]",
+                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
                                 "hostNameSslStates": [
                                     {
                                         "name": "[concat(parameters('newWebAppName'), '.azurewebsites.net')]",
@@ -144,16 +204,15 @@
                                         "hostType": "Repository"
                                     }
                                 ],
-                                "serverFarmId": "[variables('appServicePlanName')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appId')]"
+                                            "value": "[parameters('appIdForTemplate')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecret')]"
+                                            "value": "[parameters('appSecretForTemplate')]"
                                         }
                                     ],
                                     "cors": {
@@ -166,89 +225,89 @@
                             }
                         },
                         {
-                          "type": "Microsoft.Web/sites/config",
-                          "apiVersion": "2016-08-01",
-                          "name": "[concat(variables('webAppName'), '/web')]",
-                          "location": "[variables('resourcesLocation')]",
-                          "dependsOn": [
-                              "[resourceId('Microsoft.Web/sites', variables('webAppName'))]"
-                          ],
-                          "properties": {
-                              "numberOfWorkers": 1,
-                              "defaultDocuments": [
-                                  "Default.htm",
-                                  "Default.html",
-                                  "Default.asp",
-                                  "index.htm",
-                                  "index.html",
-                                  "iisstart.htm",
-                                  "default.aspx",
-                                  "index.php",
-                                  "hostingstart.html"
-                              ],
-                              "netFrameworkVersion": "v4.0",
-                              "phpVersion": "",
-                              "pythonVersion": "",
-                              "nodeVersion": "",
-                              "linuxFxVersion": "PYTHON|3.7",
-                              "requestTracingEnabled": false,
-                              "remoteDebuggingEnabled": false,
-                              "remoteDebuggingVersion": "VS2017",
-                              "httpLoggingEnabled": true,
-                              "logsDirectorySizeLimit": 35,
-                              "detailedErrorLoggingEnabled": false,
-                              "publishingUsername": "[variables('publishingUsername')]",
-                              "scmType": "None",
-                              "use32BitWorkerProcess": true,
-                              "webSocketsEnabled": false,
-                              "alwaysOn": false,
-                              "appCommandLine": "gunicorn --bind 0.0.0.0 --worker-class aiohttp.worker.GunicornWebWorker --timeout 600 app:APP",
-                              "managedPipelineMode": "Integrated",
-                              "virtualApplications": [
-                                  {
-                                      "virtualPath": "/",
-                                      "physicalPath": "site\\wwwroot",
-                                      "preloadEnabled": false,
-                                      "virtualDirectories": null
-                                  }
-                              ],
-                              "winAuthAdminState": 0,
-                              "winAuthTenantState": 0,
-                              "customAppPoolIdentityAdminState": false,
-                              "customAppPoolIdentityTenantState": false,
-                              "loadBalancing": "LeastRequests",
-                              "routingRules": [],
-                              "experiments": {
-                                  "rampUpRules": []
-                              },
-                              "autoHealEnabled": false,
-                              "vnetName": "",
-                              "minTlsVersion": "1.2",
-                              "ftpsState": "AllAllowed",
-                              "reservedInstanceCount": 0
-                          }
+                            "type": "Microsoft.Web/sites/config",
+                            "apiVersion": "2016-08-01",
+                            "name": "[concat(variables('webAppName'), '/web')]",
+                            "location": "[variables('resourcesLocation')]",
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Web/sites', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "numberOfWorkers": 1,
+                                "defaultDocuments": [
+                                    "Default.htm",
+                                    "Default.html",
+                                    "Default.asp",
+                                    "index.htm",
+                                    "index.html",
+                                    "iisstart.htm",
+                                    "default.aspx",
+                                    "index.php",
+                                    "hostingstart.html"
+                                ],
+                                "netFrameworkVersion": "v4.0",
+                                "phpVersion": "",
+                                "pythonVersion": "",
+                                "nodeVersion": "",
+                                "linuxFxVersion": "PYTHON|3.7",
+                                "requestTracingEnabled": false,
+                                "remoteDebuggingEnabled": false,
+                                "remoteDebuggingVersion": "VS2017",
+                                "httpLoggingEnabled": true,
+                                "logsDirectorySizeLimit": 35,
+                                "detailedErrorLoggingEnabled": false,
+                                "publishingUsername": "[variables('publishingUsername')]",
+                                "scmType": "None",
+                                "use32BitWorkerProcess": true,
+                                "webSocketsEnabled": false,
+                                "alwaysOn": false,
+                                "appCommandLine": "gunicorn --bind 0.0.0.0 --worker-class aiohttp.worker.GunicornWebWorker --timeout 600 app:APP",
+                                "managedPipelineMode": "Integrated",
+                                "virtualApplications": [
+                                    {
+                                        "virtualPath": "/",
+                                        "physicalPath": "site\\wwwroot",
+                                        "preloadEnabled": false,
+                                        "virtualDirectories": null
+                                    }
+                                ],
+                                "winAuthAdminState": 0,
+                                "winAuthTenantState": 0,
+                                "customAppPoolIdentityAdminState": false,
+                                "customAppPoolIdentityTenantState": false,
+                                "loadBalancing": "LeastRequests",
+                                "routingRules": [],
+                                "experiments": {
+                                    "rampUpRules": []
+                                },
+                                "autoHealEnabled": false,
+                                "vnetName": "",
+                                "minTlsVersion": "1.2",
+                                "ftpsState": "AllAllowed",
+                                "reservedInstanceCount": 0
+                            }
                         },
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botId')]",
+                            "name": "[parameters('botIdForTemplate')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSku')]"
+                                "name": "[parameters('botSkuForTemplate')]"
                             },
                             "properties": {
-                                "name": "[parameters('botId')]",
-                                "displayName": "[parameters('botId')]",
-                                "endpoint": "[variables('botEndpoint')]",
-                                "msaAppId": "[parameters('appId')]",
+                                "name": "[parameters('botIdForTemplate')]",
+                                "displayName": "[parameters('botIdForTemplate')]",
+                                "endpoint": "[parameters('botEndpointForTemplate')]",
+                                "msaAppId": "[parameters('appIdForTemplate')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
                             ]
                         }
                     ],

--- a/build/yaml/dotnetDeploySteps.yml
+++ b/build/yaml/dotnetDeploySteps.yml
@@ -16,8 +16,7 @@ steps:
     azureSubscription: $(AzureSubscription)
     scriptLocation: inlineScript
     inlineScript: |
-     call az group create --location westus --name "$(BotName)-RG"
-     call az deployment group create --resource-group "$(BotName)-RG" --name $(BotName) --template-file "$(TemplateLocation)" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" appServicePlanLocation="westus" existingAppServicePlan="" existingAppServicePlanResourceGroup="$(BotName)-RG" newWebAppName="$(BotName)-$(Build.BuildId)"
+     call az deployment create --name $(BotName) --template-file "$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotName)-RG" groupLocation="westus" newAppServicePlanLocation="westus"
 
 - task: AzureCLI@1
   displayName: 'Deploy bot'

--- a/build/yaml/dotnetHost2DotnetV3Skill.yml
+++ b/build/yaml/dotnetHost2DotnetV3Skill.yml
@@ -94,7 +94,7 @@ stages:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
         Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
@@ -108,7 +108,7 @@ stages:
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.solution: 'SkillsFunctionalTests/dotnet/v3/skill/EchoSkillBot.sln'
         Parameters.sourceLocation: 'SkillsFunctionalTests/dotnet/v3/skill/'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/v3/skill/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/dotnet/v3/skill/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: dotnetV3DeploySteps.yml
 

--- a/build/yaml/dotnetHost2JavascriptSkill.yml
+++ b/build/yaml/dotnetHost2JavascriptSkill.yml
@@ -86,7 +86,7 @@ stages:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
         Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
@@ -99,7 +99,7 @@ stages:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/skill'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/skill/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/javascript/skill/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptDeploySteps.yml
 

--- a/build/yaml/dotnetHost2JavascriptV3Skill.yml
+++ b/build/yaml/dotnetHost2JavascriptV3Skill.yml
@@ -86,7 +86,7 @@ stages:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
         Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
@@ -99,7 +99,7 @@ stages:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/v3/skill'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/skill/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/javascript/skill/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptDeploySteps.yml
 

--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -88,7 +88,7 @@ stages:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
         Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
@@ -101,7 +101,7 @@ stages:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/skill'
-        TemplateLocation: 'SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonDeploySteps.yml
 

--- a/build/yaml/dotnetHost2dotnetSkill.yml
+++ b/build/yaml/dotnetHost2dotnetSkill.yml
@@ -104,7 +104,7 @@ stages:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]        
         Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
@@ -117,7 +117,7 @@ stages:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/EchoSkillBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: dotnetDeploySteps.yml
 

--- a/build/yaml/dotnetV3DeploySteps.yml
+++ b/build/yaml/dotnetV3DeploySteps.yml
@@ -12,8 +12,7 @@ steps:
     azureSubscription: $(AzureSubscription)
     scriptLocation: inlineScript
     inlineScript: |
-     call az group create --location westus --name "$(BotName)-RG"
-     call az deployment group create --resource-group "$(BotName)-RG" --name $(BotName) --template-file "$(TemplateLocation)" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" appServicePlanLocation="westus" existingAppServicePlan="" existingAppServicePlanResourceGroup="$(BotName)-RG" newWebAppName="$(BotName)-$(Build.BuildId)"
+     call az deployment create --template-file "$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotName)-RG" botSku=F0 groupLocation="westus" newAppServicePlanLocation="westus"
 
 - task: AzureCLI@1
   displayName: 'Deploy Bot'

--- a/build/yaml/javascriptDeploySteps.yml
+++ b/build/yaml/javascriptDeploySteps.yml
@@ -63,7 +63,7 @@ steps:
     azureSubscription: $(AzureSubscription)
     scriptLocation: inlineScript
     inlineScript: |
-     call az deployment create --name "$(BotName)-RG" --template-file "$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotName)-RG" groupLocation="westus" newAppServicePlanLocation="westus"
+     call az deployment create --name "$(BotName)" --template-file "$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotName)-RG" groupLocation="westus" newAppServicePlanLocation="westus"
 
 - task: AzureCLI@1
   displayName: 'Deploy bot'

--- a/build/yaml/javascriptDeploySteps.yml
+++ b/build/yaml/javascriptDeploySteps.yml
@@ -63,7 +63,7 @@ steps:
     azureSubscription: $(AzureSubscription)
     scriptLocation: inlineScript
     inlineScript: |
-     call az deployment create --name "$(BotName)" --template-file "$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotName)-RG" groupLocation="westus" newAppServicePlanLocation="westus"
+     call az deployment create --name "$(BotName)-RG" --template-file "$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotName)-RG" groupLocation="westus" newAppServicePlanLocation="westus"
 
 - task: AzureCLI@1
   displayName: 'Deploy bot'

--- a/build/yaml/javascriptHost2DotnetSkill.yml
+++ b/build/yaml/javascriptHost2DotnetSkill.yml
@@ -86,7 +86,7 @@ stages:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
         Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/host'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/host/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/javascript/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptSetConfigFileSteps.yml
       - template: javascriptDeploySteps.yml
@@ -99,7 +99,7 @@ stages:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/EchoSkillBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: dotnetDeploySteps.yml
 

--- a/build/yaml/javascriptHost2DotnetV3Skill.yml
+++ b/build/yaml/javascriptHost2DotnetV3Skill.yml
@@ -81,7 +81,7 @@ stages:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
         Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/host'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/host/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/javascript/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptSetConfigFileSteps.yml
       - template: javascriptDeploySteps.yml
@@ -95,7 +95,7 @@ stages:
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.solution: 'SkillsFunctionalTests/dotnet/v3/skill/EchoSkillBot.sln'
         Parameters.sourceLocation: 'SkillsFunctionalTests/dotnet/v3/skill/'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/v3/skill/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/dotnet/v3/skill/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: dotnetV3DeploySteps.yml
 

--- a/build/yaml/javascriptHost2JavascriptV3Skill.yml
+++ b/build/yaml/javascriptHost2JavascriptV3Skill.yml
@@ -70,7 +70,7 @@ stages:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
         Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/host'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/host/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/javascript/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptSetConfigFileSteps.yml
       - template: javascriptDeploySteps.yml
@@ -83,7 +83,7 @@ stages:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/v3/skill'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/v3/skill/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/javascript/v3/skill/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptDeploySteps.yml
 

--- a/build/yaml/javascriptHost2PythonSkill.yml
+++ b/build/yaml/javascriptHost2PythonSkill.yml
@@ -72,7 +72,7 @@ stages:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
         Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/host'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/host/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/javascript/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptSetConfigFileSteps.yml
       - template: javascriptDeploySteps.yml
@@ -85,7 +85,7 @@ stages:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/skill'
-        TemplateLocation: 'SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonDeploySteps.yml
 

--- a/build/yaml/pythonDeploySteps.yml
+++ b/build/yaml/pythonDeploySteps.yml
@@ -89,8 +89,7 @@ steps:
     azureSubscription: $(AzureSubscription)
     scriptLocation: inlineScript
     inlineScript: |
-     call az group create --location westus --name "$(BotName)-RG"
-     call az deployment group create --resource-group "$(BotName)-RG" --name $(BotName) --template-file "$(TemplateLocation)" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" appServicePlanLocation="westus" existingAppServicePlan="" newWebAppName="$(BotName)-$(Build.BuildId)"
+     az deployment create --name "$(BotName)-RG" --template-file "$(System.DefaultWorkingDirectory)/$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotName)-RG" groupLocation="westus" newAppServicePlanLocation="westus"
 
 - script: |
    git config --global user.name "GitPythonDeploymentUser"

--- a/build/yaml/pythonHost2DotnetSkill.yml
+++ b/build/yaml/pythonHost2DotnetSkill.yml
@@ -88,7 +88,7 @@ stages:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
-        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
@@ -101,7 +101,7 @@ stages:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/EchoSkillBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: dotnetDeploySteps.yml
 

--- a/build/yaml/pythonHost2DotnetV3Skill.yml
+++ b/build/yaml/pythonHost2DotnetV3Skill.yml
@@ -83,7 +83,7 @@ stages:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
-        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
@@ -97,7 +97,7 @@ stages:
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.solution: 'SkillsFunctionalTests/dotnet/v3/skill/EchoSkillBot.sln'
         Parameters.sourceLocation: 'SkillsFunctionalTests/dotnet/v3/skill/'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/v3/skill/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/dotnet/v3/skill/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: dotnetV3DeploySteps.yml
 

--- a/build/yaml/pythonHost2JavascriptSkill.yml
+++ b/build/yaml/pythonHost2JavascriptSkill.yml
@@ -73,7 +73,7 @@ stages:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
-        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
@@ -86,7 +86,7 @@ stages:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/skill'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/skill/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/javascript/skill/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptDeploySteps.yml
 

--- a/build/yaml/pythonHost2JavascriptV3Skill.yml
+++ b/build/yaml/pythonHost2JavascriptV3Skill.yml
@@ -73,7 +73,7 @@ stages:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
-        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
@@ -86,7 +86,7 @@ stages:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/v3/skill'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/skill/DeploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/javascript/skill/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptDeploySteps.yml
 

--- a/build/yaml/pythonHost2PythonSkill.yml
+++ b/build/yaml/pythonHost2PythonSkill.yml
@@ -72,7 +72,7 @@ stages:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
-        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
@@ -85,7 +85,7 @@ stages:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/skill'
-        TemplateLocation: 'SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonDeploySteps.yml
 


### PR DESCRIPTION
Fixes #122

## Description
Fix the issue with invalid templates by using inner scope variables and reverse the workaround from the PR# 117 and PR# 118.

## Specific changes
- Reversed the main YAML to use the deploy template using a new resource group.
- Removed step to create a new resource group in all main YAML as it is already created using the deploy template with new resource group.
- Updated all the `template-with-new-rg.json` with the inner scope variable, declaration of the new variables in that scope, and used it.

Note: when referring to all main YAML we are excluding the one for JS host to JS skill and with all the `template-with-new-rg.json` we are excluding the ones for the JS bots as this changes were already added in the PR# 121.

## Testing
All the pipelines were tested with these changes applied and were working properly.
![image](https://user-images.githubusercontent.com/38112957/89417711-6fe04b00-d705-11ea-93ac-4c1e05eda680.png)
