### PR TITLE
Add XUnitLogger and some bug fixes

### DIFF
--- a/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
+++ b/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using TranscriptTestRunner;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace SkillFunctionalTests
 {
@@ -15,33 +16,27 @@ namespace SkillFunctionalTests
         private readonly string _transcriptsFolder = Directory.GetCurrentDirectory() + @"/SourceTranscripts";
         private readonly ILogger<SimpleHostBotToEchoSkillTest> _logger;
 
-        public SimpleHostBotToEchoSkillTest()
+        public SimpleHostBotToEchoSkillTest(ITestOutputHelper output)
         {
             var loggerFactory = LoggerFactory.Create(builder =>
             {
                 builder
                     .SetMinimumLevel(LogLevel.Trace)
                     .AddConsole()
-                    .AddDebug();
+                    .AddDebug()
+                    .AddXunit(output);
             });
 
             _logger = loggerFactory.CreateLogger<SimpleHostBotToEchoSkillTest>();
         }
 
-        [Fact]
-        public async Task HostWhenRequestedShouldRedirectToSkill()
+        [Theory]
+        [InlineData("ShouldRedirectToSkill.transcript")]
+        [InlineData("HostReceivesEndOfConversation.transcript")]
+        public async Task RunScripts(string transcript)
         {
             var runner = new TestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient(), _logger);
-
-            await runner.RunTestAsync($"{_transcriptsFolder}/ShouldRedirectToSkill.transcript").ConfigureAwait(false);
-        }
-
-        [Fact]
-        public async Task HostWhenSkillEndsHostReceivesEndOfConversation()
-        {
-            var runner = new TestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient(), _logger);
-
-            await runner.RunTestAsync($"{_transcriptsFolder}/HostReceivesEndOfConversation.transcript").ConfigureAwait(false);
+            await runner.RunTestAsync(Path.Combine(_transcriptsFolder, transcript));
         }
 
         [Fact]

--- a/Tests/SkillFunctionalTests/SkillFunctionalTests.csproj
+++ b/Tests/SkillFunctionalTests/SkillFunctionalTests.csproj
@@ -7,15 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Divergic.Logging.Xunit" Version="3.5.1" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.22" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
In this PR:

- Made stopwatch in test runner a lazy property so it gets initialized when RunTestScript is called or when SendActivity is called (it was failing for non script based tests).
- Added a refence to [Divergic.Logging.Xunit](https://github.com/roryprimrose/Divergic.Logging.Xunit) so we can show the XUnit tests output in test explorer
- Modified SimpleHostBotToEchoSkillTest to add XUnitlogger and regrouped some tests to use [Theory] tests and avoid code duplication.
- Updated some nuget packages
- Modified some output strings

Details, with the XUnitLogger, we should see an "Open additional output for this result" link in VS Test explorer:
![image](https://user-images.githubusercontent.com/12264946/97129756-12f99d00-1716-11eb-9464-42cf50833afa.png)

That should show the logger output:
![image](https://user-images.githubusercontent.com/12264946/97129868-4fc59400-1716-11eb-919e-abb0bbfa8707.png)



