### PR TITLE
[#127] [DotNet] Add BotBuilder Host and Skill tag versions

### DIFF
--- a/build/yaml/dotnetHost2DotnetV3Skill.yml
+++ b/build/yaml/dotnetHost2DotnetV3Skill.yml
@@ -71,6 +71,7 @@ stages:
       steps:
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
+      - template: dotnetTagBotBuilderVersion.yml
 
     - job: Build_Skill_Bot
       variables:
@@ -79,6 +80,7 @@ stages:
         Parameters.solution: 'SkillsFunctionalTests/dotnet/v3/skill/EchoSkillBot.sln'
       steps:
       - template: dotnetV3BuildSteps.yml
+      - template: dotnetV3TagBotBuilderVersion.yml
 
 - stage: Deploy
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))

--- a/build/yaml/dotnetHost2JavascriptSkill.yml
+++ b/build/yaml/dotnetHost2JavascriptSkill.yml
@@ -71,6 +71,7 @@ stages:
       steps:
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
+      - template: dotnetTagBotBuilderVersion.yml
 
 - stage: Deploy
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))

--- a/build/yaml/dotnetHost2JavascriptV3Skill.yml
+++ b/build/yaml/dotnetHost2JavascriptV3Skill.yml
@@ -71,6 +71,7 @@ stages:
       steps:
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
+      - template: dotnetTagBotBuilderVersion.yml
 
 - stage: Deploy
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))

--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -73,6 +73,7 @@ stages:
       steps:
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
+      - template: dotnetTagBotBuilderVersion.yml
 
 - stage: Deploy
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))

--- a/build/yaml/dotnetHost2dotnetSkill.yml
+++ b/build/yaml/dotnetHost2dotnetSkill.yml
@@ -72,6 +72,7 @@ stages:
       steps:
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
+      - template: dotnetTagBotBuilderVersion.yml
 
     - job: Validate_Skill_NetCore_Version
       variables:
@@ -89,6 +90,7 @@ stages:
       steps:
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
+      - template: dotnetTagBotBuilderVersion.yml
 
 - stage: Deploy
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))

--- a/build/yaml/dotnetInstallPackagesSteps.yml
+++ b/build/yaml/dotnetInstallPackagesSteps.yml
@@ -39,15 +39,14 @@ steps:
       {
          $RegistryUrlSource = "$(RegistryUrl)"
       }
+
       $PackageList = nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$RegistryUrlSource" -PreRelease
       $PackageVersion = $PackageList.Split(" ")[-1]
       $version = "--version " + "$PackageVersion"
-      echo "##vso[task.setvariable variable=PackagesVersion]$PackageVersion"
    }
    else
    {
       $version = "--version " + "$(BBVersion)"
-      echo "##vso[task.setvariable variable=PackagesVersion]$BBVersion"
    }
 
    echo "##vso[task.setvariable variable=BotBuilderPackageVersion]$version"
@@ -89,12 +88,6 @@ steps:
     projects: $(Parameters.project)
     custom: add
     arguments: 'package Microsoft.Bot.Builder.Integration.AspNet.Core $(BotBuilderPackageVersion) $(RegistrySource)'
- 
-- task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-  displayName: 'Tag build with package version'
-  inputs:
-    tags: 'BotBuilderVersion=$(PackagesVersion)'
-  continueOnError: true
 
 - task: DotNetCoreCLI@2
   displayName: 'Add custom Bot.Builder.Dialogs version'  

--- a/build/yaml/dotnetTagBotBuilderVersion.yml
+++ b/build/yaml/dotnetTagBotBuilderVersion.yml
@@ -1,0 +1,62 @@
+steps:
+- powershell: |
+    $PreRelease = ""
+    $Source = ""
+    $PackageId = ""
+
+    if ("$(RegistryUrl)" -eq "MyGet")
+    {
+        $Source = '-Source "https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json"'
+    }
+    elseif("$(RegistryUrl)" -eq "NuGet")
+    {
+        $PackageId = "packageid:"
+    }
+    elseif("$(RegistryUrl)" -eq "Artifacts")
+    {
+        $Source = '-Source "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json"'
+    }
+    else
+    {
+        $Source = '-Source "$(RegistryUrl)"'
+    }
+
+    if ("$(BBVersion)" -eq "preview")
+    {
+      $PreRelease = "-PreRelease"
+    }
+
+    $version = ""
+    $versionTag = ""
+
+    if ("$(BBVersion)" -in("stable","preview"))
+    {
+      $versionTag = " ($(BBVersion))"
+      $PackageList = Invoke-Expression "nuget list ${PackageId}Microsoft.Bot.Builder.Integration.AspNet.Core $Source $PreRelease"
+      $version = $PackageList.Split(" ")[-1]
+    }
+    else 
+    {
+      $version = "$(BBVersion)"
+    }
+
+    if ("$(Parameters.project)".Trim().Contains("/host/"))
+    {
+        echo "##vso[task.setvariable variable=HostOrSkill]Host"
+    }
+    else
+    {
+        echo "##vso[task.setvariable variable=HostOrSkill]Skill"
+    }
+    
+    write-host "Version: " $version $versionTag
+    echo "##vso[task.setvariable variable=PackagesVersionTag]$versionTag"
+    echo "##vso[task.setvariable variable=PackagesVersion]$version"
+  failOnStderr: true
+  displayName: 'Get BotBuilder Version'
+
+- task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+  displayName: 'Tag build with package version'
+  inputs:
+    tags: 'BotBuilderVersion$(HostOrSkill)=$(PackagesVersion)$(PackagesVersionTag)'
+  continueOnError: true

--- a/build/yaml/dotnetV3TagBotBuilderVersion.yml
+++ b/build/yaml/dotnetV3TagBotBuilderVersion.yml
@@ -1,0 +1,23 @@
+steps:
+- powershell: |
+    $result = Get-ChildItem "$(Build.SourcesDirectory)\SkillsFunctionalTests\dotnet\v3\skill\packages\Microsoft.Bot.Builder.[0-9]*" -directory | Sort LastWriteTime -Descending
+    
+    $version = $result[0].Name.Replace("Microsoft.Bot.Builder.", "")
+    $versionTag = ""
+
+    if ("$(BBVersion)" -in("stable","preview"))
+    {
+      $versionTag = " ($(BBVersion))"
+    }
+
+    write-host "Version: " $version $versionTag
+    echo "##vso[task.setvariable variable=PackagesVersionTag]$versionTag"
+    echo "##vso[task.setvariable variable=PackagesVersion]$version"
+  failOnStderr: true
+  displayName: 'Get BotBuilder Version'
+
+- task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+  displayName: 'Tag build with package version'
+  inputs:
+    tags: 'BotBuilderVersionSkill=$(PackagesVersion)$(PackagesVersionTag)'
+  continueOnError: true

--- a/build/yaml/javascriptHost2DotnetSkill.yml
+++ b/build/yaml/javascriptHost2DotnetSkill.yml
@@ -71,6 +71,7 @@ stages:
       steps:
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
+      - template: dotnetTagBotBuilderVersion.yml
 
 - stage: Deploy
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))

--- a/build/yaml/javascriptHost2DotnetV3Skill.yml
+++ b/build/yaml/javascriptHost2DotnetV3Skill.yml
@@ -66,6 +66,7 @@ stages:
         Parameters.solution: 'SkillsFunctionalTests/dotnet/v3/skill/EchoSkillBot.sln'
       steps:
       - template: dotnetV3BuildSteps.yml
+      - template: dotnetV3TagBotBuilderVersion.yml
 
 - stage: Deploy
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))

--- a/build/yaml/pythonHost2DotnetSkill.yml
+++ b/build/yaml/pythonHost2DotnetSkill.yml
@@ -73,6 +73,7 @@ stages:
       steps:
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
+      - template: dotnetTagBotBuilderVersion.yml
 
 - stage: Deploy
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))

--- a/build/yaml/pythonHost2DotnetV3Skill.yml
+++ b/build/yaml/pythonHost2DotnetV3Skill.yml
@@ -68,6 +68,7 @@ stages:
         Parameters.solution: 'SkillsFunctionalTests/dotnet/v3/skill/EchoSkillBot.sln'
       steps:
       - template: dotnetV3BuildSteps.yml
+      - template: dotnetV3TagBotBuilderVersion.yml
 
 - stage: Deploy
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))


### PR DESCRIPTION
Addresses #127

## Description
This PR adds BotBuilder version tags for all **DotNet** and **DotNetV3** pipelines combinations separating them in **Host** and **Skill**. 
The following display pattern was used when BotBuilderPackageVersion (**stable**, **preview**, **custom version**) is specified:
- `BotBuilderVersion{Host|Skill}={Version}+{stable|preview}` 
- `BotBuilderVersion{Host|Skill}={Version}` 

> **e.g.** 
> BotBuilderVersionHost=4.11.0-daily.20200911.165431 (preview)
> BotBuilderVersionSkill=3.30.2 (stable)
> BotBuilderVersionHost=4.10.0

## Specific Changes
- Add `dotnetTagBotBuilderVersion.yml` template file for getting and setting tag versions for DotNet.
- Add `dotnetV3TagBotBuilderVersion.yml` template file for getting and setting tag versions for DotNetV3.
- Added previous templates references to all necessary combinations.

## Testing
In the following image there is a sneak peek about the version tags.
![image](https://user-images.githubusercontent.com/62260472/92965024-7328ce00-f44b-11ea-9e6a-6cb88fef8c6a.png)