### PR TITLE
[#127] [Python] Add BotBuilder Host and Skill tag versions

### DIFF
--- a/build/yaml/pythonDeploySteps.yml
+++ b/build/yaml/pythonDeploySteps.yml
@@ -82,6 +82,8 @@ steps:
     $content
 
   displayName: 'Set BotBuilder Package Version & Registry Url'
+  
+- template: pythonTagBotBuilderVersion.yml
 
 - task: AzureCLI@1
   displayName: 'Create resource group and deploy bot'

--- a/build/yaml/pythonTagBotBuilderVersion.yml
+++ b/build/yaml/pythonTagBotBuilderVersion.yml
@@ -1,0 +1,29 @@
+steps:
+- powershell: |
+    cd '$(System.DefaultWorkingDirectory)/$(Parameters.sourceLocation)'
+    pip install -r requirements.txt --quiet
+    $packageVersion = pip show botbuilder-integration-aiohttp | Where-Object { $_ -match '^Version' }
+    $version = $packageVersion.Split(" ")[1]
+    $versionTag = ""
+    if ("$(BBVersion)" -in("stable","preview"))
+    {
+      $versionTag = " ($(BBVersion))"
+    }
+    if ("$(Parameters.sourceLocation)".Trim().Contains("/host"))
+    {
+        echo "##vso[task.setvariable variable=HostOrSkill]Host"
+    }
+    else
+    {
+        echo "##vso[task.setvariable variable=HostOrSkill]Skill"
+    }
+    write-host "Version: " $version $versionTag
+    echo "##vso[task.setvariable variable=PackagesVersionTag]$versionTag"
+    echo "##vso[task.setvariable variable=PackagesVersion]$version"
+  displayName: 'Get BotBuilder Version'
+
+- task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+  displayName: 'Tag build with package version'
+  inputs:
+    tags: 'BotBuilderVersion$(HostOrSkill)=$(PackagesVersion)$(PackagesVersionTag)'
+  continueOnError: true


### PR DESCRIPTION
Addresses #127

## Description
This PR adds BotBuilder version tags for all **Python** pipelines combinations separating them in **Host** and **Skill**. 
The following display pattern was used when BotBuilderPackageVersion (**stable**, **preview**, **custom version**) is specified:
- `BotBuilderVersion{Host|Skill}={Version}+{stable|preview}` 
- `BotBuilderVersion{Host|Skill}={Version}`

> **e.g.** 
> BotBuilderVersionHost=4.10.1 (stable)
> BotBuilderVersionHost=4.11.0.20200909.dev164711 (preview)
> BotBuilderVersionHost=4.9.2

## Specific Changes
- Add `pythonTagBotBuilderVersion.yml` template file for getting and setting tag versions for Python.
- Added previous template reference in the `pythonDeploySteps.yml` file.

## Testing
In the following image there is a sneak peek about the version tags.
![image](https://user-images.githubusercontent.com/62260472/93125670-ddd34700-f6a1-11ea-9192-3b4a08ea5b43.png)