### PR TITLE
[Skills Everywhere][#183] Add Run Test Scenarios pipeline

### DIFF
--- a/build/yaml/testScenarios/build.yml
+++ b/build/yaml/testScenarios/build.yml
@@ -1,0 +1,24 @@
+steps:
+- powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+  displayName: 'Display env vars'
+
+- task: UseDotNet@2
+  displayName: 'Use .Net Core sdk 3.1.x'
+  inputs:
+    version: 3.1.x
+
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet '
+
+- task: NuGetCommand@2
+  displayName: 'NuGet restore'
+  inputs:
+    restoreSolution: '$(Parameters.solution)'
+
+- task: VSBuild@1
+  displayName: 'Build solution'
+  inputs:
+    solution: '$(Parameters.solution)'
+    vsVersion: 16.0
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'

--- a/build/yaml/testScenarios/runFunctionalTests.yml
+++ b/build/yaml/testScenarios/runFunctionalTests.yml
@@ -1,0 +1,27 @@
+parameters:
+  resourceGroup: ''
+
+steps:
+- task: AzureCLI@1
+  displayName: 'Create DirectLine Channel'
+  inputs:
+    azureSubscription: $(AzureSubscription)
+    scriptLocation: inlineScript
+    inlineScript: |
+      call az bot directline create -n "$(HostBotName)" -g "${{ parameters.resourceGroup }}" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json"
+      
+- powershell: |
+    $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+    $key = $json.properties.properties.sites.key;
+    echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+    echo "##vso[task.setvariable variable=BOTID;]$(HostBotName)";
+  displayName: 'Get Bot Keys'
+
+- template: build.yml
+
+- task: DotNetCoreCLI@2
+  displayName: 'Dotnet Test'
+  inputs:
+    command: test
+    projects: $(Parameters.project)
+    arguments: '-v n  --configuration $(BuildConfiguration) --no-build --no-restore --filter TestCategory!=IgnoreInAutomatedBuild$(TestFilter)'

--- a/build/yaml/testScenarios/runScenario.yml
+++ b/build/yaml/testScenarios/runScenario.yml
@@ -1,0 +1,34 @@
+parameters:
+  consumers: []
+  skills: []
+
+stages:
+- ${{ each consumer in parameters.consumers }}:
+  - ${{ each skill in parameters.skills }}:
+    - stage: ${{ consumer.name }}_${{ skill.name }}
+      jobs:
+        - job: Configure
+          steps:
+            - ${{ if eq(consumer.language, 'DotNet') }}:
+              - task: AzureCLI@2
+                displayName: 'Configure Host Bots Settings'
+                inputs:
+                  azureSubscription: $(AzureSubscription)
+                  scriptType: ps
+                  scriptLocation: inlineScript
+                  inlineScript: |
+                    az webapp config appsettings set -g ${{ consumer.resourceGroup }} -n ${{ consumer.botName }} --settings BotFrameworkSkills:0:AppId=${{ skill.appId }} BotFrameworkSkills:0:SkillEndpoint=https://${{ skill.botName }}.azurewebsites.net/api/messages SkillHostEndpoint=https://${{ consumer.botName }}.azurewebsites.net/api/skills
+
+        - job: Test
+          dependsOn: Configure
+          variables:
+            HostBotName: ${{ consumer.botName }}
+            Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
+            Parameters.solution: 'SkillFunctionalTests.sln'
+            DefaultTestFilter: ''
+            FilterParam: ${{ skill.testFilter }}
+            TestFilter: $[ coalesce( variables['FilterParam'], variables['DefaultTestFilter'] ) ]
+          steps:
+          - template: runFunctionalTests.yml
+            parameters:
+              resourceGroup: ${{ consumer.resourceGroup }}

--- a/build/yaml/testScenarios/runScenario.yml
+++ b/build/yaml/testScenarios/runScenario.yml
@@ -9,7 +9,7 @@ stages:
       jobs:
         - job: Configure
           steps:
-            - ${{ if eq(consumer.language, 'DotNet') }}:
+            - ${{ if eq(consumer.configType, 'DotNet') }}:
               - task: AzureCLI@2
                 displayName: 'Configure Host Bots Settings'
                 inputs:

--- a/build/yaml/testScenarios/runTestScenarios.yml
+++ b/build/yaml/testScenarios/runTestScenarios.yml
@@ -26,12 +26,12 @@ stages:
       - name: SimpleHostBotDotnet
         botName: bffnsimplehostbotdotnet
         resourceGroup: "$(ResourceGroup)-DotNet"
-        language: "DotNet"
+        configType: "DotNet"
 
       - name: SimpleHostBot21Dotnet
         botName: bffnsimplehostbot21dotnet
         resourceGroup: "$(ResourceGroup)-DotNet"
-        language: "DotNet"
+        configType: "DotNet"
 
     Skills:
       - name: EchoSkillBotDotnet

--- a/build/yaml/testScenarios/runTestScenarios.yml
+++ b/build/yaml/testScenarios/runTestScenarios.yml
@@ -1,0 +1,48 @@
+#
+# Executes the test scenarios.
+#
+
+# "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
+name: $(Build.BuildId)
+trigger: none
+pr: none
+
+variables:
+  BuildConfiguration: 'Debug'
+  BuildPlatform: 'any cpu'
+  # AzureSubscription: define in Azure
+  # BffnEchoSkillBotDotnetAppId: define in Azure
+  # BffnEchoSkillBot21DotnetAppId: define in Azure
+  # BffnEchoSkillBotV3DotnetAppId: define in Azure
+  # ResourceGroup: define in Azure
+
+pool:
+  vmImage: 'windows-2019'
+
+stages:
+- template: runScenario.yml
+  parameters:
+    Consumers:
+      - name: SimpleHostBotDotnet
+        botName: bffnsimplehostbotdotnet
+        resourceGroup: "$(ResourceGroup)-DotNet"
+        language: "DotNet"
+
+      - name: SimpleHostBot21Dotnet
+        botName: bffnsimplehostbot21dotnet
+        resourceGroup: "$(ResourceGroup)-DotNet"
+        language: "DotNet"
+
+    Skills:
+      - name: EchoSkillBotDotnet
+        botName: bffnechoskillbotdotnet
+        appId: $(BffnEchoSkillBotDotnetAppId)
+
+      - name: EchoSkillBot21Dotnet
+        botName: bffnechoskillbot21dotnet
+        appId: $(BffnEchoSkillBot21DotnetAppId)
+
+      - name: EchoSkillBotV3Dotnet
+        botName: bffnechoskillbotv3dotnet
+        appId: $(BffnEchoSkillBotV3DotnetAppId)
+        testFilter: '&TestCategory!=SkipForV3Bots'


### PR DESCRIPTION
Addresses #183

## Description
This PR adds the yaml files for a pipeline that configure the bots and execute the test scenarios.
Each test scenario is a stage in the pipeline and they run sequentially.

## Specific Changes
- Added the following yaml files:
  - `runTestScenarios.yml` : contains the list of test scenarios to execute.
  - `runScenario.yml` : contains the steps to configure and execute the test scenario.
  - `runfunctionalTest` : contains the steps to execute the tests.
  - `build` : contains the steps to build the test project.


## Testing
The following image shows the pipeline running successfully:
![image](https://user-images.githubusercontent.com/44245136/100760237-4cd25900-33d0-11eb-9964-8b518b24d6f2.png)

And this image shows the steps executed for each host-skill pair:
![image](https://user-images.githubusercontent.com/44245136/103000433-d4ac0e80-4509-11eb-8a6c-4d9ef1da4cb5.png)
