### PR TITLE
Migrate SkillFunctionalTests project to XUnit

### DIFF
--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/Configuration/BotTestConfiguration.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/Configuration/BotTestConfiguration.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace SkillFunctionalTests.Configuration
 {
@@ -30,8 +27,8 @@ namespace SkillFunctionalTests.Configuration
         {
         }
 
-        public string BotId { get; private set; }
+        public string BotId { get; }
 
-        public string DirectLineSecret { get; private set; }
+        public string DirectLineSecret { get; }
     }
 }

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/Configuration/EnvironmentBotTestConfiguration.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/Configuration/EnvironmentBotTestConfiguration.cs
@@ -1,16 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Text;
+using Xunit.Sdk;
 
 namespace SkillFunctionalTests.Configuration
 {
     public class EnvironmentBotTestConfiguration : IBotTestConfiguration
     {
-        private const string DirectlineSecretKey = "DIRECTLINE";
+        private const string DirectLineSecretKey = "DIRECTLINE";
         private const string BotIdKey = "BOTID";
 
         public EnvironmentBotTestConfiguration(string directLineSecretKey, string botIdKey)
@@ -21,23 +19,23 @@ namespace SkillFunctionalTests.Configuration
             DirectLineSecret = Environment.GetEnvironmentVariable(directLineSecretKey);
             if (string.IsNullOrWhiteSpace(DirectLineSecret))
             {
-                Assert.Inconclusive($"Environment variable '{directLineSecretKey}' not found.");
+                throw new XunitException($"Environment variable '{directLineSecretKey}' not found.");
             }
 
             BotId = Environment.GetEnvironmentVariable(botIdKey);
             if (string.IsNullOrWhiteSpace(BotId))
             {
-                Assert.Inconclusive($"Environment variable '{botIdKey}' not found.");
+                throw new XunitException($"Environment variable '{botIdKey}' not found.");
             }
         }
 
         public EnvironmentBotTestConfiguration() 
-            : this(DirectlineSecretKey, BotIdKey)
+            : this(DirectLineSecretKey, BotIdKey)
         {
         }
 
-        public string BotId { get; private set; }
+        public string BotId { get; }
 
-        public string DirectLineSecret { get; private set; }
+        public string DirectLineSecret { get; }
     }
 }

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/Configuration/IBotTestConfiguration.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/Configuration/IBotTestConfiguration.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace SkillFunctionalTests.Configuration
 {
     public interface IBotTestConfiguration

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/OAuthSkillTest.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/OAuthSkillTest.cs
@@ -9,7 +9,6 @@ using Microsoft.Bot.Connector.DirectLine;
 using SkillFunctionalTests.Bot;
 using SkillFunctionalTests.Configuration;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace FunctionalTests
@@ -19,13 +18,6 @@ namespace FunctionalTests
     [Trait("TestCategory", "SkipForV3Bots")]
     public class OAuthSkillTest
     {
-        private readonly ITestOutputHelper _testOutputHelper;
-
-        public OAuthSkillTest(ITestOutputHelper testOutputHelper)
-        {
-            _testOutputHelper = testOutputHelper;
-        }
-
         [Fact]
         public async Task Skill_OAuthCard_SignInSuccessful()
         {
@@ -44,11 +36,11 @@ namespace FunctionalTests
 
             var activities = messages.ToList();
 
-            _testOutputHelper.WriteLine("Enumerating activities:");
+            Console.WriteLine("Enumerating activities:");
             
             foreach (var a in activities)
             {
-                _testOutputHelper.WriteLine($"Type={a.Type}; Text={a.Text}; Code={a.Code}; Attachments count={a.Attachments.Count}");
+                Console.WriteLine($"Type={a.Type}; Text={a.Text}; Code={a.Code}; Attachments count={a.Attachments.Count}");
             }
 
             var error = activities.FirstOrDefault(

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
@@ -2,22 +2,18 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Connector.DirectLine;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SkillFunctionalTests.Bot;
 using SkillFunctionalTests.Configuration;
+using Xunit;
 
 namespace FunctionalTests
 {
-    [TestClass]
-    [TestCategory("FunctionalTests")]
+    [Trait("TestCategory", "FunctionalTests")]
     public class SimpleHostBotToEchoSkillTest
     {
-        [TestMethod]
+        [Fact]
         public async Task Host_WhenRequested_ShouldRedirectToSkill()
         {
             var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(2));
@@ -31,7 +27,7 @@ namespace FunctionalTests
             await testBot.AssertReplyAsync("Echo: skill", cancellationTokenSource.Token);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Host_WhenSkillEnds_HostReceivesEndOfConversation()
         {
             var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(2));

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj
@@ -10,8 +10,11 @@
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #36

## Description
This PR migrates the tests in [SkillFunctionalTests](https://github.com/microsoft/BotFramework-FunctionalTests/tree/main/SkillsFunctionalTests/tests) from MSTests to xUnit.

### Detailed Changes
- Replaced MSTest packages with xUnit in the .csproj.
- Removed `[TestClass]` attributes.
- Replaced `[TestMethod]` with `[Fact]`.
- Changed `[TestCategory]` to `[Trait]`.
- Replaced `Assert.IsTrue` with `Assert.True`.
- Replaced `Assert.Inconclusive` with `throw new XUnitException` (_a similar change was made in [Facebook](https://github.com/microsoft/botbuilder-dotnet/blob/main/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/FacebookChatTests.cs#L135) and [Webex](https://github.com/microsoft/botbuilder-dotnet/blob/main/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/WebexClientTest.cs#L119) Functional Tests_).

Also,
- Renamed private properties to start with `_` and constants to start with uppercase.
- Used `var` instead of specific types.
- Removed unnecessary using statements.
- Fixed typos in comments.

## Testing
The following images show the tests executing successfully both locally and in the pipeline.

![image](https://user-images.githubusercontent.com/44245136/92785686-01cf1980-f37e-11ea-8ccf-d50a7653f620.png)
