### PR TITLE
[Skills Everywhere] Add XUnitTestRunner class

### DIFF
--- a/Libraries/TranscriptTestRunner/TestRunner.cs
+++ b/Libraries/TranscriptTestRunner/TestRunner.cs
@@ -98,10 +98,17 @@ namespace TranscriptTestRunner
             }
         }
 
-        public async Task AssertReplyAsync(Action<Activity> validateAction, CancellationToken cancellationToken = default)
+        protected virtual void AssertReply(TestScript expectedActivity, Activity actualActivity)
         {
-            var nextReply = await GetNextReplyAsync(cancellationToken).ConfigureAwait(false);
-            validateAction(nextReply);
+            if (expectedActivity.Type != actualActivity.Type)
+            {
+                throw new Exception($"Invalid activity type. Expected: {expectedActivity.Type} Actual: {actualActivity.Type}");
+            }
+
+            if (expectedActivity.Text != actualActivity.Text)
+            {
+                throw new Exception($"Invalid activity text. Expected: {expectedActivity.Text} Actual: {actualActivity.Text}");
+            }
         }
 
         private void ConvertTranscript(string transcriptPath)
@@ -142,20 +149,8 @@ namespace TranscriptTestRunner
                         // Assert the activity returned
                         if (!IgnoreScriptActivity(scriptActivity))
                         {
-                            await AssertReplyAsync(
-                                nextReply =>
-                                {
-                                    if (scriptActivity.Type != nextReply.Type)
-                                    {
-                                        throw new Exception($"Invalid activity type. Expected: {scriptActivity.Type} Actual: {nextReply.Type}");
-                                    }
-
-                                    if (scriptActivity.Text != nextReply.Text)
-                                    {
-                                        throw new Exception($"Invalid activity text. Expected: {scriptActivity.Text} Actual: {nextReply.Text}");
-                                    }
-                                },
-                                cancellationToken).ConfigureAwait(false);
+                            var nextReply = await GetNextReplyAsync(cancellationToken).ConfigureAwait(false);
+                            AssertReply(scriptActivity, nextReply);
                         }
 
                         break;

--- a/Libraries/TranscriptTestRunner/TestRunner.cs
+++ b/Libraries/TranscriptTestRunner/TestRunner.cs
@@ -44,17 +44,6 @@ namespace TranscriptTestRunner
             }
         }
 
-        // TODO: Not sure if it is better to avoid this and have another constructor.
-        public static async Task RunTestAsync(ClientType client, ILogger logger = null, params string[] transcriptPaths)
-        {
-            foreach (var transcriptPath in transcriptPaths)
-            {
-                // TODO: This should be outside of the loop
-                var runner = new TestRunner(new TestClientFactory(client).GetTestClient(), logger);
-                await runner.RunTestAsync(transcriptPath).ConfigureAwait(false);
-            }
-        }
-
         public async Task RunTestAsync(string transcriptPath, [CallerMemberName] string callerName = "", CancellationToken cancellationToken = default)
         {
             _logger.LogInformation($"======== Running script: {transcriptPath} ========");
@@ -98,7 +87,13 @@ namespace TranscriptTestRunner
             }
         }
 
-        protected virtual void AssertReply(TestScript expectedActivity, Activity actualActivity)
+        public async Task AssertReplyAsync(Action<Activity> validateAction, CancellationToken cancellationToken = default)
+        {
+            var nextReply = await GetNextReplyAsync(cancellationToken).ConfigureAwait(false);
+            validateAction(nextReply);
+        }
+
+        protected virtual Task AssertActivityAsync(TestScriptItem expectedActivity, Activity actualActivity, CancellationToken cancellationToken = default)
         {
             if (expectedActivity.Type != actualActivity.Type)
             {
@@ -109,6 +104,8 @@ namespace TranscriptTestRunner
             {
                 throw new Exception($"Invalid activity text. Expected: {expectedActivity.Text} Actual: {actualActivity.Text}");
             }
+
+            return Task.CompletedTask;
         }
 
         private void ConvertTranscript(string transcriptPath)
@@ -128,7 +125,7 @@ namespace TranscriptTestRunner
 
             using var reader = new StreamReader(_transcriptConverter.TestScript);
 
-            var testScript = JsonConvert.DeserializeObject<TestScript[]>(await reader.ReadToEndAsync().ConfigureAwait(false));
+            var testScript = JsonConvert.DeserializeObject<TestScriptItem[]>(await reader.ReadToEndAsync().ConfigureAwait(false));
 
             foreach (var scriptActivity in testScript)
             {
@@ -150,7 +147,7 @@ namespace TranscriptTestRunner
                         if (!IgnoreScriptActivity(scriptActivity))
                         {
                             var nextReply = await GetNextReplyAsync(cancellationToken).ConfigureAwait(false);
-                            AssertReply(scriptActivity, nextReply);
+                            await AssertActivityAsync(scriptActivity, nextReply, cancellationToken).ConfigureAwait(false);
                         }
 
                         break;
@@ -163,7 +160,7 @@ namespace TranscriptTestRunner
             _logger.LogInformation($"======== Finished running script: {Stopwatch.Elapsed} =============\n");
         }
 
-        private bool IgnoreScriptActivity(TestScript activity)
+        private bool IgnoreScriptActivity(TestScriptItem activity)
         {
             return activity.Type == ActivityTypes.Trace || activity.Type == ActivityTypes.Typing;
         }

--- a/Libraries/TranscriptTestRunner/TestScriptItem.cs
+++ b/Libraries/TranscriptTestRunner/TestScriptItem.cs
@@ -3,7 +3,7 @@
 
 namespace TranscriptTestRunner
 {
-    public class TestScript
+    public class TestScriptItem
     {
         public string Type { get; set; }
 

--- a/Libraries/TranscriptTestRunner/TranscriptTestRunner.csproj
+++ b/Libraries/TranscriptTestRunner/TranscriptTestRunner.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 
 </Project>

--- a/Libraries/TranscriptTestRunner/XUnit/XUnitTestRunner.cs
+++ b/Libraries/TranscriptTestRunner/XUnit/XUnitTestRunner.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -14,10 +16,12 @@ namespace TranscriptTestRunner.XUnit
         {
         }
 
-        protected override void AssertReply(TestScript expectedActivity, Activity actualActivity)
+        protected override Task AssertActivityAsync(TestScriptItem expectedActivity, Activity actualActivity, CancellationToken cancellationToken = default)
         {
             Assert.Equal(expectedActivity.Type, actualActivity.Type);
             Assert.Equal(expectedActivity.Text, actualActivity.Text);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/Libraries/TranscriptTestRunner/XUnit/XUnitTestRunner.cs
+++ b/Libraries/TranscriptTestRunner/XUnit/XUnitTestRunner.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace TranscriptTestRunner.XUnit
+{
+    public class XUnitTestRunner : TestRunner
+    {
+        public XUnitTestRunner(TestClientBase client, ILogger logger = null)
+            : base(client, logger)
+        {
+        }
+
+        protected override void AssertReply(TestScript expectedActivity, Activity actualActivity)
+        {
+            Assert.Equal(expectedActivity.Type, actualActivity.Type);
+            Assert.Equal(expectedActivity.Text, actualActivity.Text);
+        }
+    }
+}

--- a/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
+++ b/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -35,7 +36,7 @@ namespace SkillFunctionalTests
         [InlineData("HostReceivesEndOfConversation.transcript")]
         public async Task RunScripts(string transcript)
         {
-            var runner = new TestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient(), _logger);
+            var runner = new XUnitTestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient(), _logger);
             await runner.RunTestAsync(Path.Combine(_transcriptsFolder, transcript));
         }
 

--- a/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
+++ b/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
@@ -3,11 +3,13 @@
 
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 using TranscriptTestRunner;
 using TranscriptTestRunner.XUnit;
 using Xunit;
 using Xunit.Abstractions;
+using ActivityTypes = Microsoft.Bot.Connector.DirectLine.ActivityTypes;
 
 namespace SkillFunctionalTests
 {
@@ -41,13 +43,17 @@ namespace SkillFunctionalTests
         }
 
         [Fact]
-        public async Task HostWhenRequestedShouldRunTestTranscript()
+        public async Task ManualTest()
         {
-            await TestRunner.RunTestAsync(
-                ClientType.DirectLine, 
-                _logger,
-                $"{_transcriptsFolder}/ShouldRedirectToSkill.transcript",
-                $"{_transcriptsFolder}/HostReceivesEndOfConversation.transcript").ConfigureAwait(false);
+            var runner = new XUnitTestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient(), _logger);
+
+            await runner.SendActivityAsync(new Activity(ActivityTypes.ConversationUpdate));
+
+            await runner.AssertReplyAsync(activity =>
+            {
+                Assert.Equal(ActivityTypes.Message, activity.Type);
+                Assert.Equal("Hello and welcome!", activity.Text);
+            });
         }
     }
 }


### PR DESCRIPTION
## Description
This PR adds the XUnitTestRunner class that extends TestRunner to override the AssertReply method with XUnit asserts.

### Detailed Changes
- Added **_XUnitTestRunner_** class.
- In TestRunner class, added the protected virtual **_AssertReply_** method with default assertions.
- Added xunit dependency to the project.
- Updated **_SimpleHostBotToEchoSkillTest_** tests to use the new class XUnitTestRunner.

Also:
- Added manual test in _SimpleHostBotToEchoSkillTest_
- Removed static _RunTestAsync_ method from TestRunner class.
- Renamed _TestScript_ class as _TestScriptItem_.

## Testing
These images show what a failing test looks like with old and new implementations:
![image](https://user-images.githubusercontent.com/44245136/97216259-539ff780-17a4-11eb-84ac-1a8797240f92.png)
