### PR TITLE
Install later NuGet version for functional tests pipelines

### DIFF
--- a/build/yaml/dotnetBuildSteps.yml
+++ b/build/yaml/dotnetBuildSteps.yml
@@ -14,10 +14,8 @@ steps:
     version: 3.1.x
   condition: ne(variables['SkipNetCore'], 'true')
 
-- task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 4.9.1'
-  inputs:
-    versionSpec: 4.9.1
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet '
 
 - task: NuGetCommand@2
   displayName: 'NuGet restore'

--- a/build/yaml/dotnetInstallPackagesSteps.yml
+++ b/build/yaml/dotnetInstallPackagesSteps.yml
@@ -13,10 +13,8 @@ steps:
 
 - template: validateRegistryAndBBVersionSteps.yml
 
-- task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 4.9.1'
-  inputs:
-    versionSpec: 4.9.1
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet '
 
 - powershell: |
    Write-Host "BBVersion: "$(BBVersion)

--- a/build/yaml/dotnetV3BuildSteps.yml
+++ b/build/yaml/dotnetV3BuildSteps.yml
@@ -2,10 +2,8 @@ steps:
 - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
   displayName: 'Display env vars'
 
-- task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 4.9.1'
-  inputs:
-    versionSpec: 4.9.1
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet '
 
 - task: NuGetCommand@2
   displayName: 'NuGet restore'


### PR DESCRIPTION
Nuget being used was 4.9.1. Now it's 5.8.0.

This fixes the many errors:
##[error]C:\Program Files\dotnet\sdk\5.0.100\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(241,5): Error NETSDK1005: Assets file 'D:\a\1\s\libraries\Microsoft.Bot.Builder.Dialogs.Adaptive\obj\project.assets.json' doesn't have a target for 'netstandard2.0'. Ensure that restore has run and that you have included 'netstandard2.0' in the TargetFrameworks for your project.

Apparently brought on by a new version of msbuild being used.