### PR TITLE
[Skills Everywhere] Update Bot messages to maintain parity

### DIFF
--- a/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/Bots/EchoBot.cs
+++ b/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/Bots/EchoBot.cs
@@ -40,7 +40,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.Bots
             else if (turnContext.Activity.Text.Contains("end") || turnContext.Activity.Text.Contains("stop"))
             {
                 // Send End of conversation at the end.
-                await turnContext.SendActivityAsync(MessageFactory.Text($"ending conversation from the skill..."), cancellationToken);
+                await turnContext.SendActivityAsync(MessageFactory.Text($"Ending conversation from the skill..."), cancellationToken);
                 var endOfConversation = Activity.CreateEndOfConversationActivity();
                 endOfConversation.Code = EndOfConversationCodes.CompletedSuccessfully;
                 await turnContext.SendActivityAsync(endOfConversation, cancellationToken);

--- a/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/Dialogs/RootDialog.cs
+++ b/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/Dialogs/RootDialog.cs
@@ -22,19 +22,25 @@ namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.Dialogs
         {
             var activity = await result as Activity;
 
+            var options = new MessageOptions
+            {
+                InputHint = InputHints.AcceptingInput
+            };
+
             // Send an `endOfconversation` activity if the user cancels the skill.
             if (activity.Text.ToLower().Contains("end") || activity.Text.ToLower().Contains("stop"))
             {
-                await context.PostAsync($"Ending conversation from the skill...");
+                await context.SayAsync($"Ending conversation from the skill...", options: options);
                 var endOfConversation = activity.CreateReply();
                 endOfConversation.Type = ActivityTypes.EndOfConversation;
                 endOfConversation.Code = EndOfConversationCodes.CompletedSuccessfully;
+                endOfConversation.InputHint = InputHints.AcceptingInput;
                 await context.PostAsync(endOfConversation);
             }
             else
             {
-                await context.PostAsync($"Echo: {activity.Text}");
-                await context.PostAsync($"Say \"end\" or \"stop\" and I'll end the conversation and back to the parent.");
+                await context.SayAsync($"Echo: {activity.Text}", options: options);
+                await context.SayAsync($"Say \"end\" or \"stop\" and I'll end the conversation and back to the parent.", options: options);
             }
 
             context.Wait(MessageReceivedAsync);

--- a/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/Dialogs/RootDialog.cs
+++ b/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/Dialogs/RootDialog.cs
@@ -28,13 +28,13 @@ namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.Dialogs
                 await context.PostAsync($"Ending conversation from the skill...");
                 var endOfConversation = activity.CreateReply();
                 endOfConversation.Type = ActivityTypes.EndOfConversation;
-                endOfConversation.Code = EndOfConversationCodes.UserCancelled;
+                endOfConversation.Code = EndOfConversationCodes.CompletedSuccessfully;
                 await context.PostAsync(endOfConversation);
             }
             else
             {
                 await context.PostAsync($"Echo: {activity.Text}");
-                await context.PostAsync($"Say 'end' or 'stop' and I'll end the conversation and back to the parent.");
+                await context.PostAsync($"Say \"end\" or \"stop\" and I'll end the conversation and back to the parent.");
             }
 
             context.Wait(MessageReceivedAsync);

--- a/Bots/DotNet/Skills/CodeFirst/EchoSkillBot/Bots/EchoBot.cs
+++ b/Bots/DotNet/Skills/CodeFirst/EchoSkillBot/Bots/EchoBot.cs
@@ -40,7 +40,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.EchoSkillBot.Bots
             else if (turnContext.Activity.Text.Contains("end") || turnContext.Activity.Text.Contains("stop"))
             {
                 // Send End of conversation at the end.
-                await turnContext.SendActivityAsync(MessageFactory.Text($"ending conversation from the skill..."), cancellationToken);
+                await turnContext.SendActivityAsync(MessageFactory.Text($"Ending conversation from the skill..."), cancellationToken);
                 var endOfConversation = Activity.CreateEndOfConversationActivity();
                 endOfConversation.Code = EndOfConversationCodes.CompletedSuccessfully;
                 await turnContext.SendActivityAsync(endOfConversation, cancellationToken);

--- a/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/hostBot.js
+++ b/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/hostBot.js
@@ -47,7 +47,7 @@ class HostBot extends ActivityHandler {
                     // Send the activity to the skill
                     await this.sendToSkill(context, this.targetSkill);
                 } else {
-                    await context.sendActivity("Me no nothin'. Say 'skill' and I'll patch you through");
+                    await context.sendActivity("Me no nothin'. Say \"skill\" and I'll patch you through");
                 }
             }
 
@@ -73,8 +73,8 @@ class HostBot extends ActivityHandler {
 
                 await context.sendActivity(eocActivityMessage);
 
-                // We are back at the root
-                await context.sendActivity('Back in the root bot. Say \'skill\' and I\'ll patch you through');
+                // We are back at the host
+                await context.sendActivity('Back in the host bot. Say "skill" and I\'ll patch you through');
 
                 // Save conversation state
                 await this.conversationState.saveChanges(context, true);

--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot-v3/skill/index.js
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot-v3/skill/index.js
@@ -36,7 +36,7 @@ const bot = new builder.UniversalBot(connector, function (session) {
     switch (session.message.text.toLowerCase()) {
         case 'end':
         case 'stop':
-            session.endConversation();
+            session.endConversation("Ending conversation from the skill...");
             break;
         default:
             session.send("Echo: %s", session.message.text);

--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot-v3/skill/index.js
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot-v3/skill/index.js
@@ -36,10 +36,15 @@ const bot = new builder.UniversalBot(connector, function (session) {
     switch (session.message.text.toLowerCase()) {
         case 'end':
         case 'stop':
-            session.endConversation("Ending conversation from the skill...");
+            session.say("Ending conversation from the skill...", {
+                inputHint: builder.InputHint.acceptingInput
+            });
+            session.endConversation();
             break;
         default:
-            session.send("Echo: %s", session.message.text);
-            session.send('Say "end" or "stop" and I\'ll end the conversation and back to the parent.');
+            session.say('Echo: ' + session.message.text, {
+                inputHint: builder.InputHint.acceptingInput
+            });
+            session.say('Say "end" or "stop" and I\'ll end the conversation and back to the parent.');
     }
 }).set('storage', inMemoryStorage); // Register in memory storage

--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/bot.js
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/bot.js
@@ -41,6 +41,7 @@ class EchoBot extends ActivityHandler {
                 break;
             case 'end':
             case 'stop':
+                await context.sendActivity(`Ending conversation from the skill...`);
                 await context.sendActivity({
                     type: ActivityTypes.EndOfConversation,
                     code: EndOfConversationCodes.CompletedSuccessfully

--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/dialogs/mainDialog.js
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/dialogs/mainDialog.js
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 const { ConfirmPrompt, DialogSet, DialogTurnStatus, OAuthPrompt, WaterfallDialog } = require('botbuilder-dialogs');
+const { MessageFactory } = require('botbuilder-core');
 
 const { LogoutDialog } = require('./logoutDialog');
 
@@ -57,7 +58,7 @@ class MainDialog extends LogoutDialog {
         const tokenResponse = stepContext.result;
         if (tokenResponse) {
             await stepContext.context.sendActivity('You are now logged in.');
-            return await stepContext.prompt(CONFIRM_PROMPT, 'Would you like to view your token?');
+            return await stepContext.prompt(CONFIRM_PROMPT, MessageFactory.text('Would you like to view your token?'));
         }
         await stepContext.context.sendActivity('Login was not successful please try again.');
         return await stepContext.endDialog();

--- a/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
+++ b/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
@@ -3,8 +3,8 @@
 
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using TranscriptTestRunner;
 using TranscriptTestRunner.XUnit;


### PR DESCRIPTION
## Description

This PR updates all bots messages to maintain parity with DotNet host and skill.

## Specific Changes
- Updates DotNet EchoSkillBot and EchoSkillBot-2.1 EchoBot ending message.
- Updates Javascript SimpleHostBot messages when "Say skill".
- Updates DotNet EchoSkillBot-v3 "Say end" and ending activity.
- Added JavaScript EchoSkillBot and EchoSkillBot-v3 `Ending conversation from the skill...` message when ending the conversation.
- Updated JavaScript EchoSkillBot confirm prompt to use _MessageFactory_ to have parity on _inputHint_ property.