### PR TITLE
[Skills Everywhere][#176] Move TestClient.SignIn method out of TestClient for reusability

### DIFF
--- a/Libraries/TranscriptTestRunner/Authentication/Session.cs
+++ b/Libraries/TranscriptTestRunner/Authentication/Session.cs
@@ -3,18 +3,18 @@
 
 using Newtonsoft.Json;
 
-namespace TranscriptTestRunner.TestClients
+namespace TranscriptTestRunner.Authentication
 {
     /// <summary>
-    /// DirectLine session definition.
+    /// Session definition.
     /// </summary>
-    public class DirectLineSession
+    public class Session
     {
         /// <summary>
-        /// Gets or sets the DirectLine session ID.
+        /// Gets or sets the session ID.
         /// </summary>
         /// <value>
-        /// The DirectLine session ID.
+        /// The session ID.
         /// </value>
         [JsonProperty("sessionId")]
         public string SessionId { get; set; }

--- a/Libraries/TranscriptTestRunner/Authentication/SessionInfo.cs
+++ b/Libraries/TranscriptTestRunner/Authentication/SessionInfo.cs
@@ -3,26 +3,26 @@
 
 using System.Net;
 
-namespace TranscriptTestRunner.TestClients
+namespace TranscriptTestRunner.Authentication
 {
     /// <summary>
-    /// DirectLine session information definition.
+    /// Session information definition.
     /// </summary>
-    public class DirectLineSessionInfo
+    public class SessionInfo
     {
         /// <summary>
-        /// Gets or sets the DirectLine session ID.
+        /// Gets or sets the session ID.
         /// </summary>
         /// <value>
-        /// The DirectLine session ID.
+        /// The session ID.
         /// </value>
         public string SessionId { get; set; }
 
         /// <summary>
-        /// Gets or sets the DirectLine session cookie.
+        /// Gets or sets the session cookie.
         /// </summary>
         /// <value>
-        /// The DirectLine session cookie.
+        /// The session cookie.
         /// </value>
         public Cookie Cookie { get; set; }
     }

--- a/Libraries/TranscriptTestRunner/Authentication/TestClientAuthentication.cs
+++ b/Libraries/TranscriptTestRunner/Authentication/TestClientAuthentication.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace TranscriptTestRunner.Authentication
+{
+    /// <summary>
+    /// Authentication class for the Test Client.
+    /// </summary>
+    public static class TestClientAuthentication
+    {
+        /// <summary>
+        /// Signs in to the bot.
+        /// </summary>
+        /// <param name="url">The sign in Url.</param>
+        /// <param name="originHeader">The Origin Header with key and value.</param>
+        /// <param name="sessionInfo">The Session information definition.</param>
+        /// <returns>True, if SignIn is successful; otherwise false.</returns>
+        public static async Task<bool> SignInAsync(string url, KeyValuePair<string, string> originHeader, SessionInfo sessionInfo)
+        {
+            var cookieContainer = new CookieContainer();
+            using var handler = new HttpClientHandler
+            {
+                AllowAutoRedirect = false,
+                CookieContainer = cookieContainer
+            };
+
+            // We have a sign in url, which will produce multiple HTTP 302 for redirects
+            // This will path 
+            //      token service -> other services -> auth provider -> token service (post sign in)-> response with token
+            // When we receive the post sign in redirect, we add the cookie passed in the session info
+            // to test enhanced authentication. This in the scenarios happens by itself since browsers do this for us.
+            using var client = new HttpClient(handler);
+            client.DefaultRequestHeaders.Add(originHeader.Key, originHeader.Value);
+
+            while (!string.IsNullOrEmpty(url))
+            {
+                using var response = await client.GetAsync(new Uri(url)).ConfigureAwait(false);
+                var text = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                url = response.StatusCode == HttpStatusCode.Redirect
+                    ? response.Headers.Location.OriginalString
+                    : null;
+
+                // Once the redirects are done, there is no more url. 
+                // This means we did the entire loop.
+                if (url == null)
+                {
+                    if (!response.IsSuccessStatusCode || !text.Contains("You are now signed in and can close this window."))
+                    {
+                        throw new Exception("An error occurred signing in");
+                    }
+
+                    return true;
+                }
+
+                // If this is the post sign in callback, add the cookie and code challenge
+                // so that the token service gets the verification.
+                // Here we are simulating what WebChat does along with the browser cookies.
+                if (url.StartsWith("https://token.botframework.com/api/oauth/PostSignInCallback", StringComparison.Ordinal))
+                {
+                    url += $"&code_challenge={sessionInfo.SessionId}";
+                    cookieContainer.Add(sessionInfo.Cookie);
+                }
+            }
+
+            throw new Exception("Sign in did not succeed. Set a breakpoint in TestClientAuthentication.SignInAsync() to debug the redirect sequence.");
+        }
+
+        /// <summary>
+        /// Obtains the <see cref="SessionInfo"/> from an URL endpoint with a token.
+        /// </summary>
+        /// <param name="url">The URL endpoint to obtain the <see cref="SessionInfo"/> from.</param>
+        /// <param name="token">The token to use for authorization.</param>
+        /// <param name="originHeader">The Origin Header with key and value.</param>
+        /// <returns>The <see cref="SessionInfo"/> Task.</returns>
+        public static async Task<SessionInfo> GetSessionInfoAsync(string url, string token, KeyValuePair<string, string> originHeader)
+        {
+            // Set up cookie container to obtain response cookie
+            var cookies = new CookieContainer();
+            using var handler = new HttpClientHandler { CookieContainer = cookies };
+
+            using var client = new HttpClient(handler);
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            // We want to add the Origins header to this client as well
+            client.DefaultRequestHeaders.Add(originHeader.Key, originHeader.Value);
+
+            using var response = await client.SendAsync(request).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
+            {
+                // Extract cookie from cookies
+                var cookie = cookies.GetCookies(new Uri(url)).Cast<Cookie>().FirstOrDefault(c => c.Name == "webchat_session_v2");
+
+                // Extract session info from body
+                var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var session = JsonConvert.DeserializeObject<Session>(body);
+
+                return new SessionInfo
+                {
+                    SessionId = session.SessionId,
+                    Cookie = cookie
+                };
+            }
+
+            throw new Exception("Failed to obtain session id");
+        }
+    }
+}

--- a/Libraries/TranscriptTestRunner/Authentication/TokenInfo.cs
+++ b/Libraries/TranscriptTestRunner/Authentication/TokenInfo.cs
@@ -3,27 +3,27 @@
 
 using Newtonsoft.Json;
 
-namespace TranscriptTestRunner.TestClients
+namespace TranscriptTestRunner.Authentication
 {
     /// <summary>
-    /// DirectLine token definition.
+    /// Token definition.
     /// </summary>
-    public class DirectLineToken
+    public class TokenInfo
     {
         /// <summary>
-        /// Gets or sets the DirectLine token string.
+        /// Gets or sets the token string.
         /// </summary>
         /// <value>
-        /// The DirectLine token string.
+        /// The token string.
         /// </value>
         [JsonProperty("token")]
         public string Token { get; set; }
 
         /// <summary>
-        /// Gets or sets the DirectLine conversation ID.
+        /// Gets or sets the conversation ID.
         /// </summary>
         /// <value>
-        /// The DirectLine conversation ID.
+        /// The conversation ID.
         /// </value>
         [JsonProperty("conversationId")]
         public string ConversationId { get; set; }

--- a/Libraries/TranscriptTestRunner/TestClientBase.cs
+++ b/Libraries/TranscriptTestRunner/TestClientBase.cs
@@ -37,6 +37,6 @@ namespace TranscriptTestRunner
         /// </summary>
         /// <param name="signInUrl">The sign in Url.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
-        public abstract Task SignInAsync(string signInUrl);
+        public abstract Task<bool> SignInAsync(string signInUrl);
     }
 }

--- a/Libraries/TranscriptTestRunner/TestClientBase.cs
+++ b/Libraries/TranscriptTestRunner/TestClientBase.cs
@@ -36,7 +36,7 @@ namespace TranscriptTestRunner
         /// Signs in to the bot.
         /// </summary>
         /// <param name="signInUrl">The sign in Url.</param>
-        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <returns>True, if SignIn is successful; otherwise false.</returns>
         public abstract Task<bool> SignInAsync(string signInUrl);
     }
 }


### PR DESCRIPTION
Fixes #176

## Description
This PR moves the `SignInAsync` and `GetSessionInfoAsync` methods functionalities out of the `DirectLineTestClient` class and renames the `DirectLineSession`, `DirectLineSessionInfo`, `DirectLineToken` classes.

## Specific Changes
- Added `TestClientAuthentication` static class with the namespace `TranscriptTestRunner.Authentication` containing the `SignInAsync` and `GetSessionInfoAsync` static methods.
- Moved and renamed the following classes to the `TranscriptTestRunner.Authentication` namespace:
  - `DirectLineSession` => `Session`.
  - `DirectLineSessionInfo` => `SessionInfo`.
  - `DirectLineToken` => `Token`.

![image](https://user-images.githubusercontent.com/62260472/99565440-632ced80-29aa-11eb-85df-ba057d2b05e9.png)

## Testing
The following image shows the tests running and passing successfully.
![image](https://user-images.githubusercontent.com/62260472/99435215-94e07e80-28ee-11eb-88ae-3e7e96b92ad9.png)