### PR TITLE
[#127] [JS] Add BotBuilder Host and Skill tag versions

### DIFF
--- a/build/yaml/javascriptDeploySteps.yml
+++ b/build/yaml/javascriptDeploySteps.yml
@@ -11,26 +11,14 @@ steps:
   displayName: 'Read registry URL variable'
 
 - template: validateRegistryAndBBVersionSteps.yml
+- template: javascriptTagBotBuilderVersion.yml
 
 - powershell: |
-   $MyGet = "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/" 
-   $isV3Bot = "$(Parameters.sourceLocation)".Trim().EndsWith("v3/skill")
-
-   if($isV3Bot){
-      $MyGet = "https://botbuilder.myget.org/F/botbuilder-v3-js-daily/npm/" 
-   }
-
-   switch ("$(RegistryUrl)")
-   {
-      MyGet { $source = $MyGet }
-      NPM { $source = "https://registry.npmjs.com/"}      
-      default { $source = "$(RegistryUrl)" }
-   }
-
    Add-Content $(Parameters.sourceLocation)/deployment-scripts/.deployment "`nBOT_BUILDER_PACKAGE_VERSION = $(BBVersion)"
-   Add-Content $(Parameters.sourceLocation)/deployment-scripts/.deployment "`nREGISTRY_SOURCE = $Source"
+   Add-Content $(Parameters.sourceLocation)/deployment-scripts/.deployment "`nREGISTRY_SOURCE = $(Source)"
+
    Write-Host "Set BotBuilder Package Version to: $(BBVersion)"
-   Write-Host "Set registry url to: $source"
+   Write-Host "Set registry url to: $(Source)"
   failOnStderr: true
   displayName: 'Set BBVersion and Registry URL'
   name: 'Set_Registry_Url'

--- a/build/yaml/javascriptTagBotBuilderVersion.yml
+++ b/build/yaml/javascriptTagBotBuilderVersion.yml
@@ -1,0 +1,61 @@
+steps:
+- powershell: |
+   $version = ""
+   $versionTag = ""
+   $MyGet = "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/" 
+   $isV3Bot = "$(Parameters.sourceLocation)".Trim().EndsWith("v3/skill")
+
+   if($isV3Bot)
+   {
+      $MyGet = "https://botbuilder.myget.org/F/botbuilder-v3-js-daily/npm/" 
+   }
+
+   switch ("$(RegistryUrl)")
+   {
+      MyGet { $source = $MyGet }
+      NPM { $source = "https://registry.npmjs.com/"}
+      default { $source = "$(RegistryUrl)" }
+   }
+
+    npm config set registry $source
+
+    switch ("$(BBVersion)")
+    {
+      preview { $version = npm show botbuilder@latest version | Out-String; $versionTag = " ($(BBVersion))" }
+      stable
+      {
+        if($isV3Bot)
+        {
+          $PackageList = npm show botbuilder@3.* version | Out-String;
+        }
+        else
+        {
+          $PackageList = npm show botbuilder@* version | Out-String;
+        }
+        $version = ($PackageList.Split(" ")[-1]).Trim().TrimStart("'").TrimEnd("'");
+        $versionTag = " ($(BBVersion))"
+      }
+      default { $version = "$(BBVersion)" }
+    }
+
+    if ("$(Parameters.sourceLocation)".Trim().Contains("/host"))
+    {
+        echo "##vso[task.setvariable variable=HostOrSkill]Host"
+    }
+    else
+    {
+        echo "##vso[task.setvariable variable=HostOrSkill]Skill"
+    }
+
+    write-host "Version: " $version $versionTag
+    echo "##vso[task.setvariable variable=PackagesVersionTag]$versionTag"
+    echo "##vso[task.setvariable variable=PackagesVersion]$version"
+    echo "##vso[task.setvariable variable=Source]$source"
+  failOnStderr: true
+  displayName: 'Get BotBuilder Version'
+
+- task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+  displayName: 'Tag build with package version'
+  inputs:
+    tags: 'BotBuilderVersion$(HostOrSkill)=$(PackagesVersion)$(PackagesVersionTag)'
+  continueOnError: true


### PR DESCRIPTION
Fixes #127

## Description
This PR adds BotBuilder version tags for all **Javascript** pipelines combinations separating them in **Host** and **Skill**. 
The following display pattern was used when BotBuilderPackageVersion (**stable**, **preview**, **custom version**) is specified:
- `BotBuilderVersion{Host|Skill}={Version}+{stable|preview}` 
- `BotBuilderVersion{Host|Skill}={Version}`

> **e.g.** 
> BotBuilderVersionHost=4.10.1 (stable)
> BotBuilderVersionHost=4.11.0.20200909.dev164711 (preview)
> BotBuilderVersionHost=4.9.2

## Specific Changes
- Add `javascriptTagBotBuilderVersion.yml` template file for getting and setting tag versions for JS.
- Added previous template reference in the `javascriptDeploySteps.yml` file.
- Remove duplicated logic from _Set BBVersion and Registry URL_ step in `javascriptDeploySteps.yml` file.

## Testing
The following images show some of the builds tested with their corresponding tags.
![image](https://user-images.githubusercontent.com/44245136/93246442-2acb2200-f763-11ea-8914-f3d45fd2ab85.png)
