### PR TITLE
Fix skills functional test pipelines

### DIFF
--- a/SkillsFunctionalTests/dotnet/2.1/host/DeploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/dotnet/2.1/host/DeploymentTemplates/template-with-new-rg.json
@@ -76,7 +76,8 @@
         "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
     },
     "resources": [
         {
@@ -96,96 +97,36 @@
             ],
             "properties": {
                 "mode": "Incremental",
-                "expressionEvaluationOptions": {
-                    "scope": "inner"
-                },
-                "parameters": {
-                    "appIdForTemplate": {
-                        "value": "[parameters('appId')]"
-                    },
-                    "appServicePlanNameForTemplate": {
-                        "value": "[variables('appServicePlanName')]"
-                    },
-                    "appSecretForTemplate": {
-                        "value": "[parameters('appSecret')]"
-                    },
-                    "botEndPointForTemplate": {
-                        "value": "[variables('botEndpoint')]"
-                    },
-                    "botIdForTemplate": {
-                        "value": "[parameters('botId')]"
-                    },
-                    "botSkuForTemplate": {
-                        "value": "[parameters('botSku')]"
-                    },
-                    "resourcesLocationForTemplate": {
-                        "value": "[variables('resourcesLocation')]"
-                    },
-                    "newAppServicePlanSkuForTemplate": {
-                        "value": "[parameters('newAppServicePlanSku')]"
-                    },
-                    "webAppNameForTemplate": {
-                        "value": "[variables('webAppName')]"
-                    }
-                },
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                    "parameters": {
-                        "appIdForTemplate": {
-                            "type": "string"
-                        },
-                        "appServicePlanNameForTemplate": {
-                            "type": "string"
-                        },
-                        "appSecretForTemplate": {
-                            "type": "string"
-                        },
-                        "botEndPointForTemplate": {
-                            "type": "string"
-                        },
-                        "botIdForTemplate": {
-                            "type": "string"
-                        },
-                        "botSkuForTemplate": {
-                            "type": "string"
-                        },
-                        "resourcesLocationForTemplate": {
-                            "type": "string"
-                        },
-                        "newAppServicePlanSkuForTemplate": {
-                            "type": "object"
-                        },
-                        "webAppNameForTemplate": {
-                            "type": "string"
-                        }
-                    },
+                    "parameters": {},
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new App Service Plan",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[parameters('appServicePlanNameForTemplate')]",
+                            "name": "[variables('appServicePlanName')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
-                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
                             "properties": {
-                                "name": "[parameters('appServicePlanNameForTemplate')]"
+                                "name": "[variables('appServicePlanName')]"
                             }
                         },
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
-                            "name": "[parameters('webAppNameForTemplate')]",
+                            "name": "[variables('webAppName')]",
                             "properties": {
-                                "name": "[parameters('webAppNameForTemplate')]",
-                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
@@ -194,11 +135,11 @@
                                         },
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appIdForTemplate')]"
+                                            "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecretForTemplate')]"
+                                            "value": "[parameters('appSecret')]"
                                         }
                                     ],
                                     "cors": {
@@ -214,24 +155,24 @@
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botIdForTemplate')]",
+                            "name": "[parameters('botId')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSkuForTemplate')]"
+                                "name": "[parameters('botSku')]"
                             },
                             "properties": {
-                                "name": "[parameters('botIdForTemplate')]",
-                                "displayName": "[parameters('botIdForTemplate')]",
-                                "endpoint": "[parameters('botEndpointForTemplate')]",
-                                "msaAppId": "[parameters('appIdForTemplate')]",
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/dotnet/2.1/host/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/SkillsFunctionalTests/dotnet/2.1/host/DeploymentTemplates/template-with-preexisting-rg.json
@@ -60,13 +60,6 @@
                 "description": "Name of the existing App Service Plan used to create the Web App for the bot."
             }
         },
-        "existingAppServicePlanResourceGroup": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Name of the resource group for the existing App Service Plan used to create the Web App for the bot."
-            }
-        },        
         "newWebAppName": {
             "type": "string",
             "defaultValue": "",
@@ -104,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[concat('/subscriptions/', Subscription().SubscriptionId,'/resourceGroups/', parameters('existingAppServicePlanResourceGroup'), '/providers/Microsoft.Web/serverfarms/', variables('servicePlanName'))]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/SkillsFunctionalTests/dotnet/2.1/skill/DeploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/dotnet/2.1/skill/DeploymentTemplates/template-with-new-rg.json
@@ -76,7 +76,8 @@
         "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
     },
     "resources": [
         {
@@ -96,96 +97,36 @@
             ],
             "properties": {
                 "mode": "Incremental",
-                "expressionEvaluationOptions": {
-                    "scope": "inner"
-                },
-                "parameters": {
-                    "appIdForTemplate": {
-                        "value": "[parameters('appId')]"
-                    },
-                    "appServicePlanNameForTemplate": {
-                        "value": "[variables('appServicePlanName')]"
-                    },
-                    "appSecretForTemplate": {
-                        "value": "[parameters('appSecret')]"
-                    },
-                    "botEndPointForTemplate": {
-                        "value": "[variables('botEndpoint')]"
-                    },
-                    "botIdForTemplate": {
-                        "value": "[parameters('botId')]"
-                    },
-                    "botSkuForTemplate": {
-                        "value": "[parameters('botSku')]"
-                    },
-                    "resourcesLocationForTemplate": {
-                        "value": "[variables('resourcesLocation')]"
-                    },
-                    "newAppServicePlanSkuForTemplate": {
-                        "value": "[parameters('newAppServicePlanSku')]"
-                    },
-                    "webAppNameForTemplate": {
-                        "value": "[variables('webAppName')]"
-                    }
-                },
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                    "parameters": {
-                        "appIdForTemplate": {
-                            "type": "string"
-                        },
-                        "appServicePlanNameForTemplate": {
-                            "type": "string"
-                        },
-                        "appSecretForTemplate": {
-                            "type": "string"
-                        },
-                        "botEndPointForTemplate": {
-                            "type": "string"
-                        },
-                        "botIdForTemplate": {
-                            "type": "string"
-                        },
-                        "botSkuForTemplate": {
-                            "type": "string"
-                        },
-                        "resourcesLocationForTemplate": {
-                            "type": "string"
-                        },
-                        "newAppServicePlanSkuForTemplate": {
-                            "type": "object"
-                        },
-                        "webAppNameForTemplate": {
-                            "type": "string"
-                        }
-                    },
+                    "parameters": {},
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new App Service Plan",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[parameters('appServicePlanNameForTemplate')]",
+                            "name": "[variables('appServicePlanName')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
-                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
                             "properties": {
-                                "name": "[parameters('appServicePlanNameForTemplate')]"
+                                "name": "[variables('appServicePlanName')]"
                             }
                         },
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
-                            "name": "[parameters('webAppNameForTemplate')]",
+                            "name": "[variables('webAppName')]",
                             "properties": {
-                                "name": "[parameters('webAppNameForTemplate')]",
-                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
@@ -194,11 +135,11 @@
                                         },
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appIdForTemplate')]"
+                                            "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecretForTemplate')]"
+                                            "value": "[parameters('appSecret')]"
                                         }
                                     ],
                                     "cors": {
@@ -214,24 +155,24 @@
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botIdForTemplate')]",
+                            "name": "[parameters('botId')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSkuForTemplate')]"
+                                "name": "[parameters('botSku')]"
                             },
                             "properties": {
-                                "name": "[parameters('botIdForTemplate')]",
-                                "displayName": "[parameters('botIdForTemplate')]",
-                                "endpoint": "[parameters('botEndpointForTemplate')]",
-                                "msaAppId": "[parameters('appIdForTemplate')]",
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/dotnet/2.1/skill/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/SkillsFunctionalTests/dotnet/2.1/skill/DeploymentTemplates/template-with-preexisting-rg.json
@@ -60,13 +60,6 @@
                 "description": "Name of the existing App Service Plan used to create the Web App for the bot."
             }
         },
-        "existingAppServicePlanResourceGroup": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Name of the resource group for the existing App Service Plan used to create the Web App for the bot."
-            }
-        },        
         "newWebAppName": {
             "type": "string",
             "defaultValue": "",
@@ -104,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[concat('/subscriptions/', Subscription().SubscriptionId,'/resourceGroups/', parameters('existingAppServicePlanResourceGroup'), '/providers/Microsoft.Web/serverfarms/', variables('servicePlanName'))]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/SkillsFunctionalTests/dotnet/3.1/host/DeploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/dotnet/3.1/host/DeploymentTemplates/template-with-new-rg.json
@@ -76,7 +76,8 @@
         "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
     },
     "resources": [
         {
@@ -96,96 +97,36 @@
             ],
             "properties": {
                 "mode": "Incremental",
-                "expressionEvaluationOptions": {
-                    "scope": "inner"
-                },
-                "parameters": {
-                    "appIdForTemplate": {
-                        "value": "[parameters('appId')]"
-                    },
-                    "appServicePlanNameForTemplate": {
-                        "value": "[variables('appServicePlanName')]"
-                    },
-                    "appSecretForTemplate": {
-                        "value": "[parameters('appSecret')]"
-                    },
-                    "botEndPointForTemplate": {
-                        "value": "[variables('botEndpoint')]"
-                    },
-                    "botIdForTemplate": {
-                        "value": "[parameters('botId')]"
-                    },
-                    "botSkuForTemplate": {
-                        "value": "[parameters('botSku')]"
-                    },
-                    "resourcesLocationForTemplate": {
-                        "value": "[variables('resourcesLocation')]"
-                    },
-                    "newAppServicePlanSkuForTemplate": {
-                        "value": "[parameters('newAppServicePlanSku')]"
-                    },
-                    "webAppNameForTemplate": {
-                        "value": "[variables('webAppName')]"
-                    }
-                },
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                    "parameters": {
-                        "appIdForTemplate": {
-                            "type": "string"
-                        },
-                        "appServicePlanNameForTemplate": {
-                            "type": "string"
-                        },
-                        "appSecretForTemplate": {
-                            "type": "string"
-                        },
-                        "botEndPointForTemplate": {
-                            "type": "string"
-                        },
-                        "botIdForTemplate": {
-                            "type": "string"
-                        },
-                        "botSkuForTemplate": {
-                            "type": "string"
-                        },
-                        "resourcesLocationForTemplate": {
-                            "type": "string"
-                        },
-                        "newAppServicePlanSkuForTemplate": {
-                            "type": "object"
-                        },
-                        "webAppNameForTemplate": {
-                            "type": "string"
-                        }
-                    },
+                    "parameters": {},
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new App Service Plan",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[parameters('appServicePlanNameForTemplate')]",
+                            "name": "[variables('appServicePlanName')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
-                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
                             "properties": {
-                                "name": "[parameters('appServicePlanNameForTemplate')]"
+                                "name": "[variables('appServicePlanName')]"
                             }
                         },
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
-                            "name": "[parameters('webAppNameForTemplate')]",
+                            "name": "[variables('webAppName')]",
                             "properties": {
-                                "name": "[parameters('webAppNameForTemplate')]",
-                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
@@ -194,11 +135,11 @@
                                         },
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appIdForTemplate')]"
+                                            "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecretForTemplate')]"
+                                            "value": "[parameters('appSecret')]"
                                         }
                                     ],
                                     "cors": {
@@ -214,24 +155,24 @@
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botIdForTemplate')]",
+                            "name": "[parameters('botId')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSkuForTemplate')]"
+                                "name": "[parameters('botSku')]"
                             },
                             "properties": {
-                                "name": "[parameters('botIdForTemplate')]",
-                                "displayName": "[parameters('botIdForTemplate')]",
-                                "endpoint": "[parameters('botEndpointForTemplate')]",
-                                "msaAppId": "[parameters('appIdForTemplate')]",
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/dotnet/3.1/host/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/SkillsFunctionalTests/dotnet/3.1/host/DeploymentTemplates/template-with-preexisting-rg.json
@@ -60,13 +60,6 @@
                 "description": "Name of the existing App Service Plan used to create the Web App for the bot."
             }
         },
-        "existingAppServicePlanResourceGroup": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Name of the resource group for the existing App Service Plan used to create the Web App for the bot."
-            }
-        },        
         "newWebAppName": {
             "type": "string",
             "defaultValue": "",
@@ -104,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[concat('/subscriptions/', Subscription().SubscriptionId,'/resourceGroups/', parameters('existingAppServicePlanResourceGroup'), '/providers/Microsoft.Web/serverfarms/', variables('servicePlanName'))]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/SkillsFunctionalTests/dotnet/3.1/skill/DeploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/dotnet/3.1/skill/DeploymentTemplates/template-with-new-rg.json
@@ -76,7 +76,8 @@
         "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
     },
     "resources": [
         {
@@ -96,96 +97,36 @@
             ],
             "properties": {
                 "mode": "Incremental",
-                "expressionEvaluationOptions": {
-                    "scope": "inner"
-                },
-                "parameters": {
-                    "appIdForTemplate": {
-                        "value": "[parameters('appId')]"
-                    },
-                    "appServicePlanNameForTemplate": {
-                        "value": "[variables('appServicePlanName')]"
-                    },
-                    "appSecretForTemplate": {
-                        "value": "[parameters('appSecret')]"
-                    },
-                    "botEndPointForTemplate": {
-                        "value": "[variables('botEndpoint')]"
-                    },
-                    "botIdForTemplate": {
-                        "value": "[parameters('botId')]"
-                    },
-                    "botSkuForTemplate": {
-                        "value": "[parameters('botSku')]"
-                    },
-                    "resourcesLocationForTemplate": {
-                        "value": "[variables('resourcesLocation')]"
-                    },
-                    "newAppServicePlanSkuForTemplate": {
-                        "value": "[parameters('newAppServicePlanSku')]"
-                    },
-                    "webAppNameForTemplate": {
-                        "value": "[variables('webAppName')]"
-                    }
-                },
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                    "parameters": {
-                        "appIdForTemplate": {
-                            "type": "string"
-                        },
-                        "appServicePlanNameForTemplate": {
-                            "type": "string"
-                        },
-                        "appSecretForTemplate": {
-                            "type": "string"
-                        },
-                        "botEndPointForTemplate": {
-                            "type": "string"
-                        },
-                        "botIdForTemplate": {
-                            "type": "string"
-                        },
-                        "botSkuForTemplate": {
-                            "type": "string"
-                        },
-                        "resourcesLocationForTemplate": {
-                            "type": "string"
-                        },
-                        "newAppServicePlanSkuForTemplate": {
-                            "type": "object"
-                        },
-                        "webAppNameForTemplate": {
-                            "type": "string"
-                        }
-                    },
+                    "parameters": {},
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new App Service Plan",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[parameters('appServicePlanNameForTemplate')]",
+                            "name": "[variables('appServicePlanName')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
-                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
                             "properties": {
-                                "name": "[parameters('appServicePlanNameForTemplate')]"
+                                "name": "[variables('appServicePlanName')]"
                             }
                         },
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
-                            "name": "[parameters('webAppNameForTemplate')]",
+                            "name": "[variables('webAppName')]",
                             "properties": {
-                                "name": "[parameters('webAppNameForTemplate')]",
-                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
@@ -194,11 +135,11 @@
                                         },
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appIdForTemplate')]"
+                                            "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecretForTemplate')]"
+                                            "value": "[parameters('appSecret')]"
                                         }
                                     ],
                                     "cors": {
@@ -214,24 +155,24 @@
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botIdForTemplate')]",
+                            "name": "[parameters('botId')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSkuForTemplate')]"
+                                "name": "[parameters('botSku')]"
                             },
                             "properties": {
-                                "name": "[parameters('botIdForTemplate')]",
-                                "displayName": "[parameters('botIdForTemplate')]",
-                                "endpoint": "[parameters('botEndpointForTemplate')]",
-                                "msaAppId": "[parameters('appIdForTemplate')]",
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/dotnet/3.1/skill/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/SkillsFunctionalTests/dotnet/3.1/skill/DeploymentTemplates/template-with-preexisting-rg.json
@@ -60,13 +60,6 @@
                 "description": "Name of the existing App Service Plan used to create the Web App for the bot."
             }
         },
-        "existingAppServicePlanResourceGroup": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Name of the resource group for the existing App Service Plan used to create the Web App for the bot."
-            }
-        },        
         "newWebAppName": {
             "type": "string",
             "defaultValue": "",
@@ -104,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[concat('/subscriptions/', Subscription().SubscriptionId,'/resourceGroups/', parameters('existingAppServicePlanResourceGroup'), '/providers/Microsoft.Web/serverfarms/', variables('servicePlanName'))]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/SkillsFunctionalTests/javascript/host/deploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/javascript/host/deploymentTemplates/template-with-new-rg.json
@@ -76,7 +76,8 @@
         "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
     },
     "resources": [
         {
@@ -84,8 +85,7 @@
             "type": "Microsoft.Resources/resourceGroups",
             "apiVersion": "2018-05-01",
             "location": "[parameters('groupLocation')]",
-            "properties": {
-            }
+            "properties": {}
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -95,100 +95,38 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
             ],
-
             "properties": {
                 "mode": "Incremental",
-				"expressionEvaluationOptions": {
-					"scope": "inner"
-				},
-				"parameters": {
-					"appIdForTemplate": {
-						"value": "[parameters('appId')]"
-					},
-					"appServicePlanNameForTemplate": {
-						"value": "[variables('appServicePlanName')]"
-					},
-					"appSecretForTemplate": {
-						"value": "[parameters('appSecret')]"
-					},
-					"botEndPointForTemplate": {
-						"value": "[variables('botEndpoint')]"
-					},
-					"botIdForTemplate": {
-						"value": "[parameters('botId')]"
-					},
-					"botSkuForTemplate": {
-						"value": "[parameters('botSku')]"
-					},
-					"resourcesLocationForTemplate": {
-						"value": "[variables('resourcesLocation')]"
-					},
-					"newAppServicePlanSkuForTemplate":{
-						"value": "[parameters('newAppServicePlanSku')]"
-					},
-					"webAppNameForTemplate": {
-						"value": "[variables('webAppName')]"
-					}
-				},
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-					"parameters": {
-						"appIdForTemplate": {
-							"type": "string"
-						},
-						"appServicePlanNameForTemplate": {
-							"type": "string"
-						},
-						"appSecretForTemplate": {
-							"type": "string"
-						},
-						"botEndPointForTemplate": {
-							"type": "string"
-						},
-						"botIdForTemplate": {
-							"type": "string"
-						},
-						"botSkuForTemplate": {
-							"type": "string"
-						},
-						"resourcesLocationForTemplate": {
-							"type": "string"
-						},
-						"newAppServicePlanSkuForTemplate": {
-							"type": "object"
-						},
-						"webAppNameForTemplate": {
-							"type": "string"
-						}
-							
-					},
+                    "parameters": {},
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new App Service Plan",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[parameters('appServicePlanNameForTemplate')]",
+                            "name": "[variables('appServicePlanName')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
-                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
                             "properties": {
-                                "name": "[parameters('appServicePlanNameForTemplate')]"
+                                "name": "[variables('appServicePlanName')]"
                             }
                         },
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
-                            "name": "[parameters('webAppNameForTemplate')]",
+                            "name": "[variables('webAppName')]",
                             "properties": {
-                                "name": "[parameters('webAppNameForTemplate')]",
-                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
@@ -197,11 +135,11 @@
                                         },
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appIdForTemplate')]"
+                                            "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecretForTemplate')]"
+                                            "value": "[parameters('appSecret')]"
                                         }
                                     ],
                                     "cors": {
@@ -209,31 +147,32 @@
                                             "https://botservice.hosting.portal.azure.net",
                                             "https://hosting.onecloud.azure-test.net/"
                                         ]
-                                    }
+                                    },
+                                    "webSocketsEnabled": true
                                 }
                             }
                         },
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botIdForTemplate')]",
+                            "name": "[parameters('botId')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSkuForTemplate')]"
+                                "name": "[parameters('botSku')]"
                             },
                             "properties": {
-                                "name": "[parameters('botIdForTemplate')]",
-                                "displayName": "[parameters('botIdForTemplate')]",
-                                "endpoint": "[parameters('botEndpointForTemplate')]",
-                                "msaAppId": "[parameters('appIdForTemplate')]",
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/javascript/host/deploymentTemplates/template-with-preexisting-rg.json
+++ b/SkillsFunctionalTests/javascript/host/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {
@@ -123,7 +123,8 @@
                             "https://botservice.hosting.portal.azure.net",
                             "https://hosting.onecloud.azure-test.net/"
                         ]
-                    }
+                    },
+                    "webSocketsEnabled": true
                 }
             }
         },

--- a/SkillsFunctionalTests/javascript/skill/deploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/javascript/skill/deploymentTemplates/template-with-new-rg.json
@@ -76,7 +76,8 @@
         "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
     },
     "resources": [
         {
@@ -84,8 +85,7 @@
             "type": "Microsoft.Resources/resourceGroups",
             "apiVersion": "2018-05-01",
             "location": "[parameters('groupLocation')]",
-            "properties": {
-            }
+            "properties": {}
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -97,97 +97,36 @@
             ],
             "properties": {
                 "mode": "Incremental",
-				"expressionEvaluationOptions": {
-					"scope": "inner"
-				},
-				"parameters": {
-					"appIdForTemplate": {
-						"value": "[parameters('appId')]"
-					},
-					"appServicePlanNameForTemplate": {
-						"value": "[variables('appServicePlanName')]"
-					},
-					"appSecretForTemplate": {
-						"value": "[parameters('appSecret')]"
-					},
-					"botEndPointForTemplate": {
-						"value": "[variables('botEndpoint')]"
-					},
-					"botIdForTemplate": {
-						"value": "[parameters('botId')]"
-					},
-					"botSkuForTemplate": {
-						"value": "[parameters('botSku')]"
-					},
-					"resourcesLocationForTemplate": {
-						"value": "[variables('resourcesLocation')]"
-					},
-					"newAppServicePlanSkuForTemplate":{
-						"value": "[parameters('newAppServicePlanSku')]"
-					},
-					"webAppNameForTemplate": {
-						"value": "[variables('webAppName')]"
-					}
-				},
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-					"parameters": {
-						"appIdForTemplate": {
-							"type": "string"
-						},
-						"appServicePlanNameForTemplate": {
-							"type": "string"
-						},
-						"appSecretForTemplate": {
-							"type": "string"
-						},
-						"botEndPointForTemplate": {
-							"type": "string"
-						},
-						"botIdForTemplate": {
-							"type": "string"
-						},
-						"botSkuForTemplate": {
-							"type": "string"
-						},
-						"resourcesLocationForTemplate": {
-							"type": "string"
-						},
-						"newAppServicePlanSkuForTemplate": {
-							"type": "object"
-						},
-						"webAppNameForTemplate": {
-							"type": "string"
-						}
-							
-					},
+                    "parameters": {},
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new App Service Plan",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[parameters('appServicePlanNameForTemplate')]",
+                            "name": "[variables('appServicePlanName')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
-                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
                             "properties": {
-                                "name": "[parameters('appServicePlanNameForTemplate')]"
+                                "name": "[variables('appServicePlanName')]"
                             }
                         },
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
-                            "name": "[parameters('webAppNameForTemplate')]",
+                            "name": "[variables('webAppName')]",
                             "properties": {
-                                "name": "[parameters('webAppNameForTemplate')]",
-                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
@@ -196,11 +135,11 @@
                                         },
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appIdForTemplate')]"
+                                            "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecretForTemplate')]"
+                                            "value": "[parameters('appSecret')]"
                                         }
                                     ],
                                     "cors": {
@@ -208,31 +147,32 @@
                                             "https://botservice.hosting.portal.azure.net",
                                             "https://hosting.onecloud.azure-test.net/"
                                         ]
-                                    }
+                                    },
+                                    "webSocketsEnabled": true
                                 }
                             }
                         },
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botIdForTemplate')]",
+                            "name": "[parameters('botId')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSkuForTemplate')]"
+                                "name": "[parameters('botSku')]"
                             },
                             "properties": {
-                                "name": "[parameters('botIdForTemplate')]",
-                                "displayName": "[parameters('botIdForTemplate')]",
-                                "endpoint": "[parameters('botEndpointForTemplate')]",
-                                "msaAppId": "[parameters('appIdForTemplate')]",
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/javascript/skill/deploymentTemplates/template-with-preexisting-rg.json
+++ b/SkillsFunctionalTests/javascript/skill/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {
@@ -123,7 +123,8 @@
                             "https://botservice.hosting.portal.azure.net",
                             "https://hosting.onecloud.azure-test.net/"
                         ]
-                    }
+                    },
+                    "webSocketsEnabled": true
                 }
             }
         },

--- a/SkillsFunctionalTests/javascript/v3/skill/deploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/javascript/v3/skill/deploymentTemplates/template-with-new-rg.json
@@ -76,7 +76,8 @@
         "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
     },
     "resources": [
         {
@@ -84,8 +85,7 @@
             "type": "Microsoft.Resources/resourceGroups",
             "apiVersion": "2018-05-01",
             "location": "[parameters('groupLocation')]",
-            "properties": {
-            }
+            "properties": {}
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -97,97 +97,36 @@
             ],
             "properties": {
                 "mode": "Incremental",
-				"expressionEvaluationOptions": {
-					"scope": "inner"
-				},
-				"parameters": {
-					"appIdForTemplate": {
-						"value": "[parameters('appId')]"
-					},
-					"appServicePlanNameForTemplate": {
-						"value": "[variables('appServicePlanName')]"
-					},
-					"appSecretForTemplate": {
-						"value": "[parameters('appSecret')]"
-					},
-					"botEndPointForTemplate": {
-						"value": "[variables('botEndpoint')]"
-					},
-					"botIdForTemplate": {
-						"value": "[parameters('botId')]"
-					},
-					"botSkuForTemplate": {
-						"value": "[parameters('botSku')]"
-					},
-					"resourcesLocationForTemplate": {
-						"value": "[variables('resourcesLocation')]"
-					},
-					"newAppServicePlanSkuForTemplate":{
-						"value": "[parameters('newAppServicePlanSku')]"
-					},
-					"webAppNameForTemplate": {
-						"value": "[variables('webAppName')]"
-					}
-				},
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-					"parameters": {
-						"appIdForTemplate": {
-							"type": "string"
-						},
-						"appServicePlanNameForTemplate": {
-							"type": "string"
-						},
-						"appSecretForTemplate": {
-							"type": "string"
-						},
-						"botEndPointForTemplate": {
-							"type": "string"
-						},
-						"botIdForTemplate": {
-							"type": "string"
-						},
-						"botSkuForTemplate": {
-							"type": "string"
-						},
-						"resourcesLocationForTemplate": {
-							"type": "string"
-						},
-						"newAppServicePlanSkuForTemplate": {
-							"type": "object"
-						},
-						"webAppNameForTemplate": {
-							"type": "string"
-						}
-							
-					},
+                    "parameters": {},
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new App Service Plan",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[parameters('appServicePlanNameForTemplate')]",
+                            "name": "[variables('appServicePlanName')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
-                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
                             "properties": {
-                                "name": "[parameters('appServicePlanNameForTemplate')]"
+                                "name": "[variables('appServicePlanName')]"
                             }
                         },
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
-                            "name": "[parameters('webAppNameForTemplate')]",
+                            "name": "[variables('webAppName')]",
                             "properties": {
-                                "name": "[parameters('webAppNameForTemplate')]",
-                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
@@ -196,11 +135,11 @@
                                         },
                                         {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appIdForTemplate')]"
+                                            "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecretForTemplate')]"
+                                            "value": "[parameters('appSecret')]"
                                         }
                                     ],
                                     "cors": {
@@ -208,31 +147,32 @@
                                             "https://botservice.hosting.portal.azure.net",
                                             "https://hosting.onecloud.azure-test.net/"
                                         ]
-                                    }
+                                    },
+                                    "webSocketsEnabled": true
                                 }
                             }
                         },
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botIdForTemplate')]",
+                            "name": "[parameters('botId')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSkuForTemplate')]"
+                                "name": "[parameters('botSku')]"
                             },
                             "properties": {
-                                "name": "[parameters('botIdForTemplate')]",
-                                "displayName": "[parameters('botIdForTemplate')]",
-                                "endpoint": "[parameters('botEndpointForTemplate')]",
-                                "msaAppId": "[parameters('appIdForTemplate')]",
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/javascript/v3/skill/deploymentTemplates/template-with-preexisting-rg.json
+++ b/SkillsFunctionalTests/javascript/v3/skill/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {
@@ -123,7 +123,8 @@
                             "https://botservice.hosting.portal.azure.net",
                             "https://hosting.onecloud.azure-test.net/"
                         ]
-                    }
+                    },
+                    "webSocketsEnabled": true
                 }
             }
         },

--- a/SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json
+++ b/SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json
@@ -77,7 +77,8 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "publishingUsername": "[concat('$', parameters('newWebAppName'))]"
+        "publishingUsername": "[concat('$', parameters('newWebAppName'))]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
     },
     "resources": [
         {
@@ -97,88 +98,22 @@
             ],
             "properties": {
                 "mode": "Incremental",
-                "expressionEvaluationOptions": {
-                    "scope": "inner"
-                },
-                "parameters": {
-                    "appIdForTemplate": {
-                        "value": "[parameters('appId')]"
-                    },
-                    "appServicePlanNameForTemplate": {
-                        "value": "[variables('appServicePlanName')]"
-                    },
-                    "appSecretForTemplate": {
-                        "value": "[parameters('appSecret')]"
-                    },
-                    "botEndPointForTemplate": {
-                        "value": "[variables('botEndpoint')]"
-                    },
-                    "botIdForTemplate": {
-                        "value": "[parameters('botId')]"
-                    },
-                    "botSkuForTemplate": {
-                        "value": "[parameters('botSku')]"
-                    },
-                    "resourcesLocationForTemplate": {
-                        "value": "[variables('resourcesLocation')]"
-                    },
-                    "newAppServicePlanSkuForTemplate": {
-                        "value": "[parameters('newAppServicePlanSku')]"
-                    },
-                    "webAppNameForTemplate": {
-                        "value": "[variables('webAppName')]"
-                    },
-                    "publishingUsernameForTemplate": {
-                        "value": "[variables('publishingUsername')]"
-                    }
-                },
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                    "parameters": {
-                        "appIdForTemplate": {
-                            "type": "string"
-                        },
-                        "appServicePlanNameForTemplate": {
-                            "type": "string"
-                        },
-                        "appSecretForTemplate": {
-                            "type": "string"
-                        },
-                        "botEndPointForTemplate": {
-                            "type": "string"
-                        },
-                        "botIdForTemplate": {
-                            "type": "string"
-                        },
-                        "botSkuForTemplate": {
-                            "type": "string"
-                        },
-                        "resourcesLocationForTemplate": {
-                            "type": "string"
-                        },
-                        "newAppServicePlanSkuForTemplate": {
-                            "type": "object"
-                        },
-                        "webAppNameForTemplate": {
-                            "type": "string"
-                        },
-                        "publishingUsernameForTemplate": {
-                            "type": "string"
-                        }
-                    },
+                    "parameters": {},
                     "variables": {},
                     "resources": [
                         {
                             "comments": "Create a new Linux App Service Plan if no existing App Service Plan name was passed in.",
                             "type": "Microsoft.Web/serverfarms",
-                            "name": "[parameters('appServicePlanNameForTemplate')]",
+                            "name": "[variables('appServicePlanName')]",
                             "apiVersion": "2018-02-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
-                            "sku": "[parameters('newAppServicePlanSkuForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
                             "kind": "linux",
                             "properties": {
-                                "name": "[parameters('appServicePlanNameForTemplate')]",
+                                "name": "[variables('appServicePlanName')]",
                                 "perSiteScaling": false,
                                 "reserved": true,
                                 "targetWorkerCount": 0,
@@ -189,36 +124,40 @@
                             "comments": "Create a Web App using a Linux App Service Plan",
                             "type": "Microsoft.Web/sites",
                             "apiVersion": "2015-08-01",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "location": "[variables('resourcesLocation')]",
                             "kind": "app,linux",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', parameters('appServicePlanNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
-                            "name": "[parameters('webAppNameForTemplate')]",
+                            "name": "[variables('webAppName')]",
                             "properties": {
-                                "name": "[parameters('webAppNameForTemplate')]",
-                                "serverFarmId": "[parameters('appServicePlanNameForTemplate')]",
+                                "name": "[variables('webAppName')]",
                                 "hostNameSslStates": [
                                     {
-                                        "name": "[concat(parameters('webAppNameForTemplate'), '.azurewebsites.net')]",
+                                        "name": "[concat(parameters('newWebAppName'), '.azurewebsites.net')]",
                                         "sslState": "Disabled",
                                         "hostType": "Standard"
                                     },
                                     {
-                                        "name": "[concat(parameters('webAppNameForTemplate'), '.scm.azurewebsites.net')]",
+                                        "name": "[concat(parameters('newWebAppName'), '.scm.azurewebsites.net')]",
                                         "sslState": "Disabled",
                                         "hostType": "Repository"
                                     }
                                 ],
+                                "serverFarmId": "[variables('appServicePlanName')]",
                                 "siteConfig": {
                                     "appSettings": [
                                         {
+                                            "name": "SCM_DO_BUILD_DURING_DEPLOYMENT",
+                                            "value": "true"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
-                                            "value": "[parameters('appIdForTemplate')]"
+                                            "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecretForTemplate')]"
+                                            "value": "[parameters('appSecret')]"
                                         }
                                     ],
                                     "cors": {
@@ -233,10 +172,10 @@
                         {
                             "type": "Microsoft.Web/sites/config",
                             "apiVersion": "2016-08-01",
-                            "name": "[concat(parameters('webAppNameForTemplate'), '/web')]",
-                            "location": "[parameters('resourcesLocationForTemplate')]",
+                            "name": "[concat(variables('webAppName'), '/web')]",
+                            "location": "[variables('resourcesLocation')]",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites', parameters('webAppNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ],
                             "properties": {
                                 "numberOfWorkers": 1,
@@ -262,7 +201,7 @@
                                 "httpLoggingEnabled": true,
                                 "logsDirectorySizeLimit": 35,
                                 "detailedErrorLoggingEnabled": false,
-                                "publishingUsername": "[parameters('publishingUsernameForTemplate')]",
+                                "publishingUsername": "[variables('publishingUsername')]",
                                 "scmType": "None",
                                 "use32BitWorkerProcess": true,
                                 "webSocketsEnabled": false,
@@ -296,24 +235,24 @@
                         {
                             "apiVersion": "2017-12-01",
                             "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botIdForTemplate')]",
+                            "name": "[parameters('botId')]",
                             "location": "global",
                             "kind": "bot",
                             "sku": {
-                                "name": "[parameters('botSkuForTemplate')]"
+                                "name": "[parameters('botSku')]"
                             },
                             "properties": {
-                                "name": "[parameters('botIdForTemplate')]",
-                                "displayName": "[parameters('botIdForTemplate')]",
-                                "endpoint": "[parameters('botEndpointForTemplate')]",
-                                "msaAppId": "[parameters('appIdForTemplate')]",
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
                                 "developerAppInsightsApplicationId": null,
                                 "developerAppInsightKey": null,
                                 "publishingCredentials": null,
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', parameters('webAppNameForTemplate'))]"
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
                         }
                     ],

--- a/SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-preexisting-rg.json
+++ b/SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/build/yaml/dotnetDeploySteps.yml
+++ b/build/yaml/dotnetDeploySteps.yml
@@ -10,13 +10,17 @@ steps:
     arguments: '--output $(System.DefaultWorkingDirectory)\publishedbot\$(BotName)'
     modifyOutputPath: false
 
-- task: AzureCLI@1
-  displayName: 'Create resource group'
+- task: AzureCLI@2
+  displayName: 'create Azure resources - new RG template'
   inputs:
     azureSubscription: $(AzureSubscription)
+    scriptType: ps
     scriptLocation: inlineScript
     inlineScript: |
-     call az deployment create --name $(BotName) --template-file "$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotName)-RG" groupLocation="westus" newAppServicePlanLocation="westus"
+     Set-PSDebug -Trace 1;
+     # set up resource group, bot channels registration, app service, app service plan
+     az deployment sub create --name "$(BotName)$(Build.BuildId)" --template-file "$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus"
+     Set-PSDebug -Trace 0;
 
 - task: AzureCLI@1
   displayName: 'Deploy bot'

--- a/build/yaml/dotnetHost2DotnetV3Skill.yml
+++ b/build/yaml/dotnetHost2DotnetV3Skill.yml
@@ -9,8 +9,8 @@ pr: none
 
 variables:
   BotGroup: '$(BotName)-RG'
-  BuildPlatform: 'any cpu'
   BuildConfiguration: 'Debug'
+  BuildPlatform: 'any cpu'
   CodesignValidation: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure

--- a/build/yaml/dotnetHost2DotnetV3Skill.yml
+++ b/build/yaml/dotnetHost2DotnetV3Skill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure

--- a/build/yaml/dotnetHost2DotnetV3Skill.yml
+++ b/build/yaml/dotnetHost2DotnetV3Skill.yml
@@ -8,6 +8,7 @@ trigger: none
 pr: none
 
 variables:
+  BotGroup: '$(BotName)-RG'
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'Debug'
   CodesignValidation: false

--- a/build/yaml/dotnetHost2DotnetV3Skill.yml
+++ b/build/yaml/dotnetHost2DotnetV3Skill.yml
@@ -74,6 +74,7 @@ stages:
   dependsOn:
   - Prepare
   - Build
+  condition: succeeded('Build')
   jobs:
     - job: Deploy_Host
       variables:

--- a/build/yaml/dotnetHost2DotnetV3Skill.yml
+++ b/build/yaml/dotnetHost2DotnetV3Skill.yml
@@ -10,6 +10,7 @@ pr: none
 variables:
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'Debug'
+  CodesignValidation: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
@@ -40,7 +41,7 @@ stages:
       - template: cleanResourcesStep.yml
 
 - stage: Build
-  condition: succeededOrFailed()
+  dependsOn: []    # makes this run in parallel
   jobs:
     - job: Validate_Host_NetCore_Version
       variables:

--- a/build/yaml/dotnetHost2DotnetV3Skill.yml
+++ b/build/yaml/dotnetHost2DotnetV3Skill.yml
@@ -1,5 +1,5 @@
 #
-# Build a C# Host bot and a v3 C# Skill bot. Optionally deploy them and run functional tests.
+# Build a C# Host bot and a v3 C# Skill bot. Deploy them and run functional tests.
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
@@ -10,7 +10,6 @@ pr: none
 variables:
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'Debug'
-  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
@@ -21,20 +20,17 @@ variables:
   # DotNetDotNetV3SkillAppId: define in Azure
   # DotNetDotNetV3SkillAppSecret: define in Azure
   # DotNetDotNetV3SkillBotName: define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
   # NetCoreSdkVersionHost: define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # RegistryUrlHost (Optional): define this in Azure
   # RegistryUrlSkill (Optional): define this in Azure
   # TestFilter: (optional) define in Azure. Example: '&TestCategory!=SkipForV3Bots'
-  # TriggeredBy: define in Azure and set to an empty string
 
 pool:
   vmImage: 'windows-2019'
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -50,15 +46,6 @@ stages:
       variables:
         Parameters.netCoreSdkVersion: $(NetCoreSdkVersionHost)
       steps:
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
-        inputs:
-          tags: |
-            TriggeredReason=$(TriggeredReason)
-            $(TriggeredBy)
-            NextBuild=$(NextBuild)
-        continueOnError: true
-
       - template: dotnetValidateNetCoreSdkVersion.yml
 
     - job: Build_Host_Bot
@@ -83,7 +70,9 @@ stages:
       - template: dotnetV3TagBotBuilderVersion.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  dependsOn:
+  - Prepare
+  - Build
   jobs:
     - job: Deploy_Host
       variables:
@@ -131,7 +120,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -143,21 +132,3 @@ stages:
           inlineScript: |
            call az group delete -n "$(DotNetDotNetV3HostBotName)-RG" --yes
            call az group delete -n "$(DotNetDotNetV3SkillBotName)-RG" --yes
-        condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
-
-- stage: QueueNext
-  condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
-  jobs:
-    - job: TriggerBuild
-      steps:
-      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-        displayName: 'Trigger build $(NextBuild)'
-        inputs:
-          buildDefinition: '$(NextBuild)'
-          queueBuildForUserThatTriggeredBuild: true
-          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
-          password: '$(ExecutePipelinesPersonalAccessToken)'
-          enableBuildInQueueCondition: true
-          blockingBuildsList: '$(NextBuild)'
-        continueOnError: true
-        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))

--- a/build/yaml/dotnetHost2JavascriptSkill.yml
+++ b/build/yaml/dotnetHost2JavascriptSkill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure

--- a/build/yaml/dotnetHost2JavascriptSkill.yml
+++ b/build/yaml/dotnetHost2JavascriptSkill.yml
@@ -1,5 +1,5 @@
 #
-# Build a C# Host bot. Optionally deploy it and a Js Skill bot and run functional tests.
+# Build a C# Host bot. Deploy it and a Js Skill bot and run functional tests.
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
@@ -10,7 +10,6 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
@@ -21,20 +20,17 @@ variables:
   # DotNetJsSkillAppId: define in Azure
   # DotNetJsSkillAppSecret: define in Azure
   # DotNetJsSkillBotName: define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
   # NetCoreSdkVersionHost: define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # RegistryUrlSkill (Optional): define this in Azure
   # RegistryUrlHost (Optional): define this in Azure  
   # TestFilter: (optional) define in Azure. Example: '&TestCategory!=SkipForV3Bots'
-  # TriggeredBy: define in Azure and set to an empty string
 
 pool:
   vmImage: 'windows-2019'
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -50,15 +46,6 @@ stages:
       variables:
         Parameters.netCoreSdkVersion: $(NetCoreSdkVersionHost)
       steps:
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
-        inputs:
-          tags: |
-            TriggeredReason=$(TriggeredReason)
-            $(TriggeredBy)
-            NextBuild=$(NextBuild)
-        continueOnError: true
-
       - template: dotnetValidateNetCoreSdkVersion.yml
 
     - job: Build_Host_Bot
@@ -74,7 +61,9 @@ stages:
       - template: dotnetTagBotBuilderVersion.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  dependsOn:
+  - Prepare
+  - Build
   jobs:
     - job: Deploy_Host
       variables:
@@ -134,7 +123,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -146,21 +135,3 @@ stages:
           inlineScript: |
            call az group delete -n "$(DotNetJsHostBotName)-RG" --yes
            call az group delete -n "$(DotNetJsSkillBotName)-RG" --yes
-        condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
-
-- stage: QueueNext
-  condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
-  jobs:
-    - job: TriggerBuild
-      steps:
-      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-        displayName: 'Trigger build $(NextBuild)'
-        inputs:
-          buildDefinition: '$(NextBuild)'
-          queueBuildForUserThatTriggeredBuild: true
-          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
-          password: '$(ExecutePipelinesPersonalAccessToken)'
-          enableBuildInQueueCondition: true
-          blockingBuildsList: '$(NextBuild)'
-        continueOnError: true
-        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))

--- a/build/yaml/dotnetHost2JavascriptSkill.yml
+++ b/build/yaml/dotnetHost2JavascriptSkill.yml
@@ -10,6 +10,7 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
+  CodesignValidation: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
@@ -40,7 +41,7 @@ stages:
       - template: cleanResourcesStep.yml
 
 - stage: Build
-  condition: succeededOrFailed()
+  dependsOn: []    # makes this run in parallel
   jobs:
     - job: Validate_Host_NetCore_Version
       variables:

--- a/build/yaml/dotnetHost2JavascriptSkill.yml
+++ b/build/yaml/dotnetHost2JavascriptSkill.yml
@@ -8,6 +8,7 @@ trigger: none
 pr: none
 
 variables:
+  BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
   CodesignValidation: false

--- a/build/yaml/dotnetHost2JavascriptSkill.yml
+++ b/build/yaml/dotnetHost2JavascriptSkill.yml
@@ -65,6 +65,7 @@ stages:
   dependsOn:
   - Prepare
   - Build
+  condition: succeeded('Build')
   jobs:
     - job: Deploy_Host
       variables:

--- a/build/yaml/dotnetHost2JavascriptV3Skill.yml
+++ b/build/yaml/dotnetHost2JavascriptV3Skill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure

--- a/build/yaml/dotnetHost2JavascriptV3Skill.yml
+++ b/build/yaml/dotnetHost2JavascriptV3Skill.yml
@@ -10,6 +10,7 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
+  CodesignValidation: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
@@ -40,7 +41,7 @@ stages:
       - template: cleanResourcesStep.yml
 
 - stage: Build
-  condition: succeededOrFailed()
+  dependsOn: []    # makes this run in parallel
   jobs:
     - job: Validate_Host_NetCore_Version
       variables:

--- a/build/yaml/dotnetHost2JavascriptV3Skill.yml
+++ b/build/yaml/dotnetHost2JavascriptV3Skill.yml
@@ -8,6 +8,7 @@ trigger: none
 pr: none
 
 variables:
+  BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
   CodesignValidation: false

--- a/build/yaml/dotnetHost2JavascriptV3Skill.yml
+++ b/build/yaml/dotnetHost2JavascriptV3Skill.yml
@@ -1,5 +1,5 @@
 #
-# Build a C# Host bot. Optionally deploy it and a V3 Js Skill bot and run functional tests.
+# Build a C# Host bot. Deploy it and a V3 Js Skill bot and run functional tests.
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
@@ -10,7 +10,6 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
@@ -21,20 +20,17 @@ variables:
   # DotNetJsV3SkillAppId: define in Azure
   # DotNetJsV3SkillAppSecret: define in Azure
   # DotNetJsV3SkillBotName: define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
   # NetCoreSdkVersionHost: define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # RegistryUrlSkill (Optional): define this in Azure
   # RegistryUrlHost (Optional): define this in Azure  
   # TestFilter: (optional) define in Azure. Example: '&TestCategory!=SkipForV3Bots'
-  # TriggeredBy: define in Azure and set to an empty string
 
 pool:
   vmImage: 'windows-2019'
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -44,21 +40,12 @@ stages:
       - template: cleanResourcesStep.yml
 
 - stage: Build
-  condition: always()
+  condition: succeededOrFailed()
   jobs:
     - job: Validate_Host_NetCore_Version
       variables:
         Parameters.netCoreSdkVersion: $(NetCoreSdkVersionHost)
       steps:
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
-        inputs:
-          tags: |
-            TriggeredReason=$(TriggeredReason)
-            $(TriggeredBy)
-            NextBuild=$(NextBuild)
-        continueOnError: true
-
       - template: dotnetValidateNetCoreSdkVersion.yml
 
     - job: Build_Host_Bot
@@ -74,7 +61,9 @@ stages:
       - template: dotnetTagBotBuilderVersion.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  dependsOn:
+  - Prepare
+  - Build
   jobs:
     - job: Deploy_Host
       variables:
@@ -121,7 +110,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -134,20 +123,3 @@ stages:
            call az group delete -n "$(DotNetJsV3HostBotName)-RG" --yes
            call az group delete -n "$(DotNetJsV3SkillBotName)-RG" --yes
         condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
-
-- stage: QueueNext
-  condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
-  jobs:
-    - job: TriggerBuild
-      steps:
-      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-        displayName: 'Trigger build $(NextBuild)'
-        inputs:
-          buildDefinition: '$(NextBuild)'
-          queueBuildForUserThatTriggeredBuild: true
-          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
-          password: '$(ExecutePipelinesPersonalAccessToken)'
-          enableBuildInQueueCondition: true
-          blockingBuildsList: '$(NextBuild)'
-        continueOnError: true
-        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))

--- a/build/yaml/dotnetHost2JavascriptV3Skill.yml
+++ b/build/yaml/dotnetHost2JavascriptV3Skill.yml
@@ -65,6 +65,7 @@ stages:
   dependsOn:
   - Prepare
   - Build
+  condition: succeeded('Build')
   jobs:
     - job: Deploy_Host
       variables:

--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -8,8 +8,10 @@ trigger: none
 pr: none
 
 variables:
+  BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
+  CodesignValidation: false
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure

--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -84,6 +84,7 @@ stages:
       - template: dotnetDeploySteps.yml
 
     - job: Deploy_Skill
+      #dependsOn: Deploy_Host
       variables:
         BotName: $(DotNetPySkillBotName)
         DeployAppId: $(DotNetPySkillAppId)
@@ -91,9 +92,12 @@ stages:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/skill'
-        TemplateLocation: 'SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-preexisting-rg.json'
+        # To use template-with-new-rg.json when Deploy_Host and Deploy_Skill run in parallel gets 'Azure Error: DeploymentActive'.
+        #TemplateLocation: 'SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json'
       steps:
-      - template: pythonDeployStepsNewRG.yml
+      - template: pythonDeployStepsExistingRG.yml
+      #- template: pythonDeployStepsNewRG.yml
 
     - job: Configure_OAuth
       dependsOn: Deploy_Skill

--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -1,5 +1,5 @@
 #
-# Build a C# Host bot. Optionally deploy it and a Python Skill bot and run functional tests.
+# Build a C# Host bot. Deploy it and a Python Skill bot and run functional tests.
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
@@ -10,7 +10,6 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure
@@ -23,20 +22,17 @@ variables:
   # DotNetPySkillAppId: define in Azure
   # DotNetPySkillAppSecret: define in Azure
   # DotNetPySkillBotName: define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
   # NetCoreSdkVersionHost: define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # RegistryUrlSkill: (optional) define in Azure
   # RegistryUrlHost (Optional): define this in Azure
   # TestFilter: (optional) define in Azure. Example: '&TestCategory!=SkipForV3Bots'
-  # TriggeredBy: define in Azure and set to an empty string
 
 pool:
   vmImage: 'windows-2019'
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -52,15 +48,6 @@ stages:
       variables:
         Parameters.netCoreSdkVersion: $(NetCoreSdkVersionHost)
       steps:
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
-        inputs:
-          tags: |
-            TriggeredReason=$(TriggeredReason)
-            $(TriggeredBy)
-            NextBuild=$(NextBuild)
-        continueOnError: true
-
       - template: dotnetValidateNetCoreSdkVersion.yml
 
     - job: Build_Host_Bot
@@ -76,7 +63,9 @@ stages:
       - template: dotnetTagBotBuilderVersion.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  dependsOn:
+  - Prepare
+  - Build
   jobs:
     - job: Deploy_Host
       variables:
@@ -136,7 +125,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -149,20 +138,3 @@ stages:
            call az group delete -n "$(DotNetPyHostBotName)-RG" --yes
            call az group delete -n "$(DotNetPySkillBotName)-RG" --yes
         condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
-
-- stage: QueueNext
-  condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
-  jobs:
-    - job: TriggerBuild
-      steps:
-      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-        displayName: 'Trigger build $(NextBuild)'
-        inputs:
-          buildDefinition: '$(NextBuild)'
-          queueBuildForUserThatTriggeredBuild: true
-          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
-          password: '$(ExecutePipelinesPersonalAccessToken)'
-          enableBuildInQueueCondition: true
-          blockingBuildsList: '$(NextBuild)'
-        continueOnError: true
-        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))

--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -44,6 +44,7 @@ stages:
       - template: cleanResourcesStep.yml
 
 - stage: Build
+  dependsOn: []    # makes this run in parallel
   jobs:
     - job: Validate_Host_NetCore_Version
       variables:

--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -42,7 +42,6 @@ stages:
       - template: cleanResourcesStep.yml
 
 - stage: Build
-  condition: succeededOrFailed()
   jobs:
     - job: Validate_Host_NetCore_Version
       variables:

--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -68,6 +68,7 @@ stages:
   dependsOn:
   - Prepare
   - Build
+  condition: succeeded('Build')
   jobs:
     - job: Deploy_Host
       variables:

--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure

--- a/build/yaml/dotnetHost2dotnetSkill.yml
+++ b/build/yaml/dotnetHost2dotnetSkill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure

--- a/build/yaml/dotnetHost2dotnetSkill.yml
+++ b/build/yaml/dotnetHost2dotnetSkill.yml
@@ -10,6 +10,7 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
+  CodesignValidation: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
@@ -41,7 +42,7 @@ stages:
       - template: cleanResourcesStep.yml
 
 - stage: Build
-  condition: succeededOrFailed()
+  dependsOn: []    # makes this run in parallel
   jobs:
     - job: Validate_Host_NetCore_Version
       variables:

--- a/build/yaml/dotnetHost2dotnetSkill.yml
+++ b/build/yaml/dotnetHost2dotnetSkill.yml
@@ -8,6 +8,7 @@ trigger: none
 pr: none
 
 variables:
+  BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
   CodesignValidation: false

--- a/build/yaml/dotnetHost2dotnetSkill.yml
+++ b/build/yaml/dotnetHost2dotnetSkill.yml
@@ -1,5 +1,5 @@
 #
-# Build a C# Host bot and a C# Skill bot. Optionally deploy them and run functional tests.
+# Build a C# Host bot and a C# Skill bot. Deploy them and run functional tests.
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
@@ -10,7 +10,6 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
@@ -21,21 +20,18 @@ variables:
   # DotNetDotNetSkillAppId: define in Azure
   # DotNetDotNetSkillAppSecret: define in Azure
   # DotNetDotNetSkillBotName: define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
   # NetCoreSdkVersionHost: define in Azure
   # NetCoreSdkVersionSkill: define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # RegistryUrlHost (Optional): define this in Azure
   # RegistryUrlSkill (Optional): define this in Azure
   # TestFilter: (optional) define in Azure. Example: '&TestCategory!=SkipForV3Bots'
-  # TriggeredBy: define in Azure and set to an empty string
 
 pool:
   vmImage: 'windows-2019'
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -51,15 +47,6 @@ stages:
       variables:
         Parameters.netCoreSdkVersion: $(NetCoreSdkVersionHost)
       steps:
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
-        inputs:
-          tags: |
-            TriggeredReason=$(TriggeredReason)
-            $(TriggeredBy)
-            NextBuild=$(NextBuild)
-        continueOnError: true
-
       - template: dotnetValidateNetCoreSdkVersion.yml
 
     - job: Build_Host_Bot
@@ -93,7 +80,9 @@ stages:
       - template: dotnetTagBotBuilderVersion.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  dependsOn:
+  - Prepare
+  - Build
   jobs:
     - job: Deploy_Host
       variables:
@@ -153,7 +142,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -166,20 +155,3 @@ stages:
            call az group delete -n "$(DotNetDotNetHostBotName)-RG" --yes
            call az group delete -n "$(DotNetDotNetSkillBotName)-RG" --yes
         condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
-
-- stage: QueueNext
-  condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
-  jobs:
-    - job: TriggerBuild
-      steps:
-      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-        displayName: 'Trigger build $(NextBuild)'
-        inputs:
-          buildDefinition: '$(NextBuild)'
-          queueBuildForUserThatTriggeredBuild: true
-          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
-          password: '$(ExecutePipelinesPersonalAccessToken)'
-          enableBuildInQueueCondition: true
-          blockingBuildsList: '$(NextBuild)'
-        continueOnError: true
-        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))

--- a/build/yaml/dotnetHost2dotnetSkill.yml
+++ b/build/yaml/dotnetHost2dotnetSkill.yml
@@ -84,6 +84,7 @@ stages:
   dependsOn:
   - Prepare
   - Build
+  condition: succeeded('Build')
   jobs:
     - job: Deploy_Host
       variables:

--- a/build/yaml/dotnetV3DeploySteps.yml
+++ b/build/yaml/dotnetV3DeploySteps.yml
@@ -6,13 +6,17 @@ steps:
    Compress-Archive "$(Parameters.sourceLocation)/*" "$(Parameters.sourceLocation)/bot.zip" -Update
   displayName: 'Zip Bot'
 
-- task: AzureCLI@1
-  displayName: 'Create resources'
+- task: AzureCLI@2
+  displayName: 'create Azure resources - new RG template'
   inputs:
     azureSubscription: $(AzureSubscription)
+    scriptType: ps
     scriptLocation: inlineScript
     inlineScript: |
-     call az deployment create --template-file "$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotName)-RG" botSku=F0 groupLocation="westus" newAppServicePlanLocation="westus"
+     Set-PSDebug -Trace 1;
+     # set up resource group, bot channels registration, app service, app service plan
+     az deployment sub create --name "$(BotName)$(Build.BuildId)" --template-file "$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus"
+     Set-PSDebug -Trace 0;
 
 - task: AzureCLI@1
   displayName: 'Deploy Bot'

--- a/build/yaml/javascriptDeploySteps.yml
+++ b/build/yaml/javascriptDeploySteps.yml
@@ -45,13 +45,17 @@ steps:
    Compress-Archive "$(Parameters.sourceLocation)/*" "$(Parameters.sourceLocation)/bot.zip" -Update
   displayName: 'Zip Bot'
 
-- task: AzureCLI@1
-  displayName: 'Create resource group'
+- task: AzureCLI@2
+  displayName: 'create Azure resources - new RG template'
   inputs:
     azureSubscription: $(AzureSubscription)
+    scriptType: ps
     scriptLocation: inlineScript
     inlineScript: |
-     call az deployment create --name "$(BotName)-RG" --template-file "$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotName)-RG" groupLocation="westus" newAppServicePlanLocation="westus"
+     Set-PSDebug -Trace 1;
+     # set up resource group, bot channels registration, app service, app service plan
+     az deployment sub create --name "$(BotName)$(Build.BuildId)" --template-file "$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus"
+     Set-PSDebug -Trace 0;
 
 - task: AzureCLI@1
   displayName: 'Deploy bot'

--- a/build/yaml/javascriptHost2DotnetSkill.yml
+++ b/build/yaml/javascriptHost2DotnetSkill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure

--- a/build/yaml/javascriptHost2DotnetSkill.yml
+++ b/build/yaml/javascriptHost2DotnetSkill.yml
@@ -10,6 +10,7 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
+  CodesignValidation: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
@@ -40,7 +41,7 @@ stages:
       - template: cleanResourcesStep.yml
 
 - stage: Build
-  condition: succeededOrFailed()
+  dependsOn: []    # makes this run in parallel
   jobs:
     - job: Validate_Skill_NetCore_Version
       variables:

--- a/build/yaml/javascriptHost2DotnetSkill.yml
+++ b/build/yaml/javascriptHost2DotnetSkill.yml
@@ -8,6 +8,7 @@ trigger: none
 pr: none
 
 variables:
+  BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
   CodesignValidation: false

--- a/build/yaml/javascriptHost2DotnetSkill.yml
+++ b/build/yaml/javascriptHost2DotnetSkill.yml
@@ -1,5 +1,5 @@
 #
-# Build a C# Skill bot. Optionally deploy it and a Javascript Host bot and run functional tests.
+# Build a C# Skill bot. Deploy it and a Javascript Host bot and run functional tests.
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
@@ -10,12 +10,10 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
   # DeleteResourceGroup: (optional) define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
   # JsDotNetHostAppId: define in Azure
   # JsDotNetHostAppSecret: define in Azure
   # JsDotNetHostBotName: define in Azure
@@ -23,18 +21,16 @@ variables:
   # JsDotNetSkillAppSecret: define in Azure
   # JsDotNetSkillBotName: define in Azure
   # NetCoreSdkVersionSkill: define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # RegistryUrlHost (Optional): define this in Azure
   # RegistryUrlSkill (Optional): define this in Azure
   # TestFilter: (optional) define in Azure. Example: '&TestCategory!=SkipForV3Bots'
-  # TriggeredBy: define in Azure and set to an empty string
 
 pool:
   vmImage: 'windows-2019'
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -50,15 +46,6 @@ stages:
       variables:
         Parameters.netCoreSdkVersion: $(NetCoreSdkVersionSkill)
       steps:
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
-        inputs:
-          tags: |
-            TriggeredReason=$(TriggeredReason)
-            $(TriggeredBy)
-            NextBuild=$(NextBuild)
-        continueOnError: true
-
       - template: dotnetValidateNetCoreSdkVersion.yml
 
     - job: Build_Skill_Bot
@@ -74,7 +61,9 @@ stages:
       - template: dotnetTagBotBuilderVersion.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  dependsOn:
+  - Prepare
+  - Build
   jobs:
     - job: Deploy_Host
       variables:
@@ -134,7 +123,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -147,20 +136,3 @@ stages:
            call az group delete -n "$(JsDotNetHostBotName)-RG" --yes
            call az group delete -n "$(JsDotNetSkillBotName)-RG" --yes
         condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
-
-- stage: QueueNext
-  condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
-  jobs:
-    - job: TriggerBuild
-      steps:
-      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-        displayName: 'Trigger build $(NextBuild)'
-        inputs:
-          buildDefinition: '$(NextBuild)'
-          queueBuildForUserThatTriggeredBuild: true
-          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
-          password: '$(ExecutePipelinesPersonalAccessToken)'
-          enableBuildInQueueCondition: true
-          blockingBuildsList: '$(NextBuild)'
-        continueOnError: true
-        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))

--- a/build/yaml/javascriptHost2DotnetSkill.yml
+++ b/build/yaml/javascriptHost2DotnetSkill.yml
@@ -65,6 +65,7 @@ stages:
   dependsOn:
   - Prepare
   - Build
+  condition: succeeded('Build')
   jobs:
     - job: Deploy_Host
       variables:

--- a/build/yaml/javascriptHost2DotnetV3Skill.yml
+++ b/build/yaml/javascriptHost2DotnetV3Skill.yml
@@ -9,8 +9,8 @@ pr: none
 
 variables:
   BotGroup: '$(BotName)-RG'
-  BuildPlatform: 'any cpu'
   BuildConfiguration: 'Debug'
+  BuildPlatform: 'any cpu'
   CodesignValidation: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure

--- a/build/yaml/javascriptHost2DotnetV3Skill.yml
+++ b/build/yaml/javascriptHost2DotnetV3Skill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure

--- a/build/yaml/javascriptHost2DotnetV3Skill.yml
+++ b/build/yaml/javascriptHost2DotnetV3Skill.yml
@@ -8,6 +8,7 @@ trigger: none
 pr: none
 
 variables:
+  BotGroup: '$(BotName)-RG'
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'Debug'
   CodesignValidation: false

--- a/build/yaml/javascriptHost2DotnetV3Skill.yml
+++ b/build/yaml/javascriptHost2DotnetV3Skill.yml
@@ -1,5 +1,5 @@
 #
-# Build a v3 C# Skill bot. Optionally deploy it and a Javascript Host bot and run functional tests.
+# Build a v3 C# Skill bot. Deploy it and a Javascript Host bot and run functional tests.
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
@@ -10,30 +10,26 @@ pr: none
 variables:
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'Debug'
-  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
   # DeleteResourceGroup: (optional) define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
   # JsDotNetV3HostAppId: define in Azure
   # JsDotNetV3HostAppSecret: define in Azure
   # JsDotNetV3HostBotName: define in Azure
   # JsDotNetV3SkillAppId: define in Azure
   # JsDotNetV3SkillAppSecret: define in Azure
   # JsDotNetV3SkillBotName: define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # RegistryUrlHost (Optional): define this in Azure
   # RegistryUrlSkill (Optional): define this in Azure
   # TestFilter: (optional) define in Azure. Example: '&TestCategory!=SkipForV3Bots'
-  # TriggeredBy: define in Azure and set to an empty string
 
 pool:
   vmImage: 'windows-2019'
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -42,22 +38,8 @@ stages:
       steps:
       - template: cleanResourcesStep.yml
 
-- stage: Tag
-  condition: always()
-  jobs:
-    - job: Tag
-      steps:
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
-        inputs:
-          tags: |
-            TriggeredReason=$(TriggeredReason)
-            $(TriggeredBy)
-            NextBuild=$(NextBuild)
-        continueOnError: true
-
 - stage: Build
-  condition: always()
+  condition: succeededOrFailed()
   jobs:
     - job: Build_Skill_Bot
       variables:
@@ -69,7 +51,9 @@ stages:
       - template: dotnetV3TagBotBuilderVersion.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  dependsOn:
+  - Prepare
+  - Build
   jobs:
     - job: Deploy_Host
       variables:
@@ -117,7 +101,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -130,20 +114,3 @@ stages:
            call az group delete -n "$(JsDotNetV3HostBotName)-RG" --yes
            call az group delete -n "$(JsDotNetV3SkillBotName)-RG" --yes
         condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
-
-- stage: QueueNext
-  condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
-  jobs:
-    - job: TriggerBuild
-      steps:
-      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-        displayName: 'Trigger build $(NextBuild)'
-        inputs:
-          buildDefinition: '$(NextBuild)'
-          queueBuildForUserThatTriggeredBuild: true
-          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
-          password: '$(ExecutePipelinesPersonalAccessToken)'
-          enableBuildInQueueCondition: true
-          blockingBuildsList: '$(NextBuild)'
-        continueOnError: true
-        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))

--- a/build/yaml/javascriptHost2DotnetV3Skill.yml
+++ b/build/yaml/javascriptHost2DotnetV3Skill.yml
@@ -55,7 +55,8 @@ stages:
   dependsOn:
   - Prepare
   - Build
-  jobs:
+  condition: succeeded('Build')
+ jobs:
     - job: Deploy_Host
       variables:
         HostBotName: $(JsDotNetV3HostBotName)

--- a/build/yaml/javascriptHost2DotnetV3Skill.yml
+++ b/build/yaml/javascriptHost2DotnetV3Skill.yml
@@ -57,7 +57,7 @@ stages:
   - Prepare
   - Build
   condition: succeeded('Build')
- jobs:
+  jobs:
     - job: Deploy_Host
       variables:
         HostBotName: $(JsDotNetV3HostBotName)

--- a/build/yaml/javascriptHost2DotnetV3Skill.yml
+++ b/build/yaml/javascriptHost2DotnetV3Skill.yml
@@ -10,6 +10,7 @@ pr: none
 variables:
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'Debug'
+  CodesignValidation: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
@@ -39,7 +40,7 @@ stages:
       - template: cleanResourcesStep.yml
 
 - stage: Build
-  condition: succeededOrFailed()
+  dependsOn: []    # makes this run in parallel
   jobs:
     - job: Build_Skill_Bot
       variables:

--- a/build/yaml/javascriptHost2JavascriptSkill.yml
+++ b/build/yaml/javascriptHost2JavascriptSkill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure

--- a/build/yaml/javascriptHost2JavascriptSkill.yml
+++ b/build/yaml/javascriptHost2JavascriptSkill.yml
@@ -11,6 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
+  CodesignValidation: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure

--- a/build/yaml/javascriptHost2JavascriptSkill.yml
+++ b/build/yaml/javascriptHost2JavascriptSkill.yml
@@ -8,6 +8,7 @@ trigger: none
 pr: none
 
 variables:
+  BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
   # AzureSubscription: define in Azure

--- a/build/yaml/javascriptHost2JavascriptSkill.yml
+++ b/build/yaml/javascriptHost2JavascriptSkill.yml
@@ -1,5 +1,5 @@
 #
-# Optionally deploy a Js Host bot and a Js Skill bot and run functional tests. (No build stage.)
+# Deploy a Js Host bot and a Js Skill bot and run functional tests. (No build stage.)
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
@@ -10,30 +10,26 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
   # DeleteResourceGroup: (optional) define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
   # JsJsHostAppId: define in Azure 
   # JsJsHostAppSecret: define in Azure
   # JsJsHostBotName: define in Azure
   # JsJsSkillAppId: define in Azure
   # JsJsSkillAppSecret: define in Azure
   # JsJsSkillBotName: define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # RegistryUrlHost (Optional): define this in Azure
   # RegistryUrlSkill (Optional): define this in Azure
   # TestFilter: (optional) define in Azure. Example: '&TestCategory!=SkipForV3Bots'
-  # TriggeredBy: define in Azure and set to an empty string
 
 pool:
   vmImage: 'windows-2019'
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -42,22 +38,8 @@ stages:
       steps:
       - template: cleanResourcesStep.yml
 
-- stage: Tag
-  condition: succeededOrFailed()
-  jobs:
-    - job: Tag
-      steps:
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
-        inputs:
-          tags: |
-            TriggeredReason=$(TriggeredReason)
-            $(TriggeredBy)
-            NextBuild=$(NextBuild)
-        continueOnError: true
-       
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  dependsOn: Prepare  
   jobs:
     - job: Deploy_Host
       variables:
@@ -117,7 +99,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(always(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -130,20 +112,3 @@ stages:
            call az group delete -n "$(JsJsHostBotName)-RG" --yes
            call az group delete -n "$(JsJsSkillBotName)-RG" --yes
         condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
-
-- stage: QueueNext
-  condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
-  jobs:
-    - job: TriggerBuild
-      steps:
-      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-        displayName: 'Trigger build $(NextBuild)'
-        inputs:
-          buildDefinition: '$(NextBuild)'
-          queueBuildForUserThatTriggeredBuild: true
-          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
-          password: '$(ExecutePipelinesPersonalAccessToken)'
-          enableBuildInQueueCondition: true
-          blockingBuildsList: '$(NextBuild)'
-        continueOnError: true
-        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))

--- a/build/yaml/javascriptHost2JavascriptV3Skill.yml
+++ b/build/yaml/javascriptHost2JavascriptV3Skill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure

--- a/build/yaml/javascriptHost2JavascriptV3Skill.yml
+++ b/build/yaml/javascriptHost2JavascriptV3Skill.yml
@@ -11,6 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
+  CodesignValidation: false
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure

--- a/build/yaml/javascriptHost2JavascriptV3Skill.yml
+++ b/build/yaml/javascriptHost2JavascriptV3Skill.yml
@@ -8,6 +8,7 @@ trigger: none
 pr: none
 
 variables:
+  BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
   # AzureSubscription: define in Azure

--- a/build/yaml/javascriptHost2JavascriptV3Skill.yml
+++ b/build/yaml/javascriptHost2JavascriptV3Skill.yml
@@ -1,5 +1,5 @@
 #
-# Optionally deploy a Js Host bot and a v3 Js Skill bot and run functional tests. (No build stage.)
+# Deploy a Js Host bot and a v3 Js Skill bot and run functional tests. (No build stage.)
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
@@ -10,30 +10,26 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
   # DeleteResourceGroup: (optional) define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
   # JsJsV3HostAppId: define in Azure 
   # JsJsV3HostAppSecret: define in Azure
   # JsJsV3HostBotName: define in Azure
   # JsJsV3SkillAppId: define in Azure
   # JsJsV3SkillAppSecret: define in Azure
   # JsJsV3SkillBotName: define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # RegistryUrlHost (Optional): define this in Azure
   # RegistryUrlSkill (Optional): define this in Azure
   # TestFilter: (optional) define in Azure. Example: '&TestCategory!=SkipForV3Bots'
-  # TriggeredBy: define in Azure and set to an empty string
 
 pool:
   vmImage: 'windows-2019'
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -42,22 +38,9 @@ stages:
       steps:
       - template: cleanResourcesStep.yml
 
-- stage: Tag
-  condition: always()
-  jobs:
-    - job: Tag
-      steps:
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
-        inputs:
-          tags: |
-            TriggeredReason=$(TriggeredReason)
-            $(TriggeredBy)
-            NextBuild=$(NextBuild)
-        continueOnError: true
-       
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  dependsOn:
+  - Prepare
   jobs:
     - job: Deploy_Host
       variables:
@@ -104,7 +87,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(always(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -117,20 +100,3 @@ stages:
            call az group delete -n "$(JsJsV3HostBotName)-RG" --yes
            call az group delete -n "$(JsJsV3SkillBotName)-RG" --yes
         condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
-
-- stage: QueueNext
-  condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
-  jobs:
-    - job: TriggerBuild
-      steps:
-      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-        displayName: 'Trigger build $(NextBuild)'
-        inputs:
-          buildDefinition: '$(NextBuild)'
-          queueBuildForUserThatTriggeredBuild: true
-          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
-          password: '$(ExecutePipelinesPersonalAccessToken)'
-          enableBuildInQueueCondition: true
-          blockingBuildsList: '$(NextBuild)'
-        continueOnError: true
-        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))

--- a/build/yaml/javascriptHost2PythonSkill.yml
+++ b/build/yaml/javascriptHost2PythonSkill.yml
@@ -8,8 +8,10 @@ trigger: none
 pr: none
 
 variables:
+  BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
+  CodesignValidation: false
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure

--- a/build/yaml/javascriptHost2PythonSkill.yml
+++ b/build/yaml/javascriptHost2PythonSkill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure

--- a/build/yaml/javascriptHost2PythonSkill.yml
+++ b/build/yaml/javascriptHost2PythonSkill.yml
@@ -1,5 +1,5 @@
 #
-# Optionally deploy a Javascript Host bot and a Python Skill bot and run functional tests. (No build stage.)
+# Deploy a Javascript Host bot and a Python Skill bot and run functional tests. (No build stage.)
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
@@ -10,32 +10,28 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
   # DeleteResourceGroup: (optional) define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
   # JsPyHostAppId: define in Azure
   # JsPyHostAppSecret: define in Azure
   # JsPyHostBotName: define in Azure
   # JsPySkillAppId: define in Azure
   # JsPySkillAppSecret: define in Azure
   # JsPySkillBotName: define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # RegistryUrlSkill: (optional) define in Azure
   # RegistryUrlHost (Optional): define this in Azure
   # TestFilter: (optional) define in Azure. Example: '&TestCategory!=SkipForV3Bots'
-  # TriggeredBy: define in Azure and set to an empty string
 
 pool:
   vmImage: 'windows-2019'
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -44,22 +40,9 @@ stages:
       steps:
       - template: cleanResourcesStep.yml
         
-- stage: Tag
-  condition: succeededOrFailed()
-  jobs:
-    - job: Tag
-      steps:
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
-        inputs:
-          tags: |
-            TriggeredReason=$(TriggeredReason)
-            NextBuild=$(NextBuild)
-            $(TriggeredBy)
-        continueOnError: true
-
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  dependsOn:
+  - Prepare
   jobs:
     - job: Deploy_Host
       variables:
@@ -119,7 +102,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(always(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -132,20 +115,3 @@ stages:
            call az group delete -n "$(JsPyHostBotName)-RG" --yes
            call az group delete -n "$(JsPySkillBotName)-RG" --yes
         condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
-
-- stage: QueueNext
-  condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
-  jobs:
-    - job: TriggerBuild
-      steps:
-      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-        displayName: 'Trigger build $(NextBuild)'
-        inputs:
-          buildDefinition: '$(NextBuild)'
-          queueBuildForUserThatTriggeredBuild: true
-          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
-          password: '$(ExecutePipelinesPersonalAccessToken)'
-          enableBuildInQueueCondition: true
-          blockingBuildsList: '$(NextBuild)'
-        continueOnError: true
-        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))

--- a/build/yaml/pythonDeployStepsExistingRG.yml
+++ b/build/yaml/pythonDeployStepsExistingRG.yml
@@ -99,7 +99,7 @@ steps:
      az group create --location westus --name $(BotGroup);
 
      # set up bot channels registration, app service, app service plan
-     az deployment group create --resource-group "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)/$(TemplateLocation)" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" newAppServicePlanName="$(BotName)" appServicePlanLocation="westus" --name "$(BotName)";
+     az deployment group create --resource-group "$(BotGroup)" --name "$(BotName)$(Build.BuildId)" --template-file "$(System.DefaultWorkingDirectory)/$(TemplateLocation)" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" newAppServicePlanName="$(BotName)" appServicePlanLocation="westus" --name "$(BotName)";
      Set-PSDebug -Trace 0;
 
 - script: |

--- a/build/yaml/pythonDeployStepsNewRG.yml
+++ b/build/yaml/pythonDeployStepsNewRG.yml
@@ -97,7 +97,7 @@ steps:
     inlineScript: |
      Set-PSDebug -Trace 1;
      # set up resource group, bot channels registration, app service, app service plan
-     az deployment sub create --name "$(BotName)-RG" --template-file "$(System.DefaultWorkingDirectory)/$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotName)-RG" groupLocation="westus" newAppServicePlanLocation="westus";
+     az deployment sub create --name "$(BotName)$(Build.BuildId)" --template-file "$(System.DefaultWorkingDirectory)/$(TemplateLocation)" --location "westus" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus";
      Set-PSDebug -Trace 0;
 
 - script: |

--- a/build/yaml/pythonHost2DotnetSkill.yml
+++ b/build/yaml/pythonHost2DotnetSkill.yml
@@ -67,6 +67,7 @@ stages:
   dependsOn:
   - Prepare
   - Build
+  condition: succeeded('Build')
   jobs:
     - job: Deploy_Host
       variables:

--- a/build/yaml/pythonHost2DotnetSkill.yml
+++ b/build/yaml/pythonHost2DotnetSkill.yml
@@ -1,5 +1,5 @@
 #
-# Build a C# Skill bot. Optionally deploy it and a Python Host bot and run functional tests.
+# Build a C# Skill bot. Deploy it and a Python Host bot and run functional tests.
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
@@ -10,16 +10,13 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
   # DeleteResourceGroup: (optional) define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
   # NetCoreSdkVersionSkill: define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # PyDotNetHostAppId: define in Azure
   # PyDotNetHostAppSecret: define in Azure
   # PyDotNetHostBotName: define in Azure
@@ -29,14 +26,13 @@ variables:
   # RegistryUrlHost: (optional) define in Azure
   # RegistryUrlSkill (Optional): define this in Azure
   # TestFilter: (optional) define in Azure. Example: '&TestCategory!=SkipForV3Bots'
-  # TriggeredBy: define in Azure and set to an empty string
 
 pool:
   vmImage: 'windows-2019'
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -52,15 +48,6 @@ stages:
       variables:
         Parameters.netCoreSdkVersion: $(NetCoreSdkVersionSkill)
       steps:
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
-        inputs:
-          tags: |
-            TriggeredReason=$(TriggeredReason)
-            NextBuild=$(NextBuild)
-            $(TriggeredBy)
-        continueOnError: true
-
       - template: dotnetValidateNetCoreSdkVersion.yml
 
     - job: Build_Skill_Bot
@@ -76,7 +63,9 @@ stages:
       - template: dotnetTagBotBuilderVersion.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  dependsOn:
+  - Prepare
+  - Build
   jobs:
     - job: Deploy_Host
       variables:
@@ -136,7 +125,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -149,20 +138,3 @@ stages:
            call az group delete -n "$(PyDotNetHostBotName)-RG" --yes
            call az group delete -n "$(PyDotNetSkillBotName)-RG" --yes
         condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
-
-- stage: QueueNext
-  condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
-  jobs:
-    - job: TriggerBuild
-      steps:
-      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-        displayName: 'Trigger build $(NextBuild)'
-        inputs:
-          buildDefinition: '$(NextBuild)'
-          queueBuildForUserThatTriggeredBuild: true
-          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
-          password: '$(ExecutePipelinesPersonalAccessToken)'
-          enableBuildInQueueCondition: true
-          blockingBuildsList: '$(NextBuild)'
-        continueOnError: true
-        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))

--- a/build/yaml/pythonHost2DotnetSkill.yml
+++ b/build/yaml/pythonHost2DotnetSkill.yml
@@ -8,6 +8,7 @@ trigger: none
 pr: none
 
 variables:
+  BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
   CodesignValidation: false

--- a/build/yaml/pythonHost2DotnetSkill.yml
+++ b/build/yaml/pythonHost2DotnetSkill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure

--- a/build/yaml/pythonHost2DotnetSkill.yml
+++ b/build/yaml/pythonHost2DotnetSkill.yml
@@ -10,6 +10,7 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
+  CodesignValidation: false
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure
@@ -42,7 +43,7 @@ stages:
       - template: cleanResourcesStep.yml
 
 - stage: Build
-  condition: succeededOrFailed()
+  dependsOn: []    # makes this run in parallel
   jobs:
     - job: Validate_Skill_NetCore_Version
       variables:

--- a/build/yaml/pythonHost2DotnetV3Skill.yml
+++ b/build/yaml/pythonHost2DotnetV3Skill.yml
@@ -57,6 +57,7 @@ stages:
   dependsOn:
   - Prepare
   - Build
+  condition: succeeded('Build')
   jobs:
     - job: Deploy_Host
       variables:

--- a/build/yaml/pythonHost2DotnetV3Skill.yml
+++ b/build/yaml/pythonHost2DotnetV3Skill.yml
@@ -10,6 +10,7 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
+  CodesignValidation: false
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure
@@ -41,7 +42,7 @@ stages:
       - template: cleanResourcesStep.yml
 
 - stage: Build
-  condition: succeededOrFailed()
+  dependsOn: []    # makes this run in parallel
   jobs:
     - job: Build_Skill_Bot
       variables:

--- a/build/yaml/pythonHost2DotnetV3Skill.yml
+++ b/build/yaml/pythonHost2DotnetV3Skill.yml
@@ -1,5 +1,5 @@
 #
-# Build a v3 C# Skill bot. Optionally deploy it and a Python Host bot and run functional tests.
+# Build a v3 C# Skill bot. Deploy it and a Python Host bot and run functional tests.
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
@@ -10,15 +10,12 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
   # DeleteResourceGroup: (optional) define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # PyDotNetV3HostAppId: define in Azure
   # PyDotNetV3HostAppSecret: define in Azure
   # PyDotNetV3HostBotName: define in Azure
@@ -28,14 +25,13 @@ variables:
   # RegistryUrlHost: (optional) define in Azure
   # RegistryUrlSkill (Optional): define this in Azure
   # TestFilter: (optional) define in Azure. Example: '&TestCategory!=SkipForV3Bots'
-  # TriggeredBy: define in Azure and set to an empty string
 
 pool:
   vmImage: 'windows-2019'
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -44,22 +40,8 @@ stages:
       steps:
       - template: cleanResourcesStep.yml
 
-- stage: Tag
-  condition: always()
-  jobs:
-    - job: Tag
-      steps:
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
-        inputs:
-          tags: |
-            TriggeredReason=$(TriggeredReason)
-            NextBuild=$(NextBuild)
-            $(TriggeredBy)
-        continueOnError: true
-
 - stage: Build
-  condition: always()
+  condition: succeededOrFailed()
   jobs:
     - job: Build_Skill_Bot
       variables:
@@ -71,7 +53,9 @@ stages:
       - template: dotnetV3TagBotBuilderVersion.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  dependsOn:
+  - Prepare
+  - Build
   jobs:
     - job: Deploy_Host
       variables:
@@ -119,7 +103,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(succeeded('Build'), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -132,20 +116,3 @@ stages:
            call az group delete -n "$(PyDotNetV3HostBotName)-RG" --yes
            call az group delete -n "$(PyDotNetV3SkillBotName)-RG" --yes
         condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
-
-- stage: QueueNext
-  condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
-  jobs:
-    - job: TriggerBuild
-      steps:
-      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-        displayName: 'Trigger build $(NextBuild)'
-        inputs:
-          buildDefinition: '$(NextBuild)'
-          queueBuildForUserThatTriggeredBuild: true
-          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
-          password: '$(ExecutePipelinesPersonalAccessToken)'
-          enableBuildInQueueCondition: true
-          blockingBuildsList: '$(NextBuild)'
-        continueOnError: true
-        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))

--- a/build/yaml/pythonHost2DotnetV3Skill.yml
+++ b/build/yaml/pythonHost2DotnetV3Skill.yml
@@ -8,6 +8,7 @@ trigger: none
 pr: none
 
 variables:
+  BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
   CodesignValidation: false

--- a/build/yaml/pythonHost2DotnetV3Skill.yml
+++ b/build/yaml/pythonHost2DotnetV3Skill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure

--- a/build/yaml/pythonHost2JavascriptSkill.yml
+++ b/build/yaml/pythonHost2JavascriptSkill.yml
@@ -8,8 +8,10 @@ trigger: none
 pr: none
 
 variables:
+  BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
+  CodesignValidation: false
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure

--- a/build/yaml/pythonHost2JavascriptSkill.yml
+++ b/build/yaml/pythonHost2JavascriptSkill.yml
@@ -1,5 +1,5 @@
 #
-# Optionally deploy a Python Host bot and a JS Skill bot and run functional tests. (No build stage.)
+# Deploy a Python Host bot and a JS Skill bot and run functional tests. (No build stage.)
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
@@ -10,15 +10,12 @@ pr: none
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
   # DeleteResourceGroup: (optional) define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # PyJsHostAppId: define in Azure
   # PyJsHostAppSecret: define in Azure
   # PyJsHostBotName: define in Azure
@@ -26,17 +23,15 @@ variables:
   # PyJsSkillAppSecret: define in Azure
   # PyJsSkillBotName: define in Azure
   # RegistryUrlHost: (optional) define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # RegistryUrlSkill (Optional): define this in Azure
   # TestFilter: (optional) define in Azure. Example: '&TestCategory!=SkipForV3Bots'
-  # TriggeredBy: define in Azure and set to an empty string
 
 pool:
   vmImage: 'windows-2019'
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -45,22 +40,8 @@ stages:
       steps:
       - template: cleanResourcesStep.yml
 
-- stage: Tag
-  condition: succeededOrFailed()
-  jobs:
-    - job: Tag
-      steps:
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
-        inputs:
-          tags: |
-            TriggeredReason=$(TriggeredReason)
-            $(TriggeredBy)
-            NextBuild=$(NextBuild)
-        continueOnError: true
-
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  dependsOn: Prepare  
   jobs:
     - job: Deploy_Host
       variables:
@@ -120,7 +101,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(always(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -133,20 +114,3 @@ stages:
            call az group delete -n "$(PyJsHostBotName)-RG" --yes
            call az group delete -n "$(PyJsSkillBotName)-RG" --yes
         condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
-
-- stage: QueueNext
-  condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
-  jobs:
-    - job: TriggerBuild
-      steps:
-      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-        displayName: 'Trigger build $(NextBuild)'
-        inputs:
-          buildDefinition: '$(NextBuild)'
-          queueBuildForUserThatTriggeredBuild: true
-          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
-          password: '$(ExecutePipelinesPersonalAccessToken)'
-          enableBuildInQueueCondition: true
-          blockingBuildsList: '$(NextBuild)'
-        continueOnError: true
-        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))

--- a/build/yaml/pythonHost2JavascriptSkill.yml
+++ b/build/yaml/pythonHost2JavascriptSkill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure

--- a/build/yaml/pythonHost2JavascriptSkill.yml
+++ b/build/yaml/pythonHost2JavascriptSkill.yml
@@ -44,6 +44,7 @@ stages:
 
 - stage: Deploy
   dependsOn: Prepare  
+  condition: succeededOrFailed()
   jobs:
     - job: Deploy_Host
       variables:

--- a/build/yaml/pythonHost2JavascriptV3Skill.yml
+++ b/build/yaml/pythonHost2JavascriptV3Skill.yml
@@ -8,17 +8,16 @@ trigger: none
 pr: none
 
 variables:
+  BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]
+  CodesignValidation: false
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
   # DeleteResourceGroup: (optional) define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # PyJsV3HostAppId: define in Azure
   # PyJsV3HostAppSecret: define in Azure
   # PyJsV3HostBotName: define in Azure
@@ -26,17 +25,15 @@ variables:
   # PyJsV3SkillAppSecret: define in Azure
   # PyJsV3SkillBotName: define in Azure
   # RegistryUrlHost: (optional) define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # RegistryUrlSkill (Optional): define this in Azure
   # TestFilter: (optional) define in Azure. Example: '&TestCategory!=SkipForV3Bots'
-  # TriggeredBy: define in Azure and set to an empty string
 
 pool:
   vmImage: 'windows-2019'
 
 stages:
 - stage: Prepare
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -93,7 +90,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: and(always(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -106,20 +103,3 @@ stages:
            call az group delete -n "$(PyJsV3HostBotName)-RG" --yes
            call az group delete -n "$(PyJsV3SkillBotName)-RG" --yes
         condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
-
-- stage: QueueNext
-  condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''))
-  jobs:
-    - job: TriggerBuild
-      steps:
-      - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-        displayName: 'Trigger build $(NextBuild)'
-        inputs:
-          buildDefinition: '$(NextBuild)'
-          queueBuildForUserThatTriggeredBuild: true
-          buildParameters: 'TriggeringBuildReason: $(TriggeredReason), TriggeredBy: Triggered_by_$(Build.DefinitionName)/$(Build.BuildNumber)'
-          password: '$(ExecutePipelinesPersonalAccessToken)'
-          enableBuildInQueueCondition: true
-          blockingBuildsList: '$(NextBuild)'
-        continueOnError: true
-        condition: and(succeededOrFailed(), ne(variables['TriggeredReason'], 'Manual'), ne(variables['NextBuild'], ''), ne(variables['ExecutePipelinesPersonalAccessToken'], ''))

--- a/build/yaml/pythonHost2JavascriptV3Skill.yml
+++ b/build/yaml/pythonHost2JavascriptV3Skill.yml
@@ -1,5 +1,5 @@
 #
-# Optionally deploy a Python Host bot and a V3 JS Skill bot and run functional tests. (No build stage.)
+# Deploy a Python Host bot and a V3 JS Skill bot and run functional tests. (No build stage.)
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
@@ -44,20 +44,6 @@ stages:
         SkillBotName: $(PyJsV3SkillBotName)
       steps:
       - template: cleanResourcesStep.yml
-
-- stage: Tag
-  condition: always()
-  jobs:
-    - job: Tag
-      steps:
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-        displayName: 'Tag Build with TriggeredReason, TriggeredBy, NextBuild'
-        inputs:
-          tags: |
-            TriggeredReason=$(TriggeredReason)
-            $(TriggeredBy)
-            NextBuild=$(NextBuild)
-        continueOnError: true
 
 - stage: Deploy
   condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))

--- a/build/yaml/pythonHost2JavascriptV3Skill.yml
+++ b/build/yaml/pythonHost2JavascriptV3Skill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure

--- a/build/yaml/pythonHost2JavascriptV3Skill.yml
+++ b/build/yaml/pythonHost2JavascriptV3Skill.yml
@@ -43,7 +43,8 @@ stages:
       - template: cleanResourcesStep.yml
 
 - stage: Deploy
-  condition: and(succeeded(), in(variables['TriggeredReason'], 'Schedule', 'Manual', 'BuildRunner'))
+  dependsOn: Prepare  
+  condition: succeededOrFailed()
   jobs:
     - job: Deploy_Host
       variables:

--- a/build/yaml/pythonHost2PythonSkill.yml
+++ b/build/yaml/pythonHost2PythonSkill.yml
@@ -17,8 +17,6 @@ variables:
   # BotBuilderPackageVersionHost: (optional) define in Azure
   # BotBuilderPackageVersionSkill: (optional) define in Azure
   # DeleteResourceGroup: (optional) define in Azure
-  # ExecutePipelinesPersonalAccessToken: (optional) define in Azure
-  # NextBuild: define in Azure and set to either a build name or an empty string
   # PyPyHostAppId: define in Azure
   # PyPyHostAppSecret: define in Azure
   # PyPyHostBotName: define in Azure
@@ -34,6 +32,7 @@ pool:
 
 stages:
 - stage: Prepare
+  condition: and(succeeded(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_Preexisting_Resources
       variables:
@@ -110,7 +109,7 @@ stages:
   dependsOn:
   - Deploy
   - Test
-  condition: always()
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
   jobs:
     - job: Delete_RG
       steps:
@@ -122,4 +121,3 @@ stages:
           inlineScript: |
            call az group delete -n "$(PyPyHostBotName)-RG" --yes
            call az group delete -n "$(PyPySkillBotName)-RG" --yes
-        condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))

--- a/build/yaml/pythonHost2PythonSkill.yml
+++ b/build/yaml/pythonHost2PythonSkill.yml
@@ -11,6 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
+  CodesignValidation: false
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure

--- a/build/yaml/pythonHost2PythonSkill.yml
+++ b/build/yaml/pythonHost2PythonSkill.yml
@@ -72,7 +72,7 @@ stages:
         Registry: $[variables.RegistryUrlSkill]
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.sourceLocation: 'SkillsFunctionalTests/python/skill'
-        TemplateLocation: 'SkillsFunctionalTests/python/host/deploymentTemplates/template-with-preexisting-rg.json'
+        TemplateLocation: 'SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-preexisting-rg.json'
         # Using template-with-new-rg.json when Deploy_Host and Deploy_Skill run in parallel gets 'Azure Error: DeploymentActive'.
         #TemplateLocation: 'SkillsFunctionalTests/python/skill/deploymentTemplates/template-with-new-rg.json'
       steps:

--- a/build/yaml/pythonHost2PythonSkill.yml
+++ b/build/yaml/pythonHost2PythonSkill.yml
@@ -11,7 +11,7 @@ variables:
   BotGroup: '$(BotName)-RG'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'any cpu'
-  CodesignValidation: false
+  runCodesignValidationInjection: false
   # AzureDeploymentPassword: define in Azure
   # AzureDeploymentUser: define in Azure
   # AzureSubscription: define in Azure

--- a/build/yaml/pythonHost2PythonSkill.yml
+++ b/build/yaml/pythonHost2PythonSkill.yml
@@ -44,6 +44,7 @@ stages:
 
 - stage: Deploy
   dependsOn: Prepare  
+  condition: succeededOrFailed()
   jobs:
     - job: Deploy_Host
       variables:


### PR DESCRIPTION
Normalize ARM templates to match the templates from Botbuilder-Samples which were corrected and made uniform by Kyle Delaney.

Fix the deprecated "az deployment create" calls which were generating warnings.

Fix the stages conditionals and "dependsOns" for proper dependencies and parallelisms.

Add "runCodesignValidationInjection: false". This unnecessary injected task is costing every build several minutes.

Make deployment names unique by appending build ID with: az deployment sub create --name "$(BotName)$(Build.BuildId)". Non-unique deployment names I believe was causing the "Azure Error: DeploymentActive" errors.