### PR TITLE
[Skills Everywhere] Add StyleCop and FxCop analyzers

### DIFF
--- a/BotFramework-FunctionalTests.ruleset
+++ b/BotFramework-FunctionalTests.ruleset
@@ -1,0 +1,198 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for StyleCop.Analyzers" Description="Source analysis rules treat as errors for BotBuilder-DotNet solution." ToolsVersion="16.0">
+  <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
+    <Rule Id="AvoidAsyncSuffix" Action="Error" />
+    <Rule Id="AvoidAsyncVoid" Action="Error" />
+    <Rule Id="UseAsyncSuffix" Action="Error" />
+    <Rule Id="UseConfigureAwait" Action="Error" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA1054" Action="None" /> <!-- UriParametersShouldNotBeStrings -->
+    <Rule Id="CA1062" Action="None" /> <!-- ValidateArgumentsOfPublicMethods -->
+    <Rule Id="CA1308" Action="None" /> <!-- Normalize strings to uppercase (most of our operations are normalized on lowercase -->
+    <Rule Id="CA1822" Action="None" /> <!-- Ignore Mark members as static -->
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
+    <Rule Id="CA1303" Action="None" /> <!-- DoNotPassLiteralsAsLocalizedParameters -->
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetCore.CSharp.Analyzers" RuleNamespace="Microsoft.NetCore.CSharp.Analyzers">
+    <Rule Id="CA1309" Action="Error" /> <!-- Use ordinal StringComparison -->
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" />
+    <Rule Id="SA0002" Action="Error" />
+    <Rule Id="SA1000" Action="Error" />
+    <Rule Id="SA1001" Action="Error" />
+    <Rule Id="SA1002" Action="Error" />
+    <Rule Id="SA1003" Action="Error" />
+    <Rule Id="SA1004" Action="Error" />
+    <Rule Id="SA1005" Action="None" /> <!-- SingleLineCommentsMustBeginWithSingleSpace -->
+    <Rule Id="SA1006" Action="Error" />
+    <Rule Id="SA1007" Action="Error" />
+    <Rule Id="SA1008" Action="Error" />
+    <Rule Id="SA1009" Action="Error" />
+    <Rule Id="SA1010" Action="Error" />
+    <Rule Id="SA1011" Action="Error" />
+    <Rule Id="SA1012" Action="Error" />
+    <Rule Id="SA1013" Action="Error" />
+    <Rule Id="SA1014" Action="Error" />
+    <Rule Id="SA1015" Action="Error" />
+    <Rule Id="SA1016" Action="Error" />
+    <Rule Id="SA1017" Action="Error" />
+    <Rule Id="SA1018" Action="Error" />
+    <Rule Id="SA1019" Action="Error" />
+    <Rule Id="SA1020" Action="Error" />
+    <Rule Id="SA1021" Action="Error" />
+    <Rule Id="SA1022" Action="Error" />
+    <Rule Id="SA1023" Action="Error" />
+    <Rule Id="SA1024" Action="Error" />
+    <Rule Id="SA1025" Action="Error" />
+    <Rule Id="SA1026" Action="Error" />
+    <Rule Id="SA1027" Action="Error" />
+    <Rule Id="SA1028" Action="None" /> <!-- Code should not contain trailing whitespace -->
+    <Rule Id="SA1100" Action="Error" />
+    <Rule Id="SA1102" Action="Error" />
+    <Rule Id="SA1103" Action="Error" />
+    <Rule Id="SA1104" Action="Error" />
+    <Rule Id="SA1105" Action="Error" />
+    <Rule Id="SA1106" Action="Error" />
+    <Rule Id="SA1107" Action="Error" />
+    <Rule Id="SA1108" Action="Error" />
+    <Rule Id="SA1110" Action="Error" />
+    <Rule Id="SA1111" Action="Error" />
+    <Rule Id="SA1112" Action="Error" />
+    <Rule Id="SA1113" Action="Error" />
+    <Rule Id="SA1114" Action="Error" />
+    <Rule Id="SA1115" Action="Error" />
+    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1117" Action="Error" />
+    <Rule Id="SA1118" Action="Error" />
+    <Rule Id="SA1119" Action="Error" />
+    <Rule Id="SA1120" Action="Error" />
+    <Rule Id="SA1121" Action="Error" />
+    <Rule Id="SA1122" Action="Error" />
+    <Rule Id="SA1123" Action="Error" />
+    <Rule Id="SA1124" Action="Error" />
+    <Rule Id="SA1125" Action="Error" />
+    <Rule Id="SA1127" Action="Error" />
+    <Rule Id="SA1128" Action="Error" />
+    <Rule Id="SA1130" Action="Error" />
+    <Rule Id="SA1131" Action="Error" />
+    <Rule Id="SA1132" Action="Error" />
+    <Rule Id="SA1133" Action="Error" />
+    <Rule Id="SA1134" Action="Error" />
+    <Rule Id="SA1135" Action="Error" />
+    <Rule Id="SA1136" Action="Error" />
+    <Rule Id="SA1137" Action="Error" />
+    <Rule Id="SA1139" Action="Error" />
+    <Rule Id="SA1200" Action="None" />
+    <Rule Id="SA1201" Action="Error" />
+    <Rule Id="SA1202" Action="Error" />
+    <Rule Id="SA1203" Action="Error" />
+    <Rule Id="SA1204" Action="Error" />
+    <Rule Id="SA1205" Action="Error" />
+    <Rule Id="SA1206" Action="Error" />
+    <Rule Id="SA1207" Action="Error" />
+    <Rule Id="SA1208" Action="Error" />
+    <Rule Id="SA1209" Action="Error" />
+    <Rule Id="SA1210" Action="Error" />
+    <Rule Id="SA1211" Action="Error" />
+    <Rule Id="SA1212" Action="Error" />
+    <Rule Id="SA1213" Action="Error" />
+    <Rule Id="SA1214" Action="None" />
+    <Rule Id="SA1216" Action="Error" />
+    <Rule Id="SA1217" Action="Error" />
+    <Rule Id="SA1300" Action="Error" />
+    <Rule Id="SA1302" Action="Error" />
+    <Rule Id="SA1303" Action="Error" />
+    <Rule Id="SA1304" Action="Error" />
+    <Rule Id="SA1305" Action="None" /> <!-- FieldNamesMustNotUseHungarianNotation -->
+    <Rule Id="SA1306" Action="Error" />
+    <Rule Id="SA1307" Action="Error" />
+    <Rule Id="SA1308" Action="Error" />
+    <Rule Id="SA1309" Action="None" />
+    <Rule Id="SA1310" Action="Error" />
+    <Rule Id="SA1311" Action="Error" />
+    <Rule Id="SA1312" Action="Error" />
+    <Rule Id="SA1313" Action="Error" />
+    <Rule Id="SA1314" Action="Error" />
+    <Rule Id="SA1400" Action="Error" />
+    <Rule Id="SA1401" Action="Error" />
+    <Rule Id="SA1402" Action="Error" />
+    <Rule Id="SA1403" Action="Error" />
+    <Rule Id="SA1404" Action="Error" />
+    <Rule Id="SA1405" Action="Error" />
+    <Rule Id="SA1406" Action="Error" />
+    <Rule Id="SA1407" Action="Error" />
+    <Rule Id="SA1408" Action="Error" />
+    <Rule Id="SA1410" Action="Error" />
+    <Rule Id="SA1411" Action="Error" />
+    <Rule Id="SA1412" Action="Error" />
+    <Rule Id="SA1413" Action="None" /> <!-- UseTrailingCommasInMultiLineInitializers-->
+    <Rule Id="SA1101" Action="None" /> <!-- PrefixLocalCallsWithThis -->
+    <Rule Id="SA1129" Action="None" /> <!-- DoNotUseDefaultValueTypeConstructor-->
+    <Rule Id="SA1500" Action="Error" />
+    <Rule Id="SA1501" Action="Error" />
+    <Rule Id="SA1502" Action="Error" />
+    <Rule Id="SA1503" Action="Error" />
+    <Rule Id="SA1504" Action="Error" />
+    <Rule Id="SA1505" Action="Error" />
+    <Rule Id="SA1506" Action="Error" />
+    <Rule Id="SA1507" Action="Error" />
+    <Rule Id="SA1508" Action="Error" />
+    <Rule Id="SA1509" Action="Error" />
+    <Rule Id="SA1510" Action="Error" />
+    <Rule Id="SA1511" Action="Error" />
+    <Rule Id="SA1512" Action="None" /> <!-- SingleLineCommentsMustNotBeFollowedByBlankLine -->
+    <Rule Id="SA1513" Action="Error" />
+    <Rule Id="SA1514" Action="Error" />
+    <Rule Id="SA1515" Action="Error" />
+    <Rule Id="SA1516" Action="Error" />
+    <Rule Id="SA1517" Action="Error" />
+    <Rule Id="SA1518" Action="Error" />
+    <Rule Id="SA1519" Action="Error" />
+    <Rule Id="SA1520" Action="Error" />
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1601" Action="Error" />
+    <Rule Id="SA1602" Action="Error" />
+    <Rule Id="SA1604" Action="Error" />
+    <Rule Id="SA1605" Action="Error" />
+    <Rule Id="SA1606" Action="Error" />
+    <Rule Id="SA1607" Action="Error" />
+    <Rule Id="SA1608" Action="Error" />
+    <Rule Id="SA1609" Action="Error" />
+    <Rule Id="SA1610" Action="Error" />
+    <Rule Id="SA1611" Action="Error" />
+    <Rule Id="SA1612" Action="Error" />
+    <Rule Id="SA1613" Action="Error" />
+    <Rule Id="SA1614" Action="Error" />
+    <Rule Id="SA1615" Action="Error" />
+    <Rule Id="SA1616" Action="Error" />
+    <Rule Id="SA1617" Action="Error" />
+    <Rule Id="SA1618" Action="Error" />
+    <Rule Id="SA1619" Action="Error" />
+    <Rule Id="SA1620" Action="Error" />
+    <Rule Id="SA1621" Action="Error" />
+    <Rule Id="SA1622" Action="Error" />
+    <Rule Id="SA1623" Action="Error" />
+    <Rule Id="SA1624" Action="Error" />
+    <Rule Id="SA1625" Action="Error" />
+    <Rule Id="SA1626" Action="Error" />
+    <Rule Id="SA1627" Action="Error" />
+    <Rule Id="SA1629" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
+    <Rule Id="SA1634" Action="Error" />
+    <Rule Id="SA1635" Action="Error" />
+    <Rule Id="SA1636" Action="Error" />
+    <Rule Id="SA1637" Action="Error" />
+    <Rule Id="SA1638" Action="Error" />
+    <Rule Id="SA1640" Action="Error" />
+    <Rule Id="SA1641" Action="Error" />
+    <Rule Id="SA1642" Action="Error" />
+    <Rule Id="SA1643" Action="Error" />
+    <Rule Id="SA1648" Action="Error" />
+    <Rule Id="SA1649" Action="Error" />
+    <Rule Id="SA1651" Action="Error" />
+    <Rule Id="SX1309" Action="Error" /> <!-- FieldNamesShouldBeginWithUnderscores -->
+  </Rules>
+</RuleSet>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)BotFramework-FunctionalTests.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests.sln
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests.sln
@@ -7,6 +7,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkillFunctionalTests", "Ski
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TranscriptTestRunner", "..\..\TranscriptTestRunner\TranscriptTestRunner.csproj", "{65C3A2E0-FDC5-4132-9980-3BAE230E9F2E}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BCBFF5A2-F2CD-4F82-BCD1-ED8E7950D82F}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\BotFramework-FunctionalTests.ruleset = ..\..\BotFramework-FunctionalTests.ruleset
+		..\..\Directory.Build.props = ..\..\Directory.Build.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/Bot/DirectLineSession.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/Bot/DirectLineSession.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+
+namespace SkillFunctionalTests.Bot
+{
+    public class DirectLineSession
+    {
+        [JsonProperty("sessionId")]
+        public string SessionId { get; set; }
+    }
+}

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/Bot/DirectLineSessionInfo.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/Bot/DirectLineSessionInfo.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+
+namespace SkillFunctionalTests.Bot
+{
+    public class DirectLineSessionInfo
+    {
+        public string SessionId { get; set; }
+        
+        public Cookie Cookie { get; set; }
+    }
+}

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/Bot/DirectLineToken.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/Bot/DirectLineToken.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+
+namespace SkillFunctionalTests.Bot
+{
+    public class DirectLineToken
+    {
+        [JsonProperty("token")]
+        public string Token { get; set; }
+
+        [JsonProperty("conversationId")]
+        public string ConversationId { get; set; }
+    }
+}

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/Bot/TestBotClient.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/Bot/TestBotClient.cs
@@ -36,12 +36,12 @@ namespace SkillFunctionalTests.Bot
 
             if (string.IsNullOrEmpty(config.DirectLineSecret))
             {
-                throw new ArgumentNullException(config.DirectLineSecret);
+                throw new ArgumentException(nameof(config.DirectLineSecret));
             }
 
             if (string.IsNullOrEmpty(config.BotId))
             {
-                throw new ArgumentNullException(config.BotId);
+                throw new ArgumentException(nameof(config.BotId));
             }
 
             // Instead of generating a vanilla DirectLineClient with secret, 

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/Configuration/BotTestConfiguration.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/Configuration/BotTestConfiguration.cs
@@ -22,6 +22,7 @@ namespace SkillFunctionalTests.Configuration
         private static readonly IConfiguration _configuration;
 
         /// <summary>
+        /// Initializes static members of the <see cref="BotTestConfiguration"/> class.
         /// Static constructor to initialize IConfiguration only once.
         /// </summary>
         static BotTestConfiguration()

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/OAuthSkillTest.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/OAuthSkillTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -11,7 +11,7 @@ using SkillFunctionalTests.Configuration;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FunctionalTests
+namespace SkillFunctionalTests
 {
     [Trait("TestCategory", "FunctionalTests")]
     [Trait("TestCategory", "OAuth")]
@@ -19,20 +19,20 @@ namespace FunctionalTests
     public class OAuthSkillTest
     {
         [Fact]
-        public async Task Skill_OAuthCard_SignInSuccessful()
+        public async Task SkillOAuthCardSignInSuccessful()
         {
             // If the test takes more than two minutes, declare failure.
-            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+            using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(2));
 
             var testBot = new TestBotClient(new BotTestConfiguration());
 
-            await testBot.StartConversation(cancellationTokenSource.Token);
-            await testBot.SendMessageAsync("Hello", cancellationTokenSource.Token);
-            await testBot.AssertReplyAsync("Me no nothin", cancellationTokenSource.Token);
-            await testBot.SendMessageAsync("skill", cancellationTokenSource.Token);
-            await testBot.AssertReplyAsync("Echo: skill", cancellationTokenSource.Token);
-            await testBot.SendMessageAsync("auth", cancellationTokenSource.Token);
-            var messages = await testBot.ReadBotMessagesAsync(cancellationTokenSource.Token);
+            await testBot.StartConversation(cancellationTokenSource.Token).ConfigureAwait(false);
+            await testBot.SendMessageAsync("Hello", cancellationTokenSource.Token).ConfigureAwait(false);
+            await testBot.AssertReplyAsync("Me no nothin", cancellationTokenSource.Token).ConfigureAwait(false);
+            await testBot.SendMessageAsync("skill", cancellationTokenSource.Token).ConfigureAwait(false);
+            await testBot.AssertReplyAsync("Echo: skill", cancellationTokenSource.Token).ConfigureAwait(false);
+            await testBot.SendMessageAsync("auth", cancellationTokenSource.Token).ConfigureAwait(false);
+            var messages = await testBot.ReadBotMessagesAsync(cancellationTokenSource.Token).ConfigureAwait(false);
 
             var activities = messages.ToList();
 
@@ -51,7 +51,7 @@ namespace FunctionalTests
                 throw new XunitException(error.Text);
             }
 
-            await testBot.SignInAndVerifyOAuthAsync(activities.FirstOrDefault(m => m.Attachments != null && m.Attachments.Any()), cancellationTokenSource.Token);
+            await testBot.SignInAndVerifyOAuthAsync(activities.FirstOrDefault(m => m.Attachments != null && m.Attachments.Any()), cancellationTokenSource.Token).ConfigureAwait(false);
         }
     }
 }

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
@@ -1,16 +1,12 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
-using SkillFunctionalTests.Bot;
-using SkillFunctionalTests.Configuration;
 using TranscriptTestRunner;
 using Xunit;
 
-namespace FunctionalTests
+namespace SkillFunctionalTests
 {
     [Trait("TestCategory", "FunctionalTests")]
     public class SimpleHostBotToEchoSkillTest
@@ -18,28 +14,28 @@ namespace FunctionalTests
         private readonly string _transcriptsFolder = Directory.GetCurrentDirectory() + @"/SourceTranscripts";
 
         [Fact]
-        public async Task Host_WhenRequested_ShouldRedirectToSkill()
+        public async Task HostWhenRequestedShouldRedirectToSkill()
         {
             var runner = new TestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient());
 
-            await runner.RunTestAsync($"{ _transcriptsFolder }/ShouldRedirectToSkill.transcript");
+            await runner.RunTestAsync($"{_transcriptsFolder}/ShouldRedirectToSkill.transcript").ConfigureAwait(false);
         }
 
         [Fact]
-        public async Task Host_WhenSkillEnds_HostReceivesEndOfConversation()
+        public async Task HostWhenSkillEndsHostReceivesEndOfConversation()
         {
             var runner = new TestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient());
 
-            await runner.RunTestAsync($"{ _transcriptsFolder }/HostReceivesEndOfConversation.transcript");
+            await runner.RunTestAsync($"{_transcriptsFolder}/HostReceivesEndOfConversation.transcript").ConfigureAwait(false);
         }
 
         [Fact]
-        public async Task Host_WhenRequested_ShouldRunTestTranscript()
+        public async Task HostWhenRequestedShouldRunTestTranscript()
         {
             await TestRunner.RunTestAsync(
                 ClientType.DirectLine,
-                $"{ _transcriptsFolder }/ShouldRedirectToSkill.transcript",
-                $"{ _transcriptsFolder }/HostReceivesEndOfConversation.transcript");
+                $"{_transcriptsFolder}/ShouldRedirectToSkill.transcript",
+                $"{_transcriptsFolder}/HostReceivesEndOfConversation.transcript").ConfigureAwait(false);
         }
     }
 }

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj
@@ -8,10 +8,18 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>

--- a/TranscriptTestRunner/ClientType.cs
+++ b/TranscriptTestRunner/ClientType.cs
@@ -3,12 +3,34 @@
 
 namespace TranscriptTestRunner
 {
+    /// <summary>
+    /// List of possible client types.
+    /// </summary>
     public enum ClientType
     {
+        /// <summary>
+        /// DirectLine client.
+        /// </summary>
         DirectLine,
+        
+        /// <summary>
+        /// Emulator client.
+        /// </summary>
         Emulator,
+
+        /// <summary>
+        /// Teams client.
+        /// </summary>
         Teams,
+
+        /// <summary>
+        /// Facebook client.
+        /// </summary>
         Facebook,
+
+        /// <summary>
+        /// Slack client.
+        /// </summary>
         Slack
     }
 }

--- a/TranscriptTestRunner/TestClientFactory.cs
+++ b/TranscriptTestRunner/TestClientFactory.cs
@@ -21,7 +21,7 @@ namespace TranscriptTestRunner
             switch (client)
             {
                 case ClientType.DirectLine:
-                    _testClientBase =  new DirectLineTestClient(configuration);
+                    _testClientBase = new DirectLineTestClient(configuration);
                     break;
                 case ClientType.Emulator:
                     break;

--- a/TranscriptTestRunner/TestScript.cs
+++ b/TranscriptTestRunner/TestScript.cs
@@ -5,10 +5,10 @@ namespace TranscriptTestRunner
 {
     public class TestScript
     {
-        public string Type;
+        public string Type { get; set; }
 
-        public string Role;
+        public string Role { get; set; }
 
-        public string Text;
+        public string Text { get; set; }
     }
 }

--- a/TranscriptTestRunner/TranscriptConverter.cs
+++ b/TranscriptTestRunner/TranscriptConverter.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Microsoft.Bot.Schema;
 
 namespace TranscriptTestRunner
 {

--- a/TranscriptTestRunner/TranscriptTestRunner.csproj
+++ b/TranscriptTestRunner/TranscriptTestRunner.csproj
@@ -8,9 +8,17 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.10.3" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description

This PR adds StyleCop and FxCop analyzers to the SkillsFunctionalTest solution.
Also, fixes all errors and most warnings raised (we left three warnings that would require a refactor of some existing methods).

### Detailed Changes

- Added StyleCop and FxCop packages to the projects.
- Added ruleset with the same configuration that the one in [_BotBuilder-dotnet_](https://github.com/microsoft/botbuilder-dotnet/blob/main/BotBuilder-DotNet.ruleset) repo.
- Added _Directory.Build.props_ file to share the ruleset through the solution's projects.
- Fixed all StyleCop and FxCop errors and most warnings.
     - Separate classes in their own files
     - Reordered properties, fields and methods.
     - Added ConfigureAwait(false) to all async calls.
     - Added `using` clause to disposable members. 
     - Added `StringComparison.Ordinal` to string comparison statements.
     - Removed underscores from tests' names.

## Testing
These images show the current status of the solution after fixing all the errors and the tests running in the pipeline.

![image](https://user-images.githubusercontent.com/44245136/96463145-c89b8c00-11fc-11eb-80d5-92b428d84a2a.png)

![image](https://user-images.githubusercontent.com/44245136/96465489-65f7bf80-11ff-11eb-93e9-70cfef4fb79f.png)