### PR TITLE
[Skills Everywhere] Update YAML files with new structure

### DIFF
--- a/build/yaml/dotnetHost2DotnetV3Skill.yml
+++ b/build/yaml/dotnetHost2DotnetV3Skill.yml
@@ -66,9 +66,21 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.solution: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.sln'
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
+         {
+           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.sln"
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
+         }
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
+         {
+           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.sln"
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+        displayName: 'Set solution and project paths'
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -77,7 +89,7 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.solution: 'SkillsFunctionalTests/dotnet/v3/skill/EchoSkillBot.sln'
+        Parameters.solution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot.sln'
       steps:
       - template: dotnetV3BuildSteps.yml
       - template: dotnetV3TagBotBuilderVersion.yml
@@ -95,9 +107,21 @@ stages:
         DeployAppSecret: $(DotNetDotNetV3HostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
+         {
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
+           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/DeploymentTemplates/template-with-new-rg.json"
+         }
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
+         {
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
+           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/DeploymentTemplates/template-with-new-rg.json"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
+        displayName: 'Set solution and project paths'
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 
@@ -108,9 +132,9 @@ stages:
         DeployAppSecret: $(DotNetDotNetV3SkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.solution: 'SkillsFunctionalTests/dotnet/v3/skill/EchoSkillBot.sln'
-        Parameters.sourceLocation: 'SkillsFunctionalTests/dotnet/v3/skill/'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/v3/skill/DeploymentTemplates/template-with-new-rg.json'
+        Parameters.solution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot.sln'
+        Parameters.sourceLocation: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/'
+        TemplateLocation: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: dotnetV3DeploySteps.yml
 
@@ -120,8 +144,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(DotNetDotNetV3HostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/dotnetHost2DotnetV3Skill.yml
+++ b/build/yaml/dotnetHost2DotnetV3Skill.yml
@@ -66,21 +66,9 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
+        BotType: Host
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
-         {
-           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.sln"
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
-         }
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
-         {
-           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.sln"
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-        displayName: 'Set solution and project paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -107,21 +95,9 @@ stages:
         DeployAppSecret: $(DotNetDotNetV3HostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
+        BotType: Host
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
-         {
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
-           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/DeploymentTemplates/template-with-new-rg.json"
-         }
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
-         {
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
-           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/DeploymentTemplates/template-with-new-rg.json"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
-        displayName: 'Set solution and project paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 

--- a/build/yaml/dotnetHost2JavascriptSkill.yml
+++ b/build/yaml/dotnetHost2JavascriptSkill.yml
@@ -66,21 +66,9 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
+        BotType: Host
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
-         {
-           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.sln"
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
-         }
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
-         {
-           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.sln"
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-        displayName: 'Set solution and project paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -98,21 +86,9 @@ stages:
         DeployAppSecret: $(DotNetJsHostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
+        BotType: Host
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
-         {
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
-           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/DeploymentTemplates/template-with-new-rg.json"
-         }
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
-         {
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
-           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/DeploymentTemplates/template-with-new-rg.json"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
-        displayName: 'Set project and template paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 

--- a/build/yaml/dotnetHost2JavascriptSkill.yml
+++ b/build/yaml/dotnetHost2JavascriptSkill.yml
@@ -66,9 +66,21 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.solution: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.sln'
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
+         {
+           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.sln"
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
+         }
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
+         {
+           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.sln"
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+        displayName: 'Set solution and project paths'
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -86,9 +98,21 @@ stages:
         DeployAppSecret: $(DotNetJsHostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
+         {
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
+           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/DeploymentTemplates/template-with-new-rg.json"
+         }
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
+         {
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
+           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/DeploymentTemplates/template-with-new-rg.json"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
+        displayName: 'Set project and template paths'
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 
@@ -99,8 +123,8 @@ stages:
         DeployAppSecret: $(DotNetJsSkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/skill'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/skill/DeploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/JavaScript/Skills/CodeFirst/EchoSkillBot'
+        TemplateLocation: 'Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptDeploySteps.yml
 
@@ -123,8 +147,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(DotNetJsHostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/dotnetHost2JavascriptV3Skill.yml
+++ b/build/yaml/dotnetHost2JavascriptV3Skill.yml
@@ -66,9 +66,21 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.solution: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.sln'
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
+         {
+           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.sln"
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
+         }
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
+         {
+           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.sln"
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+        displayName: 'Set solution and project paths'
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -86,9 +98,21 @@ stages:
         DeployAppSecret: $(DotNetJsV3HostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
+         {
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
+           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/DeploymentTemplates/template-with-new-rg.json"
+         }
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
+         {
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
+           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/DeploymentTemplates/template-with-new-rg.json"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
+        displayName: 'Set project and template paths'
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 
@@ -99,8 +123,8 @@ stages:
         DeployAppSecret: $(DotNetJsV3SkillAppSecret)        
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/v3/skill'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/skill/DeploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/JavaScript/Skills/CodeFirst/EchoSkillBot-v3/skill'
+        TemplateLocation: 'Bots/JavaScript/Skills/CodeFirst/EchoSkillBot-v3/skill/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptDeploySteps.yml
 
@@ -110,8 +134,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(DotNetJsV3HostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/dotnetHost2JavascriptV3Skill.yml
+++ b/build/yaml/dotnetHost2JavascriptV3Skill.yml
@@ -66,21 +66,9 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
+        BotType: Host
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
-         {
-           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.sln"
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
-         }
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
-         {
-           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.sln"
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-        displayName: 'Set solution and project paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -98,21 +86,9 @@ stages:
         DeployAppSecret: $(DotNetJsV3HostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
+        BotType: Host
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
-         {
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
-           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/DeploymentTemplates/template-with-new-rg.json"
-         }
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
-         {
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
-           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/DeploymentTemplates/template-with-new-rg.json"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
-        displayName: 'Set project and template paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 

--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -68,9 +68,21 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.solution: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.sln'
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
+         {
+           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.sln"
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
+         }
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
+         {
+           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.sln"
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+        displayName: 'Set solution and project paths'
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -88,9 +100,21 @@ stages:
         DeployAppSecret: $(DotNetPyHostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
+         {
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
+           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/DeploymentTemplates/template-with-new-rg.json"
+         }
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
+         {
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
+           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/DeploymentTemplates/template-with-new-rg.json"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
+        displayName: 'Set solution and project paths'
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 
@@ -101,8 +125,8 @@ stages:
         DeployAppSecret: $(DotNetPySkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/python/skill'
-        TemplateLocation: 'SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/Python/Skills/CodeFirst/EchoSkillBot'
+        TemplateLocation: 'Bots/Python/Skills/CodeFirst/EchoSkillBot/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonDeploySteps.yml
 
@@ -125,8 +149,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(DotNetPyHostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -68,21 +68,9 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
+        BotType: Host
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
-         {
-           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.sln"
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
-         }
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
-         {
-           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.sln"
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-        displayName: 'Set solution and project paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -100,21 +88,9 @@ stages:
         DeployAppSecret: $(DotNetPyHostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
+        BotType: Host
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
-         {
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
-           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/DeploymentTemplates/template-with-new-rg.json"
-         }
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
-         {
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
-           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/DeploymentTemplates/template-with-new-rg.json"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
-        displayName: 'Set solution and project paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 

--- a/build/yaml/dotnetHost2dotnetSkill.yml
+++ b/build/yaml/dotnetHost2dotnetSkill.yml
@@ -67,9 +67,21 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.solution: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.sln'
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
+         {
+           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.sln"
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
+         }
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
+         {
+           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.sln"
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+        displayName: 'Set solution and project paths'
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -85,9 +97,21 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.solution: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/EchoSkillBot.sln'
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/EchoSkillBot.csproj'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionSkill".Trim() -eq "3.1")
+         {
+           $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.sln"
+           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj"
+         }
+         if("$env:NetCoreSdkVersionSkill".Trim() -eq "2.1")
+         {
+           $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.sln"
+           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.csproj"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+        displayName: 'Set solution and project paths'
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -105,9 +129,21 @@ stages:
         DeployAppSecret: $(DotNetDotNetHostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]        
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/SimpleHostBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionHost)/host/DeploymentTemplates/template-with-new-rg.json'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
+         {
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
+           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/DeploymentTemplates/template-with-new-rg.json"
+         }
+         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
+         {
+           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
+           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/DeploymentTemplates/template-with-new-rg.json"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
+        displayName: 'Set project and template paths'
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 
@@ -118,9 +154,21 @@ stages:
         DeployAppSecret: $(DotNetDotNetSkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/EchoSkillBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/DeploymentTemplates/template-with-new-rg.json'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionSkill".Trim() -eq "3.1")
+         {
+           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj"
+           $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json"
+         }
+         if("$env:NetCoreSdkVersionSkill".Trim() -eq "2.1")
+         {
+           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.csproj"
+           $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/DeploymentTemplates/template-with-new-rg.json"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
+        displayName: 'Set project and template paths'
       - template: dotnetDeploySteps.yml
 
     - job: Configure_OAuth
@@ -142,8 +190,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(DotNetDotNetHostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/dotnetHost2dotnetSkill.yml
+++ b/build/yaml/dotnetHost2dotnetSkill.yml
@@ -67,21 +67,9 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
+        BotType: Host
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
-         {
-           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.sln"
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
-         }
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
-         {
-           $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.sln"
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-        displayName: 'Set solution and project paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -97,21 +85,9 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
+        BotType: EchoSkill
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionSkill".Trim() -eq "3.1")
-         {
-           $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.sln"
-           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj"
-         }
-         if("$env:NetCoreSdkVersionSkill".Trim() -eq "2.1")
-         {
-           $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.sln"
-           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.csproj"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-        displayName: 'Set solution and project paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -128,22 +104,10 @@ stages:
         DeployAppId: $(DotNetDotNetHostAppId)
         DeployAppSecret: $(DotNetDotNetHostAppSecret)
         Registry: $[variables.RegistryUrlHost]
-        BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]        
+        BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
+        BotType: Host
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
-         {
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
-           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/DeploymentTemplates/template-with-new-rg.json"
-         }
-         if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
-         {
-           $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
-           $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/DeploymentTemplates/template-with-new-rg.json"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
-        displayName: 'Set project and template paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetSetConfigFileSteps.yml
       - template: dotnetDeploySteps.yml
 
@@ -154,21 +118,9 @@ stages:
         DeployAppSecret: $(DotNetDotNetSkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
+        BotType: EchoSkill
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionSkill".Trim() -eq "3.1")
-         {
-           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj"
-           $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json"
-         }
-         if("$env:NetCoreSdkVersionSkill".Trim() -eq "2.1")
-         {
-           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.csproj"
-           $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/DeploymentTemplates/template-with-new-rg.json"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
-        displayName: 'Set project and template paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetDeploySteps.yml
 
     - job: Configure_OAuth

--- a/build/yaml/dotnetSetConfigFileSteps.yml
+++ b/build/yaml/dotnetSetConfigFileSteps.yml
@@ -1,7 +1,14 @@
 steps:
 - powershell: |
    # Set values in appsettings.json file.
-   $file = "$(System.DefaultWorkingDirectory)\SkillsFunctionalTests\dotnet\$(NetCoreSdkVersionHost)\host\appsettings.json";
+   if("$env:NetCoreSdkVersionHost".Trim() -eq "3.1")
+   {
+     $file = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/appsettings.json"
+   }
+   if("$env:NetCoreSdkVersionHost".Trim() -eq "2.1")
+   {
+     $file = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/appsettings.json"
+   }
    $content = Get-Content -Raw $file | ConvertFrom-Json;
    $content.SkillHostEndpoint = "https://$(HostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
 

--- a/build/yaml/dotnetSetPaths.yml
+++ b/build/yaml/dotnetSetPaths.yml
@@ -31,6 +31,9 @@ steps:
      }
    }
    Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
+   Write-Host "Solution path set to $SolutionPath"
    Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+   Write-Host "Project path set to $ProjectPath"
    Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
+   Write-Host "Template path set to $TemplatePath"
   displayName: 'Set path variables'

--- a/build/yaml/dotnetSetPaths.yml
+++ b/build/yaml/dotnetSetPaths.yml
@@ -1,0 +1,36 @@
+steps:
+- powershell: |
+   if("$(BotType)" -eq "Host")
+   {
+     if("$(NetCoreSdkVersionHost)".Trim() -eq "3.1")
+     {
+       $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.sln"
+       $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
+       $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/DeploymentTemplates/template-with-new-rg.json"
+     }
+     if("$(NetCoreSdkVersionHost)".Trim() -eq "2.1")
+     {
+       $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.sln"
+       $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.csproj"
+       $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/DeploymentTemplates/template-with-new-rg.json"
+     }
+   }
+   if("$(BotType)" -eq "EchoSkill")
+   {
+     if("$(NetCoreSdkVersionSkill)".Trim() -eq "3.1")
+     {
+       $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.sln"
+       $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj"
+       $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json"
+     }
+     if("$(NetCoreSdkVersionSkill)".Trim() -eq "2.1")
+     {
+       $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.sln"
+       $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.csproj"
+       $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/DeploymentTemplates/template-with-new-rg.json"
+     }
+   }
+   Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
+   Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+   Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
+  displayName: 'Set path variables'

--- a/build/yaml/dotnetTagBotBuilderVersion.yml
+++ b/build/yaml/dotnetTagBotBuilderVersion.yml
@@ -40,13 +40,11 @@ steps:
       $version = "$(BBVersion)"
     }
 
-    if ("$(Parameters.project)".Trim().Contains("/host/"))
+    switch -wildcard ("$(Parameters.project)".Trim())
     {
-        echo "##vso[task.setvariable variable=HostOrSkill]Host"
-    }
-    else
-    {
-        echo "##vso[task.setvariable variable=HostOrSkill]Skill"
+      "*/Consumers/*" { echo "##vso[task.setvariable variable=HostOrSkill]Host" }
+      "*/Skills/*" { echo "##vso[task.setvariable variable=HostOrSkill]Skill" }
+      default { echo "##vso[task.setvariable variable=HostOrSkill]" }
     }
     
     write-host "Version: " $version $versionTag

--- a/build/yaml/dotnetV3TagBotBuilderVersion.yml
+++ b/build/yaml/dotnetV3TagBotBuilderVersion.yml
@@ -1,6 +1,6 @@
 steps:
 - powershell: |
-    $result = Get-ChildItem "$(Build.SourcesDirectory)\SkillsFunctionalTests\dotnet\v3\skill\packages\Microsoft.Bot.Builder.[0-9]*" -directory | Sort LastWriteTime -Descending
+    $result = Get-ChildItem "$(Build.SourcesDirectory)\Bots\DotNet\Skills\CodeFirst\EchoSkillBot-v3\packages\Microsoft.Bot.Builder.[0-9]*" -directory | Sort LastWriteTime -Descending
     
     $version = $result[0].Name.Replace("Microsoft.Bot.Builder.", "")
     $versionTag = ""

--- a/build/yaml/javascriptHost2DotnetSkill.yml
+++ b/build/yaml/javascriptHost2DotnetSkill.yml
@@ -66,9 +66,21 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.solution: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/EchoSkillBot.sln'
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/EchoSkillBot.csproj'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionSkill".Trim() -eq "3.1")
+         {
+           $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.sln"
+           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj"
+         }
+         if("$env:NetCoreSdkVersionSkill".Trim() -eq "2.1")
+         {
+           $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.sln"
+           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.csproj"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+        displayName: 'Set solution and project paths'
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -86,8 +98,8 @@ stages:
         DeployAppSecret: $(JsDotNetHostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/host'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/host/DeploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot'
+        TemplateLocation: 'Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptSetConfigFileSteps.yml
       - template: javascriptDeploySteps.yml
@@ -99,9 +111,21 @@ stages:
         DeployAppSecret: $(JsDotNetSkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/EchoSkillBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/DeploymentTemplates/template-with-new-rg.json'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionSkill".Trim() -eq "3.1")
+         {
+           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj"
+           $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json"
+         }
+         if("$env:NetCoreSdkVersionSkill".Trim() -eq "2.1")
+         {
+           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.csproj"
+           $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/DeploymentTemplates/template-with-new-rg.json"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
+        displayName: 'Set project and template paths'
       - template: dotnetDeploySteps.yml
 
     - job: Configure_OAuth
@@ -123,8 +147,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(JsDotNetHostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/javascriptHost2DotnetSkill.yml
+++ b/build/yaml/javascriptHost2DotnetSkill.yml
@@ -66,21 +66,9 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
+        BotType: EchoSkill
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionSkill".Trim() -eq "3.1")
-         {
-           $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.sln"
-           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj"
-         }
-         if("$env:NetCoreSdkVersionSkill".Trim() -eq "2.1")
-         {
-           $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.sln"
-           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.csproj"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-        displayName: 'Set solution and project paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -111,21 +99,9 @@ stages:
         DeployAppSecret: $(JsDotNetSkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
+        BotType: EchoSkill
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionSkill".Trim() -eq "3.1")
-         {
-           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj"
-           $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json"
-         }
-         if("$env:NetCoreSdkVersionSkill".Trim() -eq "2.1")
-         {
-           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.csproj"
-           $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/DeploymentTemplates/template-with-new-rg.json"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
-        displayName: 'Set project and template paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetDeploySteps.yml
 
     - job: Configure_OAuth

--- a/build/yaml/javascriptHost2DotnetV3Skill.yml
+++ b/build/yaml/javascriptHost2DotnetV3Skill.yml
@@ -63,7 +63,7 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.solution: 'SkillsFunctionalTests/dotnet/v3/skill/EchoSkillBot.sln'
+        Parameters.solution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot.sln'
       steps:
       - template: dotnetV3BuildSteps.yml
       - template: dotnetV3TagBotBuilderVersion.yml
@@ -81,8 +81,8 @@ stages:
         DeployAppSecret: $(JsDotNetV3HostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/host'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/host/DeploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot'
+        TemplateLocation: 'Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptSetConfigFileSteps.yml
       - template: javascriptDeploySteps.yml
@@ -94,9 +94,9 @@ stages:
         DeployAppSecret: $(JsDotNetV3SkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.solution: 'SkillsFunctionalTests/dotnet/v3/skill/EchoSkillBot.sln'
-        Parameters.sourceLocation: 'SkillsFunctionalTests/dotnet/v3/skill/'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/v3/skill/DeploymentTemplates/template-with-new-rg.json'
+        Parameters.solution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot.sln'
+        Parameters.sourceLocation: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/'
+        TemplateLocation: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: dotnetV3DeploySteps.yml
 
@@ -106,8 +106,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(JsDotNetV3HostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/javascriptHost2JavascriptSkill.yml
+++ b/build/yaml/javascriptHost2JavascriptSkill.yml
@@ -69,8 +69,8 @@ stages:
         DeployAppSecret: $(JsJsHostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/host'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/host/DeploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot'
+        TemplateLocation: 'Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptSetConfigFileSteps.yml
       - template: javascriptDeploySteps.yml
@@ -82,8 +82,8 @@ stages:
         DeployAppSecret: $(JsJsSkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/skill'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/skill/DeploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/JavaScript/Skills/CodeFirst/EchoSkillBot'
+        TemplateLocation: 'Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptDeploySteps.yml
 
@@ -106,8 +106,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(JsJsHostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/javascriptHost2JavascriptV3Skill.yml
+++ b/build/yaml/javascriptHost2JavascriptV3Skill.yml
@@ -69,8 +69,8 @@ stages:
         DeployAppSecret: $(JsJsV3HostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/host'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/host/DeploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot'
+        TemplateLocation: 'Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptSetConfigFileSteps.yml
       - template: javascriptDeploySteps.yml
@@ -82,8 +82,8 @@ stages:
         DeployAppSecret: $(JsJsV3SkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/v3/skill'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/v3/skill/DeploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/JavaScript/Skills/CodeFirst/EchoSkillBot-v3/skill'
+        TemplateLocation: 'Bots/JavaScript/Skills/CodeFirst/EchoSkillBot-v3/skill/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptDeploySteps.yml
 
@@ -93,8 +93,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(JsJsV3HostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/javascriptHost2PythonSkill.yml
+++ b/build/yaml/javascriptHost2PythonSkill.yml
@@ -71,8 +71,8 @@ stages:
         DeployAppSecret: $(JsPyHostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/host'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/host/DeploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot'
+        TemplateLocation: 'Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptSetConfigFileSteps.yml
       - template: javascriptDeploySteps.yml
@@ -84,8 +84,8 @@ stages:
         DeployAppSecret: $(JsPySkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/python/skill'
-        TemplateLocation: 'SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/Python/Skills/CodeFirst/EchoSkillBot'
+        TemplateLocation: 'Bots/Python/Skills/CodeFirst/EchoSkillBot/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonDeploySteps.yml
 
@@ -108,8 +108,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(JsPyHostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/javascriptSetConfigFileSteps.yml
+++ b/build/yaml/javascriptSetConfigFileSteps.yml
@@ -1,7 +1,7 @@
 steps:
 - powershell: |
     Write-host "Setting values in .env file"
-    $file = "$(System.DefaultWorkingDirectory)/SkillsFunctionalTests/javascript/host/.env";
+    $file = "$(System.DefaultWorkingDirectory)/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/.env";
     $content = Get-Content -Raw $file | ConvertFrom-StringData;
 
     $content.SkillHostEndpoint = "https://$(HostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";

--- a/build/yaml/javascriptTagBotBuilderVersion.yml
+++ b/build/yaml/javascriptTagBotBuilderVersion.yml
@@ -38,13 +38,11 @@ steps:
       default { $version = "$(BBVersion)" }
     }
 
-    if ("$(Parameters.sourceLocation)".Trim().Contains("/host"))
+    switch -wildcard ("$(Parameters.sourceLocation)".Trim())
     {
-        echo "##vso[task.setvariable variable=HostOrSkill]Host"
-    }
-    else
-    {
-        echo "##vso[task.setvariable variable=HostOrSkill]Skill"
+      "*/Consumers/*" { echo "##vso[task.setvariable variable=HostOrSkill]Host" }
+      "*/Skills/*" { echo "##vso[task.setvariable variable=HostOrSkill]Skill" }
+      default { echo "##vso[task.setvariable variable=HostOrSkill]" }
     }
 
     write-host "Version: " $version $versionTag

--- a/build/yaml/pythonHost2DotnetSkill.yml
+++ b/build/yaml/pythonHost2DotnetSkill.yml
@@ -68,9 +68,21 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.solution: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/EchoSkillBot.sln'
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/EchoSkillBot.csproj'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionSkill".Trim() -eq "3.1")
+         {
+           $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.sln"
+           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj"
+         }
+         if("$env:NetCoreSdkVersionSkill".Trim() -eq "2.1")
+         {
+           $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.sln"
+           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.csproj"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+        displayName: 'Set solution and project paths'
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -88,8 +100,8 @@ stages:
         DeployAppSecret: $(PyDotNetHostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
-        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/Python/Consumers/CodeFirst/SimpleHostBot'
+        TemplateLocation: 'Bots/Python/Consumers/CodeFirst/SimpleHostBot/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
@@ -101,9 +113,21 @@ stages:
         DeployAppSecret: $(PyDotNetSkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.project: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/EchoSkillBot.csproj'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/$(NetCoreSdkVersionSkill)/skill/DeploymentTemplates/template-with-new-rg.json'
       steps:
+      - powershell: |
+         if("$env:NetCoreSdkVersionSkill".Trim() -eq "3.1")
+         {
+           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj"
+           $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json"
+         }
+         if("$env:NetCoreSdkVersionSkill".Trim() -eq "2.1")
+         {
+           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.csproj"
+           $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/DeploymentTemplates/template-with-new-rg.json"
+         }
+         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
+         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
+        displayName: 'Set project and template paths'
       - template: dotnetDeploySteps.yml
 
     - job: Configure_OAuth
@@ -125,8 +149,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(PyDotNetHostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/pythonHost2DotnetSkill.yml
+++ b/build/yaml/pythonHost2DotnetSkill.yml
@@ -68,21 +68,9 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
+        BotType: EchoSkill
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionSkill".Trim() -eq "3.1")
-         {
-           $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.sln"
-           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj"
-         }
-         if("$env:NetCoreSdkVersionSkill".Trim() -eq "2.1")
-         {
-           $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.sln"
-           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.csproj"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-        displayName: 'Set solution and project paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetInstallPackagesSteps.yml
       - template: dotnetBuildSteps.yml
       - template: dotnetTagBotBuilderVersion.yml
@@ -113,21 +101,9 @@ stages:
         DeployAppSecret: $(PyDotNetSkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
+        BotType: EchoSkill
       steps:
-      - powershell: |
-         if("$env:NetCoreSdkVersionSkill".Trim() -eq "3.1")
-         {
-           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj"
-           $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json"
-         }
-         if("$env:NetCoreSdkVersionSkill".Trim() -eq "2.1")
-         {
-           $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.csproj"
-           $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/DeploymentTemplates/template-with-new-rg.json"
-         }
-         Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
-         Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"
-        displayName: 'Set project and template paths'
+      - template: dotnetSetPaths.yml
       - template: dotnetDeploySteps.yml
 
     - job: Configure_OAuth

--- a/build/yaml/pythonHost2DotnetV3Skill.yml
+++ b/build/yaml/pythonHost2DotnetV3Skill.yml
@@ -65,7 +65,7 @@ stages:
       variables:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.solution: 'SkillsFunctionalTests/dotnet/v3/skill/EchoSkillBot.sln'
+        Parameters.solution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot.sln'
       steps:
       - template: dotnetV3BuildSteps.yml
       - template: dotnetV3TagBotBuilderVersion.yml
@@ -83,8 +83,8 @@ stages:
         DeployAppSecret: $(PyDotNetV3HostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
-        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/Python/Consumers/CodeFirst/SimpleHostBot'
+        TemplateLocation: 'Bots/Python/Consumers/CodeFirst/SimpleHostBot/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
@@ -96,9 +96,9 @@ stages:
         DeployAppSecret: $(PyDotNetV3SkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.solution: 'SkillsFunctionalTests/dotnet/v3/skill/EchoSkillBot.sln'
-        Parameters.sourceLocation: 'SkillsFunctionalTests/dotnet/v3/skill/'
-        TemplateLocation: 'SkillsFunctionalTests/dotnet/v3/skill/DeploymentTemplates/template-with-new-rg.json'
+        Parameters.solution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot.sln'
+        Parameters.sourceLocation: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/'
+        TemplateLocation: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: dotnetV3DeploySteps.yml
 
@@ -108,8 +108,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(PyDotNetV3HostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/pythonHost2JavascriptSkill.yml
+++ b/build/yaml/pythonHost2JavascriptSkill.yml
@@ -72,8 +72,8 @@ stages:
         DeployAppSecret: $(PyJsHostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
-        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/Python/Consumers/CodeFirst/SimpleHostBot'
+        TemplateLocation: 'Bots/Python/Consumers/CodeFirst/SimpleHostBot/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
@@ -85,8 +85,8 @@ stages:
         DeployAppSecret: $(PyJsSkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/skill'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/skill/DeploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/JavaScript/Skills/CodeFirst/EchoSkillBot'
+        TemplateLocation: 'Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptDeploySteps.yml
 
@@ -109,8 +109,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(PyJsHostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/pythonHost2JavascriptV3Skill.yml
+++ b/build/yaml/pythonHost2JavascriptV3Skill.yml
@@ -72,8 +72,8 @@ stages:
         DeployAppSecret: $(PyJsV3HostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
-        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/Python/Consumers/CodeFirst/SimpleHostBot'
+        TemplateLocation: 'Bots/Python/Consumers/CodeFirst/SimpleHostBot/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
@@ -85,8 +85,8 @@ stages:
         DeployAppSecret: $(PyJsV3SkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/javascript/v3/skill'
-        TemplateLocation: 'SkillsFunctionalTests/javascript/skill/DeploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/JavaScript/Skills/CodeFirst/EchoSkillBot-v3/skill'
+        TemplateLocation: 'Bots/JavaScript/Skills/CodeFirst/EchoSkillBot-v3/skill/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: javascriptDeploySteps.yml
 
@@ -96,8 +96,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(PyJsV3HostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/pythonHost2PythonSkill.yml
+++ b/build/yaml/pythonHost2PythonSkill.yml
@@ -71,8 +71,8 @@ stages:
         DeployAppSecret: $(PyPyHostAppSecret)
         Registry: $[variables.RegistryUrlHost]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionHost]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/python/host'
-        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/Python/Consumers/CodeFirst/SimpleHostBot'
+        TemplateLocation: 'Bots/Python/Consumers/CodeFirst/SimpleHostBot/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonSetConfigFileSteps.yml
       - template: pythonDeploySteps.yml
@@ -84,8 +84,8 @@ stages:
         DeployAppSecret: $(PyPySkillAppSecret)
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
-        Parameters.sourceLocation: 'SkillsFunctionalTests/python/skill'
-        TemplateLocation: 'SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json'
+        Parameters.sourceLocation: 'Bots/Python/Skills/CodeFirst/EchoSkillBot'
+        TemplateLocation: 'Bots/Python/Skills/CodeFirst/EchoSkillBot/deploymentTemplates/template-with-new-rg.json'
       steps:
       - template: pythonDeploySteps.yml
 
@@ -108,8 +108,8 @@ stages:
     - job: Run_Functional_Test
       variables:
         HostBotName: $(PyPyHostBotName)
-        Parameters.project: 'SkillsFunctionalTests/tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillsFunctionalTests/tests/SkillFunctionalTests.sln'
+        Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/pythonTagBotBuilderVersion.yml
+++ b/build/yaml/pythonTagBotBuilderVersion.yml
@@ -5,18 +5,19 @@ steps:
     $packageVersion = pip show botbuilder-integration-aiohttp | Where-Object { $_ -match '^Version' }
     $version = $packageVersion.Split(" ")[1]
     $versionTag = ""
+
     if ("$(BBVersion)" -in("stable","preview"))
     {
       $versionTag = " ($(BBVersion))"
     }
-    if ("$(Parameters.sourceLocation)".Trim().Contains("/host"))
+
+    switch -wildcard ("$(Parameters.sourceLocation)".Trim())
     {
-        echo "##vso[task.setvariable variable=HostOrSkill]Host"
+      "*/Consumers/*" { echo "##vso[task.setvariable variable=HostOrSkill]Host" }
+      "*/Skills/*" { echo "##vso[task.setvariable variable=HostOrSkill]Skill" }
+      default { echo "##vso[task.setvariable variable=HostOrSkill]" }
     }
-    else
-    {
-        echo "##vso[task.setvariable variable=HostOrSkill]Skill"
-    }
+
     write-host "Version: " $version $versionTag
     echo "##vso[task.setvariable variable=PackagesVersionTag]$versionTag"
     echo "##vso[task.setvariable variable=PackagesVersion]$version"


### PR DESCRIPTION
## Description
This branch updates all Skill Functional Test YAML files to work with the directory refactor.

PowerShell steps were included to update DotNet's host and skill reference paths based on their version (2.1 or 3.1) since their refactored folder names were incompatible with the previous implementation.

## Specific Changes
  - Updates all explicit path references in YAML files.
  - Adds PowerShell scripts to update DotNet's bots paths.