### PR TITLE
[Skills Everywhere] Improve TranscriptConverter adding assertions list

### DIFF
--- a/Libraries/TranscriptTestRunner/TestClients/DirectLineTestClient.cs
+++ b/Libraries/TranscriptTestRunner/TestClients/DirectLineTestClient.cs
@@ -6,10 +6,14 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector.DirectLine;
+using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Rest.TransientFaultHandling;
 using Newtonsoft.Json;
+using Activity = Microsoft.Bot.Connector.DirectLine.Activity;
 using BotActivity = Microsoft.Bot.Schema.Activity;
+using BotChannelAccount = Microsoft.Bot.Schema.ChannelAccount;
+using ChannelAccount = Microsoft.Bot.Connector.DirectLine.ChannelAccount;
 
 namespace TranscriptTestRunner.TestClients
 {
@@ -120,7 +124,10 @@ namespace TranscriptTestRunner.TestClients
                     if (dlActivity.From.Id == _botId)
                     {
                         // Convert the DL Activity object to a BF activity object.
-                        _activityQueue.Enqueue(JsonConvert.DeserializeObject<BotActivity>(JsonConvert.SerializeObject(dlActivity)));
+                        var botActivity = JsonConvert.DeserializeObject<BotActivity>(JsonConvert.SerializeObject(dlActivity));
+                        botActivity.From.Role = RoleTypes.Bot;
+                        botActivity.Recipient = new BotChannelAccount(role: RoleTypes.User);
+                        _activityQueue.Enqueue(botActivity);
                     }
                 }
             }

--- a/Libraries/TranscriptTestRunner/TestScriptItem.cs
+++ b/Libraries/TranscriptTestRunner/TestScriptItem.cs
@@ -1,14 +1,28 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
 namespace TranscriptTestRunner
 {
     public class TestScriptItem
     {
+        [JsonProperty("type")]
         public string Type { get; set; }
 
+        [JsonProperty("role")]
         public string Role { get; set; }
 
+        [JsonProperty("text")]
         public string Text { get; set; }
+
+        [JsonProperty("assertions")] 
+        public List<string> Assertions { get; } = new List<string>();
+
+        public bool ShouldSerializeAssertions()
+        {
+            return Assertions.Count > 0;
+        }
     }
 }

--- a/Libraries/TranscriptTestRunner/TranscriptConverter.cs
+++ b/Libraries/TranscriptTestRunner/TranscriptConverter.cs
@@ -291,7 +291,7 @@ namespace TranscriptTestRunner
         {
             var json = JsonConvert.SerializeObject(
                 testScript,
-                Formatting.None,
+                Formatting.Indented,
                 new JsonSerializerSettings
                 {
                     NullValueHandling = NullValueHandling.Ignore

--- a/Libraries/TranscriptTestRunner/TranscriptConverter.cs
+++ b/Libraries/TranscriptTestRunner/TranscriptConverter.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Text.RegularExpressions;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -35,34 +37,208 @@ namespace TranscriptTestRunner
             ValidatePaths();
 
             var transcript = ReadEmulatorTranscript();
-            var activities = JsonConvert.DeserializeObject<Activity[]>(transcript);
-            var testScript = CreateTestScript(activities);
+
+            var cleanedTranscript = RemoveUndesiredFields(transcript);
+
+            var testScript = CreateTestScript(cleanedTranscript);
 
             WriteTestScript(testScript);
         }
 
         /// <summary>
-        /// Creates the test script based on the transcript content.
+        /// Recursively goes through the json content removing the undesired elements.
         /// </summary>
-        /// <param name="transcript">The .transcript content parsed as Activities.</param>
-        /// <returns>A string representing the test script json content.</returns>
-        private static string CreateTestScript(IEnumerable<Activity> transcript)
+        /// <param name="token">The JToken element to process.</param>
+        /// <param name="callback">The recursive function to iterate over the JToken.</param>
+        private static void RemoveFields(JToken token, Func<JProperty, bool> callback)
         {
-            var scriptArray = new JArray();
-
-            foreach (var activity in transcript)
+            if (!(token is JContainer container))
             {
-                var script = new JObject
-                {
-                    { "type", activity.Type },
-                    { "role", activity.From.Role },
-                    { "text", activity.Text }
-                };
-
-                scriptArray.Add(script);
+                return;
             }
 
-            return JsonConvert.SerializeObject(scriptArray);
+            var removeList = new List<JToken>();
+
+            foreach (var element in container.Children())
+            {
+                if (element is JProperty prop && callback(prop))
+                {
+                    removeList.Add(element);
+                }
+
+                RemoveFields(element, callback);
+            }
+
+            foreach (var element in removeList)
+            {
+                element.Remove();
+            }
+        }
+
+        /// <summary>
+        /// Checks if a string is a GUID value.
+        /// </summary>
+        /// <param name="guid">The string to check.</param>
+        /// <returns>True if the string is a GUID, otherwise, returns false.</returns>
+        private static bool IsGuid(string guid)
+        {
+            var guidMatch = Regex.Match(
+                guid,
+                @"([a-z0-9]{8}[-][a-z0-9]{4}[-][a-z0-9]{4}[-][a-z0-9]{4}[-][a-z0-9]{12})",
+                RegexOptions.IgnoreCase);
+            return guidMatch.Success;
+        }
+
+        /// <summary>
+        /// Checks if a string is an ID value.
+        /// </summary>
+        /// <param name="id">The string to check.</param>
+        /// <returns>True if the string is an ID, otherwise, returns false.</returns>
+        private static bool IsId(string id)
+        {
+            var idMatch = Regex.Match(
+                id,
+                @"([a-z0-9]{23})",
+                RegexOptions.IgnoreCase);
+            return idMatch.Success;
+        }
+
+        private static bool IsServiceUrl(string url)
+        {
+            var idMatch = Regex.Match(
+                url,
+                @"https://([a-z0-9]{12})",
+                RegexOptions.IgnoreCase);
+            return idMatch.Success;
+        }
+
+        private static bool IschannelId(string value)
+        {
+            return value.ToUpper(CultureInfo.InvariantCulture) == "EMULATOR";
+        }
+
+        /// <summary>
+        /// Checks if a string is a JSON Object.
+        /// </summary>
+        /// <param name="value">The string to check.</param>
+        /// <returns>True if the string is a JSON Object, otherwise, returns false.</returns>
+        private static bool IsJsonObject(string value)
+        {
+            try
+            {
+                JsonConvert.DeserializeObject(value);
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        private static List<TestScriptItem> CreateTestScript(string json)
+        {
+            var activities = JsonConvert.DeserializeObject<IEnumerable<Activity>>(json);
+            var testScript = new List<TestScriptItem>();
+
+            foreach (var activity in activities)
+            {
+                var scriptItem = new TestScriptItem
+                {
+                    Type = activity.Type,
+                    Role = activity.From.Role,
+                    Text = activity.Text
+                };
+
+                if (scriptItem.Role == "bot")
+                {
+                    var assertionsList = CreateAssertionsList(activity);
+
+                    foreach (var assertion in assertionsList)
+                    {
+                        scriptItem.Assertions.Add(assertion);
+                    }
+                }
+
+                testScript.Add(scriptItem);
+            }
+
+            return testScript;
+        }
+
+        private static IEnumerable<string> CreateAssertionsList(IActivity activity)
+        {
+            var json = JsonConvert.SerializeObject(
+                activity,
+                Formatting.None,
+                new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Ignore
+                });
+
+            var token = JToken.Parse(json);
+            var assertionsList = new List<string>();
+
+            AddAssertions(token, assertionsList);
+
+            return assertionsList;
+        }
+
+        private static void AddAssertions(JToken token, ICollection<string> assertionsList)
+        {
+            foreach (var property in token)
+            {
+                if (property is JProperty prop && !IsJsonObject(prop.Value.ToString()))
+                {
+                    if (prop.Path == "from.name")
+                    {
+                        continue;
+                    }
+
+                    var value = prop.Value.Type == JTokenType.String
+                        ? $"'{prop.Value.ToString().Replace("'", "\\'")}'"
+                        : prop.Value;
+
+                    assertionsList.Add($"{prop.Path} == {value}");
+                }
+                else
+                {
+                    AddAssertions(property, assertionsList);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes the IDs and DateTime fields from the transcript file.
+        /// </summary>
+        /// <param name="transcript">The transcript file content.</param>
+        /// <returns>The transcript content without the undesired fields.</returns>
+        private string RemoveUndesiredFields(string transcript)
+        {
+            var token = JToken.Parse(transcript);
+
+            RemoveFields(token, (attr) =>
+            {
+                var value = attr.Value.ToString();
+
+                if (IsJsonObject(value))
+                {
+                    return false;
+                }
+
+                return IsGuid(value) || IsDateTime(value) || IsId(value) || IsServiceUrl(value) || IschannelId(value);
+            });
+
+            return token.ToString();
+        }
+
+        /// <summary>
+        /// Checks if a string is a DateTime value.
+        /// </summary>
+        /// <param name="datetime">The string to check.</param>
+        /// <returns>True if the string is a DateTime, otherwise, returns false.</returns>
+        private bool IsDateTime(string datetime)
+        {
+            return DateTime.TryParse(datetime, out _);
         }
 
         /// <summary>
@@ -111,9 +287,16 @@ namespace TranscriptTestRunner
         /// <summary>
         /// Writes the test script content to the path set in the TestScript property.
         /// </summary>
-        /// <param name="json">The test script content to be written.</param>
-        private void WriteTestScript(string json)
+        private void WriteTestScript(List<TestScriptItem> testScript)
         {
+            var json = JsonConvert.SerializeObject(
+                testScript,
+                Formatting.None,
+                new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Ignore
+                });
+
             using var streamWriter = new StreamWriter(TestScript);
             streamWriter.Write(json);
         }

--- a/Libraries/TranscriptTestRunner/TranscriptTestRunner.csproj
+++ b/Libraries/TranscriptTestRunner/TranscriptTestRunner.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AdaptiveExpressions" Version="4.10.3" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.10.3" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />

--- a/Libraries/TranscriptTestRunner/testscript.schema
+++ b/Libraries/TranscriptTestRunner/testscript.schema
@@ -1,0 +1,171 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "description": "Schema for TestScript items.",
+    "additionalProperties": false,
+    "definitions": {
+        "TestScriptItem": {
+            "type": "object",
+            "description": "TestScript item.",
+            "title": "TestScriptItem",
+            "additionalProperties": false,
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The activity type.",
+                    "title": "type",
+                    "oneOf": [
+                        {
+                            "const": "message",
+                            "description": "The type value for message activities.",
+                            "title": "message"
+                        },
+                        {
+                            "const": "contactRelationUpdate",
+                            "description": "The type value for contact relation update activities.",
+                            "title": "contactRelationUpdate"
+                        },
+                        {
+                            "const": "conversationUpdate",
+                            "description": "The type value for conversation update activities.",
+                            "title": "conversationUpdate"
+                        },
+                        {
+                            "const": "typing",
+                            "description": "The type value for typing activities.",
+                            "title": "typing"
+                        },
+                        {
+                            "const": "endOfConversation",
+                            "description": "The type value for end of conversation activities.",
+                            "title": "endOfConversation"
+                        },
+                        {
+                            "const": "event",
+                            "description": "The type value for event activities.",
+                            "title": "event"
+                        },
+                        {
+                            "const": "invoke",
+                            "description": "The type value for invoke activities.",
+                            "title": "invoke"
+                        },
+                        {
+                            "const": "deleteUserData",
+                            "description": "The type value for delete user data activities.",
+                            "title": "deleteUserData"
+                        },
+                        {
+                            "const": "messageUpdate",
+                            "description": "The type value for message update activities.",
+                            "title": "messageUpdate"
+                        },
+                        {
+                            "const": "messageDelete",
+                            "description": "The type value for message delete activities.",
+                            "title": "messageDelete"
+                        },
+                        {
+                            "const": "installationUpdate",
+                            "description": "The type value for installation update activities.",
+                            "title": "installationUpdate"
+                        },
+                        {
+                            "const": "messageReaction",
+                            "description": "The type value for message reaction activities.",
+                            "title": "messageReaction"
+                        },
+                        {
+                            "const": "suggestion",
+                            "description": "The type value for suggestion activities.",
+                            "title": "suggestion"
+                        },
+                        {
+                            "const": "trace",
+                            "description": "The type value for trace activities.",
+                            "title": "trace"
+                        },
+                        {
+                            "const": "handoff",
+                            "description": "The type value for handoff activities.",
+                            "title": "handoff"
+                        }
+                    ]
+                },
+                "role": {
+                    "type": "string",
+                    "description": "Role of the entity behind the account.",
+                    "title": "role",
+                    "oneOf": [
+                        {
+                            "const": "user",
+                            "description": "User"
+                        },
+                        {
+                            "const": "bot",
+                            "description": "Bot"
+                        }
+                    ]
+                },
+                "text": {
+                    "type": "string",
+                    "description": "The text content of the message.",
+                    "title": "text"
+                },
+                "assertions": {
+                    "type": "array",
+                    "title": "Assertions to perform to validate Activity.",
+                    "description": "Sequence of expressions which must evaluate to true.",
+                    "items": {
+                        "$ref": "#/definitions/condition",
+                        "title": "Assertion",
+                        "description": "Assertion as an expression, which must evaluate to true or it will fail the test script."
+                    }
+                }
+            }
+        },
+        "condition": {
+            "$role": "expression",
+            "description": "Boolean constant or expression to evaluate.",
+            "title": "condition",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/expression"
+                }
+            ]
+        },
+        "expression": {
+            "$role": "expression",
+            "type": "string",
+            "description": "Expression to evaluate. More information at\n https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-adaptive-expressions?view=azure-bot-service-4.0&tabs=comparison#operators",
+            "title": "expression",
+            "examples": [
+                "type",
+                "recipient.role",
+                "from.name",
+                "from.role",
+                "text",
+                "inputHint"
+            ]
+        }
+    },
+    "properties": {
+        "$schema": {
+            "type": "string",
+            "description": "Schema.",
+            "title": "$schema"
+        },
+        "items": {
+            "type": "array",
+            "description": "List of TestScript items.",
+            "title": "items",
+            "additionalItems": false,
+            "items": {
+                "$ref": "#/definitions/TestScriptItem"
+            }
+        }
+    }
+}

--- a/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
+++ b/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
@@ -3,8 +3,8 @@
 
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using TranscriptTestRunner;
 using TranscriptTestRunner.XUnit;
@@ -18,6 +18,7 @@ namespace SkillFunctionalTests
     public class SimpleHostBotToEchoSkillTest
     {
         private readonly string _transcriptsFolder = Directory.GetCurrentDirectory() + @"/SourceTranscripts";
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/SourceTestScripts";
         private readonly ILogger<SimpleHostBotToEchoSkillTest> _logger;
 
         public SimpleHostBotToEchoSkillTest(ITestOutputHelper output)

--- a/Tests/SkillFunctionalTests/SkillFunctionalTests.csproj
+++ b/Tests/SkillFunctionalTests/SkillFunctionalTests.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="TestScripts\**" />
+    <EmbeddedResource Remove="TestScripts\**" />
+    <None Remove="TestScripts\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Divergic.Logging.Xunit" Version="3.5.1" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
@@ -37,11 +43,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="TestScripts\" />
+    <None Update="SourceTestScripts/**/*.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Libraries\TranscriptTestRunner\TranscriptTestRunner.csproj" />
   </ItemGroup>
+
+  <ProjectExtensions><VisualStudio><UserProperties /></VisualStudio></ProjectExtensions>
 
 </Project>

--- a/Tests/SkillFunctionalTests/SourceTestScripts/HostReceivesEndOfConversation.json
+++ b/Tests/SkillFunctionalTests/SourceTestScripts/HostReceivesEndOfConversation.json
@@ -1,0 +1,117 @@
+[
+  {
+    "type": "conversationUpdate",
+    "role": "user"
+  },
+  {
+    "type": "message",
+    "role": "bot",
+    "text": "Hello and welcome!",
+    "assertions": [
+      "type == 'message'",
+      "from.role == 'bot'",
+      "recipient.role == 'user'",
+      "text == 'Hello and welcome!'",
+      "inputHint == 'acceptingInput'"
+    ]
+  },
+  {
+    "type": "message",
+    "role": "user",
+    "text": "Hi"
+  },
+  {
+    "type": "message",
+    "role": "bot",
+    "text": "Me no nothin'. Say \"skill\" and I'll patch you through",
+    "assertions": [
+      "type == 'message'",
+      "from.role == 'bot'",
+      "recipient.role == 'user'",
+      "text == 'Me no nothin\\'. Say \"skill\" and I\\'ll patch you through'",
+      "inputHint == 'acceptingInput'"
+    ]
+  },
+  {
+    "type": "message",
+    "role": "user",
+    "text": "skill"
+  },
+  {
+    "type": "message",
+    "role": "bot",
+    "text": "Got it, connecting you to the skill...",
+    "assertions": [
+      "type == 'message'",
+      "from.role == 'bot'",
+      "recipient.role == 'user'",
+      "text == 'Got it, connecting you to the skill...'",
+      "inputHint == 'acceptingInput'"
+    ]
+  },
+  {
+    "type": "message",
+    "role": "bot",
+    "text": "Echo: skill",
+    "assertions": [
+      "type == 'message'",
+      "from.role == 'bot'",
+      "recipient.role == 'user'",
+      "text == 'Echo: skill'",
+      "inputHint == 'acceptingInput'"
+    ]
+  },
+  {
+    "type": "message",
+    "role": "bot",
+    "text": "Say \"end\" or \"stop\" and I'll end the conversation and back to the parent.",
+    "assertions": [
+      "type == 'message'",
+      "from.role == 'bot'",
+      "recipient.role == 'user'",
+      "text == 'Say \"end\" or \"stop\" and I\\'ll end the conversation and back to the parent.'",
+      "inputHint == 'acceptingInput'"
+    ]
+  },
+  {
+    "type": "message",
+    "role": "user",
+    "text": "end"
+  },
+  {
+    "type": "message",
+    "role": "bot",
+    "text": "Ending conversation from the skill...",
+    "assertions": [
+      "type == 'message'",
+      "from.role == 'bot'",
+      "recipient.role == 'user'",
+      "text == 'Ending conversation from the skill...'",
+      "inputHint == 'acceptingInput'"
+    ]
+  },
+  {
+    "type": "message",
+    "role": "bot",
+    "text": "Received endOfConversation.\n\nCode: completedSuccessfully",
+    "assertions": [
+      "type == 'message'",
+      "from.role == 'bot'",
+      "recipient.role == 'user'",
+      "text == 'Received endOfConversation.\n\nCode: completedSuccessfully'",
+      "inputHint == 'acceptingInput'"
+    ]
+  },
+  {
+    "type": "message",
+    "role": "bot",
+    "text": "Back in the host bot. Say \"skill\" and I'll patch you through",
+    "assertions": [
+      "type == 'message'",
+      "from.role == 'bot'",
+      "recipient.role == 'user'",
+      "text == 'Back in the host bot. Say \"skill\" and I\\'ll patch you through'",
+      "inputHint == 'acceptingInput'"
+    ]
+  }
+]

--- a/Tests/SkillFunctionalTests/SourceTestScripts/ShouldRedirectToSkill.json
+++ b/Tests/SkillFunctionalTests/SourceTestScripts/ShouldRedirectToSkill.json
@@ -1,0 +1,76 @@
+[
+  {
+    "type": "conversationUpdate",
+    "role": "user"
+  },
+  {
+    "type": "message",
+    "role": "bot",
+    "text": "Hello and welcome!",
+    "assertions": [
+      "type == 'message'",
+      "from.role == 'bot'",
+      "recipient.role == 'user'",
+      "text == 'Hello and welcome!'",
+      "inputHint == 'acceptingInput'"
+    ]
+  },
+  {
+    "type": "message",
+    "role": "user",
+    "text": "Hi"
+  },
+  {
+    "type": "message",
+    "role": "bot",
+    "text": "Me no nothin'. Say \"skill\" and I'll patch you through",
+    "assertions": [
+      "type == 'message'",
+      "from.role == 'bot'",
+      "recipient.role == 'user'",
+      "text == 'Me no nothin\\'. Say \"skill\" and I\\'ll patch you through'",
+      "inputHint == 'acceptingInput'"
+    ]
+  },
+  {
+    "type": "message",
+    "role": "user",
+    "text": "skill"
+  },
+  {
+    "type": "message",
+    "role": "bot",
+    "text": "Got it, connecting you to the skill...",
+    "assertions": [
+      "type == 'message'",
+      "from.role == 'bot'",
+      "recipient.role == 'user'",
+      "text == 'Got it, connecting you to the skill...'",
+      "inputHint == 'acceptingInput'"
+    ]
+  },
+  {
+    "type": "message",
+    "role": "bot",
+    "text": "Echo: skill",
+    "assertions": [
+      "type == 'message'",
+      "from.role == 'bot'",
+      "recipient.role == 'user'",
+      "text == 'Echo: skill'",
+      "inputHint == 'acceptingInput'"
+    ]
+  },
+  {
+    "type": "message",
+    "role": "bot",
+    "text": "Say \"end\" or \"stop\" and I'll end the conversation and back to the parent.",
+    "assertions": [
+      "type == 'message'",
+      "from.role == 'bot'",
+      "recipient.role == 'user'",
+      "text == 'Say \"end\" or \"stop\" and I\\'ll end the conversation and back to the parent.'",
+      "inputHint == 'acceptingInput'"
+    ]
+  }
+]


### PR DESCRIPTION
## Description
This PR improves the TranscriptConverter class by removing the undesired fields like ids and timestamps, and adding an assertion list to each _TestScriptItem_ of the TestScrip.
Also, fixes an issue where the _from.role_ and _recipient.role_ properties were not set on the bot's activity.

### Detailed Changes
- **TranscriptConverter**:
   - Added logic to remove the undesired fields (ids, timestamps and URLs).
   - Created TestScriptItem's assertion list base on each bot activity properties.
- **DirectLineTestClient**: Set the _from.role_ and _recipient.role_ properties when pulling the bot's activities.
- **TestRunner**:
   - Added validation to run the converter only when receiving a .transcript file.
   - Used **_Adaptive Expressions_** for the assertions in _AssertActivityAsync_ method.
- **XUnitTestRunner**: Used **_Adaptive Expressions_** for the assertions in _AssertActivityAsync_ method.
- **TestScriptItem**: Added a list of assertions.

Also, added **testscript.schema** with the JSON schema for the TestScript file.
Added _HostReceivesEndOfConversation.json_ and _ShouldRedirectToSkill.json_ test scripts.

## Testing
This image shows the tests passing after the changes made:
![image](https://user-images.githubusercontent.com/44245136/97909625-4e542700-1d27-11eb-84c5-d9147bc9f668.png)
