### PR TITLE
[Skills Functional Tests][Python] Revert YAML azureSubscription to $(AzureSubscription)

### DIFF
--- a/build/yaml/pythonDeployStepsExistingRG.yml
+++ b/build/yaml/pythonDeployStepsExistingRG.yml
@@ -91,7 +91,7 @@ steps:
 - task: AzureCLI@2
   displayName: 'create Azure resources - pre-existing RG template'
   inputs:
-    azureSubscription: 'FUSE Temporary (174c5021-8109-4087-a3e2-a1de20420569)'
+    azureSubscription: $(AzureSubscription)
     scriptType: ps
     scriptLocation: inlineScript
     inlineScript: |

--- a/build/yaml/pythonDeployStepsNewRG.yml
+++ b/build/yaml/pythonDeployStepsNewRG.yml
@@ -91,7 +91,7 @@ steps:
 - task: AzureCLI@2
   displayName: 'create Azure resources - new RG template'
   inputs:
-    azureSubscription: 'FUSE Temporary (174c5021-8109-4087-a3e2-a1de20420569)'
+    azureSubscription: $(AzureSubscription)
     scriptType: ps
     scriptLocation: inlineScript
     inlineScript: |


### PR DESCRIPTION
## Description
Reverts the temporary changes of _azureSubscription_ in Python's resource creation step YAML files.

## Specific Changes

  - Reverts `azureSubscription` to `$(AzureSubscription)` in `pythonDeployStepsExistingRG.yml` and `pythonDeployStepsNewRG.yml`