### PR TITLE
Refactor some classes and optimizations

### DIFF
--- a/SkillsFunctionalTests/tests/.editorconfig
+++ b/SkillsFunctionalTests/tests/.editorconfig
@@ -1,0 +1,162 @@
+# EditorConfig is awesome:http://EditorConfig.org
+
+###############################
+# Core EditorConfig Options   #
+###############################
+root = true
+
+# All files
+[*]
+indent_style = space
+# (Please don't specify an indent_size here; that has too many unintended consequences.)
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_size = 2
+
+# Schema files
+[*.{schema,uischema}]
+indent_size = 4
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# this. preferences
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+dotnet_style_readonly_field = true:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:none
+dotnet_prefer_inferred_tuple_names = true:suggestion
+dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+
+###############################
+# Naming Conventions          #
+###############################
+
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# Use PascalCase for constant fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = *
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+
+###############################
+# C# Code Style Rules         #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = true:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+
+# Pattern-matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# Expression-level preferences
+csharp_prefer_braces = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+
+# CS0618: Type or member is obsolete
+dotnet_diagnostic.CS0618.severity = none

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests.sln
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests.sln
@@ -9,6 +9,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TranscriptTestRunner", "..\
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BCBFF5A2-F2CD-4F82-BCD1-ED8E7950D82F}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		..\..\BotFramework-FunctionalTests.ruleset = ..\..\BotFramework-FunctionalTests.ruleset
 		..\..\Directory.Build.props = ..\..\Directory.Build.props
 	EndProjectSection

--- a/SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj
+++ b/SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj
@@ -35,11 +35,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="SourceTranscripts\ShouldRedirectToSkill.transcript">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="SourceTranscripts\HostReceivesEndOfConversation.transcript">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    <None Update="SourceTranscripts/**/*.transcript">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/TranscriptTestRunner/TestClientBase.cs
+++ b/TranscriptTestRunner/TestClientBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 
@@ -8,8 +9,8 @@ namespace TranscriptTestRunner
 {
     public abstract class TestClientBase
     {
-        public abstract Task SendActivityAsync(Activity activity);
+        public abstract Task SendActivityAsync(Activity activity, CancellationToken cancellationToken);
 
-        public abstract Task<bool> ValidateActivityAsync(Activity expected);
+        public abstract Task<Activity> GetNextReplyAsync(CancellationToken cancellationToken);
     }
 }

--- a/TranscriptTestRunner/TestClients/DirectLineTestClient.cs
+++ b/TranscriptTestRunner/TestClients/DirectLineTestClient.cs
@@ -2,35 +2,49 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector.DirectLine;
 using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
 using BotActivity = Microsoft.Bot.Schema.Activity;
 
 namespace TranscriptTestRunner.TestClients
 {
-    public class DirectLineTestClient : TestClientBase
+    public class DirectLineTestClient : TestClientBase, IDisposable
     {
+        // DL client sample: https://github.com/microsoft/BotFramework-DirectLine-DotNet/tree/main/samples/core-DirectLine/DirectLineClient
         private const string DirectLineSecretKey = "DIRECTLINE";
         private const string BotIdKey = "BOTID";
-        private static string _directLineSecret;
         private static string _botId;
+        private readonly ConcurrentQueue<BotActivity> _activityQueue = new ConcurrentQueue<BotActivity>();
+        private readonly DirectLineClient _dlClient;
         private readonly string _user = $"TestUser-{Guid.NewGuid()}";
         private string _conversationId;
-        
+
+        // To detect redundant calls to dispose
+        private bool _disposed;
+        private string _watermark;
+
         public DirectLineTestClient(IConfiguration config)
         {
-            GetConfiguration(config);
+            _botId = config[BotIdKey];
+            if (string.IsNullOrWhiteSpace(_botId))
+            {
+                throw new ArgumentException($"Configuration setting '{BotIdKey}' not set.");
+            }
 
-            Client = new DirectLineClient(_directLineSecret);
+            var directLineSecret = config[DirectLineSecretKey];
+            if (string.IsNullOrWhiteSpace(directLineSecret))
+            {
+                throw new ArgumentException($"Configuration setting '{DirectLineSecretKey}' not found.");
+            }
+
+            _dlClient = new DirectLineClient(directLineSecret);
         }
-        
-        private DirectLineClient Client { get; }
 
-        public override async Task SendActivityAsync(BotActivity activity)
+        public override async Task SendActivityAsync(BotActivity activity, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(_conversationId))
             {
@@ -44,66 +58,70 @@ namespace TranscriptTestRunner.TestClients
                 Type = activity.Type
             };
 
-            await Client.Conversations.PostActivityAsync(_conversationId, activityPost, default).ConfigureAwait(false);
+            await _dlClient.Conversations.PostActivityAsync(_conversationId, activityPost, cancellationToken).ConfigureAwait(false);
         }
 
-        public override async Task<bool> ValidateActivityAsync(BotActivity expected)
+        public override async Task<BotActivity> GetNextReplyAsync(CancellationToken cancellationToken)
         {
-            var activities = await PollBotMessagesAsync(default).ConfigureAwait(false);
-            var botMessages = activities.Where(a => a.Type == ActivityTypes.Message);
+            await PullActivitiesFromDirectLineAsync(cancellationToken).ConfigureAwait(false);
 
-            return botMessages.Any(message => message.Text == expected.Text);
-        }
-
-        private static void GetConfiguration(IConfiguration config)
-        {
-            _directLineSecret = config[DirectLineSecretKey];
-
-            if (string.IsNullOrWhiteSpace(_directLineSecret))
+            // Return the first activity in the queue (if any)
+            if (_activityQueue.TryDequeue(out var activity))
             {
-                throw new ArgumentException($"Configuration setting '{DirectLineSecretKey}' not found.");
+                return activity;
             }
 
-            _botId = config[BotIdKey];
-            
-            if (string.IsNullOrWhiteSpace(_botId))
-            {
-                throw new ArgumentException($"Configuration setting '{BotIdKey}' not set.");
-            }
+            // No activities in the queue
+            return null;
         }
 
-        private async Task<IEnumerable<Activity>> PollBotMessagesAsync(CancellationToken cancellationToken = default)
+        public void Dispose()
         {
-            using var maxCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(2));
-
-            while (!cancellationToken.IsCancellationRequested && !maxCancellation.IsCancellationRequested)
-            {
-                await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken).ConfigureAwait(false);
-
-                var activities = await ReadBotMessagesAsync(cancellationToken).ConfigureAwait(false);
-
-                if (activities != null && activities.Any())
-                {
-                    return activities;
-                }
-            }
-
-            throw new Exception("No activities received");
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
-        private async Task<IEnumerable<Activity>> ReadBotMessagesAsync(CancellationToken cancellationToken = default)
+        protected virtual void Dispose(bool disposing)
         {
-            var activitySet = await Client.Conversations.GetActivitiesAsync(_conversationId, null, cancellationToken).ConfigureAwait(false);
+            if (_disposed)
+            {
+                return;
+            }
 
-            // Extract and return the activities sent from the bot.
-            return activitySet?.Activities?.Where(activity => activity.From.Id == _botId);
+            if (disposing)
+            {
+                // Dispose managed objects owned by the class here.
+                _dlClient?.Dispose();
+            }
+
+            _disposed = true;
         }
 
         private async Task CreateConversationAsync()
         {
-            var conversation = await Client.Conversations.StartConversationAsync().ConfigureAwait(false);
-
+            var conversation = await _dlClient.Conversations.StartConversationAsync().ConfigureAwait(false);
             _conversationId = conversation.ConversationId;
+        }
+
+        private async Task PullActivitiesFromDirectLineAsync(CancellationToken cancellationToken)
+        {
+            // Pull all the available activities from direct line
+            var activitySet = await _dlClient.Conversations.GetActivitiesAsync(_conversationId, _watermark, cancellationToken).ConfigureAwait(false);
+
+            if (activitySet != null)
+            {
+                _watermark = activitySet.Watermark;
+
+                // Add activities to the queue
+                foreach (var dlActivity in activitySet.Activities)
+                {
+                    if (dlActivity.From.Id == _botId)
+                    {
+                        // Convert the DL Activity object to a BF activity object.
+                        _activityQueue.Enqueue(JsonConvert.DeserializeObject<BotActivity>(JsonConvert.SerializeObject(dlActivity)));
+                    }
+                }
+            }
         }
     }
 }

--- a/TranscriptTestRunner/TestRunner.cs
+++ b/TranscriptTestRunner/TestRunner.cs
@@ -2,39 +2,78 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
+using Activity = Microsoft.Bot.Schema.Activity;
 
 namespace TranscriptTestRunner
 {
     public class TestRunner
     {
+        private readonly int _replyTimeout;
+        private readonly TestClientBase _testClient;
+
         public TestRunner(TestClientBase client)
         {
-            TestClientBase = client;
+            _testClient = client;
+            _replyTimeout = 45000;
         }
-
-        private TestClientBase TestClientBase { get; set; }
 
         private TranscriptConverter TranscriptConverter { get; set; }
 
+        // TODO: Not sure if it is better to avoid this and have another constructor.
         public static async Task RunTestAsync(ClientType client, params string[] transcriptPaths)
         {
             foreach (var transcriptPath in transcriptPaths)
             {
+                // TODO: This should be outside of the loop
                 var runner = new TestRunner(new TestClientFactory(client).GetTestClient());
-
                 await runner.RunTestAsync(transcriptPath).ConfigureAwait(false);
             }
         }
 
-        public async Task RunTestAsync(string transcriptPath)
+        public async Task RunTestAsync(string transcriptPath, CancellationToken cancellationToken = default)
         {
             ConvertTranscript(transcriptPath);
+            await ExecuteTestScriptAsync(cancellationToken).ConfigureAwait(false);
+        }
 
-            await ExecuteTestScriptAsync().ConfigureAwait(false);
+        public async Task SendActivityAsync(Activity sendActivity, CancellationToken cancellationToken)
+        {
+            await _testClient.SendActivityAsync(sendActivity, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<Activity> GetNextReplyAsync(CancellationToken cancellationToken)
+        {
+            var timeoutCheck = new Stopwatch();
+            timeoutCheck.Start();
+            while (true)
+            {
+                var activity = await _testClient.GetNextReplyAsync(cancellationToken).ConfigureAwait(false);
+                do
+                {
+                    if (activity != null && activity.Type != ActivityTypes.Trace && activity.Type != ActivityTypes.Typing)
+                    {
+                        return activity;
+                    }
+
+                    // Pop the next activity un the queue.
+                    activity = await _testClient.GetNextReplyAsync(cancellationToken).ConfigureAwait(false);
+                } 
+                while (activity != null);
+
+                // Wait a bit for the bot
+                await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken).ConfigureAwait(false);
+
+                if (timeoutCheck.ElapsedMilliseconds > _replyTimeout)
+                {
+                    throw new TimeoutException("operation timed out while waiting for a response from the bot");
+                }
+            }
         }
 
         private void ConvertTranscript(string transcriptPath)
@@ -48,38 +87,62 @@ namespace TranscriptTestRunner
             TranscriptConverter.Convert();
         }
 
-        private async Task ExecuteTestScriptAsync()
+        private async Task ExecuteTestScriptAsync(CancellationToken cancellationToken)
         {
             using var reader = new StreamReader(TranscriptConverter.TestScript);
 
-            var testScript = JsonConvert.DeserializeObject<TestScript[]>(reader.ReadToEnd());
+            var testScript = JsonConvert.DeserializeObject<TestScript[]>(await reader.ReadToEndAsync().ConfigureAwait(false));
 
-            foreach (var script in testScript)
+            foreach (var scriptActivity in testScript)
             {
-               if (script.Role == "bot")
-               {
-                   var activity = new Activity
-                   {
-                       Type = script.Type,
-                       Text = script.Text
-                   };
+                switch (scriptActivity.Role)
+                {
+                    case RoleTypes.User:
+                        // Send the activity.
+                        var sendActivity = new Activity
+                        {
+                            Type = scriptActivity.Type,
+                            Text = scriptActivity.Text
+                        };
 
-                   if (!await TestClientBase.ValidateActivityAsync(activity).ConfigureAwait(false))
-                   {
-                       throw new Exception($"The bot didn't reply as expected. It should have said: {activity.Text}");
-                   }
-               }
-               else
-               {
-                   var activity = new Activity
-                   {
-                       Type = script.Type,
-                       Text = script.Text
-                   };
+                        await SendActivityAsync(sendActivity, cancellationToken).ConfigureAwait(false);
+                        break;
 
-                   await TestClientBase.SendActivityAsync(activity).ConfigureAwait(false);
-               }
+                    case RoleTypes.Bot:
+                        // Assert the activity returned
+                        if (!IgnoreScriptActivity(scriptActivity))
+                        {
+                            var activity = await GetNextReplyAsync(cancellationToken).ConfigureAwait(false);
+
+                            // Assert here
+                            AssertReply(scriptActivity, activity);
+                        }
+
+                        break;
+
+                    default:
+                        throw new InvalidOperationException($"Invalid script activity type {scriptActivity.Role}.");
+                }
             }
+        }
+
+        // (temp approach)
+        private void AssertReply(TestScript expected, Activity actual)
+        {
+            if (expected.Type != actual.Type)
+            {
+                throw new Exception($"Invalid activity type. Expected: {expected.Type} Actual: {actual.Type}");
+            }
+
+            if (expected.Text != actual.Text)
+            {
+                throw new Exception($"Invalid activity text. Expected: {expected.Text} Actual: {actual.Text}");
+            }
+        }
+
+        private bool IgnoreScriptActivity(TestScript activity)
+        {
+            return activity.Type == ActivityTypes.Trace || activity.Type == ActivityTypes.Typing;
         }
     }
 }

--- a/TranscriptTestRunner/TranscriptTestRunner.csproj
+++ b/TranscriptTestRunner/TranscriptTestRunner.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Updated SkillFunctionalTests.csproj to always copy anything under the SourceTranscripts folder so I don't forget to set the copy always property.
- Changed TranscriptTestRunner.csproj to target netstandard2.0 and set it to use the latest C# version to make it more compatible with other consumers.
- TestClientBase: Removed ValidateActivityAsync (this has been moved to the runner.
- TestClientBase: Added GetNextReplyAsync to be able to pop activities from the client's internal queue.
- DirectLineTestClient: made it disposabled and implemented the dispose pattern to ensure we dispose direct line client.
- DirectLineTestClient: Implemented GetNextReplyAsync that stores whatever it pulls from DL in an internal queue and returns the first activity if any.
- DirectLineTestClient: added watermark field to store latest read activity (as the https://github.com/microsoft/BotFramework-DirectLine-DotNet/tree/main/samples/core-DirectLine/DirectLineClient shows).
- DirectLineTestClient: removed the validation code (this is now in TestRunner).
- TestRunner: Added SendActivityAsync and GetNextReplyAsync so we can send an receive activities without a script if we want.
- TestRunner: Implemented rough AssertReply method with logic to check activities.
- TestRunner: implemented some very basic filtering.