### PR TITLE
[Skills Everywhere] Add python timeout workaround

### DIFF
--- a/Libraries/TranscriptTestRunner/TestRunner.cs
+++ b/Libraries/TranscriptTestRunner/TestRunner.cs
@@ -37,7 +37,7 @@ namespace TranscriptTestRunner
         public TestRunner(TestClientBase client, ILogger logger = null)
         {
             _testClient = client;
-            _replyTimeout = 45000;
+            _replyTimeout = 100000;
             _logger = logger ?? NullLogger.Instance;
         }
 

--- a/Tests/SkillFunctionalTests/OAuthSkillTest.cs
+++ b/Tests/SkillFunctionalTests/OAuthSkillTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -48,29 +49,47 @@ namespace SkillFunctionalTests
         [Fact]
         public async Task ShouldSignIn()
         {
-            var runner = new XUnitTestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient(), _logger);
-            var signInUrl = string.Empty;
-            
-            // Execute the first part of the conversation.
-            await runner.RunTestAsync(Path.Combine(_transcriptsFolder, "ShouldSignIn1.transcript"));
-
-            // Obtain the signIn url.
-            await runner.AssertReplyAsync(activity =>
+            var tries = 3;
+            for (int index = 0; index < tries; index++)
             {
-                Assert.Equal(ActivityTypes.Message, activity.Type);
-                Assert.True(activity.Attachments.Count > 0);
-                
-                var card = JsonConvert.DeserializeObject<SigninCard>(JsonConvert.SerializeObject(activity.Attachments.FirstOrDefault().Content));
-                signInUrl = card.Buttons[0].Value?.ToString();
+                try
+                {
+                    var runner = new XUnitTestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient(), _logger);
+                    var signInUrl = string.Empty;
 
-                Assert.False(string.IsNullOrEmpty(signInUrl));
-            });
+                    // Execute the first part of the conversation.
+                    await runner.RunTestAsync(Path.Combine(_transcriptsFolder, "ShouldSignIn1.transcript"));
 
-            // Execute the SignIn.
-            await runner.ClientSignInAsync(signInUrl);
+                    // Obtain the signIn url.
+                    await runner.AssertReplyAsync(activity =>
+                    {
+                        Assert.Equal(ActivityTypes.Message, activity.Type);
+                        Assert.True(activity.Attachments.Count > 0);
 
-            // Execute the rest of the conversation.
-            await runner.RunTestAsync(Path.Combine(_transcriptsFolder, "ShouldSignIn2.transcript"));
+                        var card = JsonConvert.DeserializeObject<SigninCard>(JsonConvert.SerializeObject(activity.Attachments.FirstOrDefault().Content));
+                        signInUrl = card.Buttons[0].Value?.ToString();
+
+                        Assert.False(string.IsNullOrEmpty(signInUrl));
+                    });
+
+                    // Execute the SignIn.
+                    await runner.ClientSignInAsync(signInUrl);
+
+                    // Execute the rest of the conversation.
+                    await runner.RunTestAsync(Path.Combine(_transcriptsFolder, "ShouldSignIn2.transcript"));
+                }
+                catch (TimeoutException timeoutException)
+                {
+                    if (index + 1 == tries)
+                    {
+                        throw timeoutException;
+                    }
+                    else
+                    {
+                        _logger.LogInformation($"======== Timeout exception on try number {index + 1}, starting retry... ========");
+                    }
+                }
+            }
         }
     }
 }

--- a/Tests/SkillFunctionalTests/OAuthSkillTest.cs
+++ b/Tests/SkillFunctionalTests/OAuthSkillTest.cs
@@ -49,8 +49,8 @@ namespace SkillFunctionalTests
         [Fact]
         public async Task ShouldSignIn()
         {
-            var tries = 3;
-            for (int index = 0; index < tries; index++)
+            const int tries = 3;
+            for (var index = 0; index < tries; index++)
             {
                 try
                 {
@@ -78,16 +78,13 @@ namespace SkillFunctionalTests
                     // Execute the rest of the conversation.
                     await runner.RunTestAsync(Path.Combine(_transcriptsFolder, "ShouldSignIn2.transcript"));
                 }
-                catch (TimeoutException timeoutException)
+                catch (TimeoutException)
                 {
                     if (index + 1 == tries)
                     {
-                        throw timeoutException;
+                        throw;
                     }
-                    else
-                    {
-                        _logger.LogInformation($"======== Timeout exception on try number {index + 1}, starting retry... ========");
-                    }
+                    _logger.LogInformation($"======== Timeout exception on try number {index + 1}, starting retry... ========");
                 }
             }
         }

--- a/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
+++ b/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
@@ -48,24 +48,21 @@ namespace SkillFunctionalTests
         [InlineData("HostReceivesEndOfConversation.transcript")]
         public async Task RunScripts(string transcript)
         {
-            var tries = 3;
-            for (int index = 0; index < tries; index++)
+            const int tries = 3;
+            for (var index = 0; index < tries; index++)
             {
                 try
                 {
                     var runner = new XUnitTestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient(), _logger);
                     await runner.RunTestAsync(Path.Combine(_transcriptsFolder, transcript));
                 }
-                catch (TimeoutException timeoutException)
+                catch (TimeoutException)
                 {
                     if (index + 1 == tries)
                     {
-                        throw timeoutException;
+                        throw;
                     }
-                    else
-                    {
-                        _logger.LogInformation($"======== Timeout exception on try number {index + 1}, starting retry... ========");
-                    }
+                    _logger.LogInformation($"======== Timeout exception on try number {index + 1}, starting retry... ========");
                 }
             }
         }
@@ -73,8 +70,8 @@ namespace SkillFunctionalTests
         [Fact]
         public async Task ManualTest()
         {
-            var tries = 3;
-            for (int index = 0; index < tries; index++)
+            const int tries = 3;
+            for (var index = 0; index < tries; index++)
             {
                 try
                 {
@@ -88,16 +85,13 @@ namespace SkillFunctionalTests
                         Assert.Equal("Hello and welcome!", activity.Text);
                     });
                 }
-                catch (TimeoutException timeoutException)
+                catch (TimeoutException)
                 {
                     if (index + 1 == tries)
                     {
-                        throw timeoutException;
+                        throw;
                     }
-                    else
-                    {
-                        _logger.LogInformation($"======== Timeout exception on try number {index + 1}, starting retry... ========");
-                    }
+                    _logger.LogInformation($"======== Timeout exception on try number {index + 1}, starting retry... ========");
                 }
             }
         }

--- a/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
+++ b/Tests/SkillFunctionalTests/SimpleHostBotToEchoSkillTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
@@ -47,22 +48,58 @@ namespace SkillFunctionalTests
         [InlineData("HostReceivesEndOfConversation.transcript")]
         public async Task RunScripts(string transcript)
         {
-            var runner = new XUnitTestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient(), _logger);
-            await runner.RunTestAsync(Path.Combine(_transcriptsFolder, transcript));
+            var tries = 3;
+            for (int index = 0; index < tries; index++)
+            {
+                try
+                {
+                    var runner = new XUnitTestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient(), _logger);
+                    await runner.RunTestAsync(Path.Combine(_transcriptsFolder, transcript));
+                }
+                catch (TimeoutException timeoutException)
+                {
+                    if (index + 1 == tries)
+                    {
+                        throw timeoutException;
+                    }
+                    else
+                    {
+                        _logger.LogInformation($"======== Timeout exception on try number {index + 1}, starting retry... ========");
+                    }
+                }
+            }
         }
 
         [Fact]
         public async Task ManualTest()
         {
-            var runner = new XUnitTestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient(), _logger);
-
-            await runner.SendActivityAsync(new Activity(ActivityTypes.ConversationUpdate));
-
-            await runner.AssertReplyAsync(activity =>
+            var tries = 3;
+            for (int index = 0; index < tries; index++)
             {
-                Assert.Equal(ActivityTypes.Message, activity.Type);
-                Assert.Equal("Hello and welcome!", activity.Text);
-            });
+                try
+                {
+                    var runner = new XUnitTestRunner(new TestClientFactory(ClientType.DirectLine).GetTestClient(), _logger);
+
+                    await runner.SendActivityAsync(new Activity(ActivityTypes.ConversationUpdate));
+
+                    await runner.AssertReplyAsync(activity =>
+                    {
+                        Assert.Equal(ActivityTypes.Message, activity.Type);
+                        Assert.Equal("Hello and welcome!", activity.Text);
+                    });
+                }
+                catch (TimeoutException timeoutException)
+                {
+                    if (index + 1 == tries)
+                    {
+                        throw timeoutException;
+                    }
+                    else
+                    {
+                        _logger.LogInformation($"======== Timeout exception on try number {index + 1}, starting retry... ========");
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Addresses #175

## Description
Python's functional tests tend to result in timeout exceptions; these timeouts can happen at any point in the tests.
This PR adds a retry to the skill functional tests as a workaround for the timeout exceptions. If a test fails due to timeout, it will start over up to three times.
The bot response timeout was increased to `100,000 milliseconds` to avoid double timeouts.

_Note: The tests may fail if generic exceptions are thrown by the bots as it only retries timeouts._

## Specific Changes

  - Adds retry solution to all skill functional tests
  - Increases the bot response timeout to `100,000 milliseconds`

## Testing
The following screenshot shows a test that was retried working, and how to retry output looks like:
![image](https://user-images.githubusercontent.com/64803884/100482859-f49d0d80-30d6-11eb-840e-bfa00e77a191.png)
