### PR TITLE
[Skills Everywhere] Add ILogger implementation

### DIFF
--- a/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
+++ b/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using TranscriptTestRunner;
 using Xunit;
 
@@ -12,11 +13,25 @@ namespace SkillFunctionalTests
     public class SimpleHostBotToEchoSkillTest
     {
         private readonly string _transcriptsFolder = Directory.GetCurrentDirectory() + @"/SourceTranscripts";
+        private readonly ILogger<SimpleHostBotToEchoSkillTest> _logger;
+
+        public SimpleHostBotToEchoSkillTest()
+        {
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder
+                    .SetMinimumLevel(LogLevel.Trace)
+                    .AddConsole()
+                    .AddDebug();
+            });
+
+            _logger = loggerFactory.CreateLogger<SimpleHostBotToEchoSkillTest>();
+        }
 
         [Fact]
         public async Task HostWhenRequestedShouldRedirectToSkill()
         {
-            var runner = new TestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient());
+            var runner = new TestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient(), _logger);
 
             await runner.RunTestAsync($"{_transcriptsFolder}/ShouldRedirectToSkill.transcript").ConfigureAwait(false);
         }
@@ -24,7 +39,7 @@ namespace SkillFunctionalTests
         [Fact]
         public async Task HostWhenSkillEndsHostReceivesEndOfConversation()
         {
-            var runner = new TestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient());
+            var runner = new TestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient(), _logger);
 
             await runner.RunTestAsync($"{_transcriptsFolder}/HostReceivesEndOfConversation.transcript").ConfigureAwait(false);
         }
@@ -33,7 +48,8 @@ namespace SkillFunctionalTests
         public async Task HostWhenRequestedShouldRunTestTranscript()
         {
             await TestRunner.RunTestAsync(
-                ClientType.DirectLine,
+                ClientType.DirectLine, 
+                _logger,
                 $"{_transcriptsFolder}/ShouldRedirectToSkill.transcript",
                 $"{_transcriptsFolder}/HostReceivesEndOfConversation.transcript").ConfigureAwait(false);
         }

--- a/Tests/SkillFunctionalTests/SkillFunctionalTests.csproj
+++ b/Tests/SkillFunctionalTests/SkillFunctionalTests.csproj
@@ -10,6 +10,8 @@
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.9" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
## Description
This PR implements ILogger interface replacing the `Debug.WriteLine` logger option by creating it from the LoggerFactory, it adds support for logging in Debug (Locally) and Console (Pipeline).

### Detailed Changes
- Added new `ILogger` parameter to be passed onto the `TestRunner`.
- Added `LoggerFactory` on `SimpleHostBotToEchoSkillTest` to create the `ILogger` and send it to the `TestRunner`.
- Added to the `LoggerFactory`, Debug and Console support.

## Testing
The following images shows the logging output, the first one is on the Debug output window on Visual Studio and the second one is the console output on the pipelines.
![image](https://user-images.githubusercontent.com/62260472/97051583-c9625400-1555-11eb-8d74-3f22ec43359e.png)
![image](https://user-images.githubusercontent.com/62260472/97051590-cb2c1780-1555-11eb-8e6b-d7d63bdcb674.png)