### PR TITLE
Fixed some lg issues for composer bots so the RunScripts test pass when running against composer

### DIFF
--- a/Bots/DotNet/Consumers/Composer/SimpleComposerHostBot/language-generation/en-us/simplecomposerhostbot.en-us.lg
+++ b/Bots/DotNet/Consumers/Composer/SimpleComposerHostBot/language-generation/en-us/simplecomposerhostbot.en-us.lg
@@ -2,10 +2,27 @@
 
 
 # SendActivity_1fPEND()
-- Hello and welcome!
+[Activity
+    Text = Hello and welcome!
+    InputHint = acceptingInput
+]
 # SendActivity_VV7JVt()
-- Me no nothin'. Say "skill" and I'll patch you through
-
+[Activity
+    Text = Me no nothin'. Say "skill" and I'll patch you through
+    InputHint = acceptingInput
+]
 # SendActivity_mb8ZXL()
-- Got it, connecting you to the skill...
-
+[Activity
+    Text = Got it, connecting you to the skill...
+    InputHint = acceptingInput
+]
+# SendActivity_Zkprn3()
+[Activity
+    Text = Received endOfConversation.\n\nCode: ${turn.activity.code}completedSuccessfully
+    InputHint = acceptingInput
+]
+# SendActivity_71moHf()
+[Activity
+    Text = Back in the host bot. Say "skill" and I'll patch you through
+    InputHint = acceptingInput
+]

--- a/Bots/DotNet/Consumers/Composer/SimpleComposerHostBot/simplecomposerhostbot.dialog
+++ b/Bots/DotNet/Consumers/Composer/SimpleComposerHostBot/simplecomposerhostbot.dialog
@@ -70,6 +70,28 @@
           "resultProperty": "dialog.result"
         }
       ]
+    },
+    {
+      "$kind": "Microsoft.OnEndOfConversationActivity",
+      "$designer": {
+        "id": "PGigli"
+      },
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "$designer": {
+            "id": "Zkprn3"
+          },
+          "activity": "${SendActivity_Zkprn3()}"
+        },
+        {
+          "$kind": "Microsoft.SendActivity",
+          "$designer": {
+            "id": "71moHf"
+          },
+          "activity": "${SendActivity_71moHf()}"
+        }
+      ]
     }
   ],
   "$schema": "https://raw.githubusercontent.com/microsoft/BotFramework-Composer/stable/Composer/packages/server/schemas/sdk.schema",

--- a/Bots/DotNet/Skills/Composer/EchoComposerSkillBot/language-generation/en-us/echocomposerskillbot.en-us.lg
+++ b/Bots/DotNet/Skills/Composer/EchoComposerSkillBot/language-generation/en-us/echocomposerskillbot.en-us.lg
@@ -4,8 +4,19 @@
 - ${WelcomeUser()}
 
 # SendActivity_xkiYnF()
-- Echo: ${turn.activity.text}
+[Activity
+    Text = Echo: ${turn.activity.text}
+    InputHint = acceptingInput
+]
+
 # SendActivity_P5ISO4()
-- Ending conversation from the skill...
+[Activity
+    Text = Ending conversation from the skill...
+    InputHint = acceptingInput
+]
+
 # SendActivity_rKkWVg()
-- Say "end" or "stop" and I'll end the conversation and back to the parent.
+[Activity
+    Text = Say "end" or "stop" and I'll end the conversation and back to the parent.
+    InputHint = acceptingInput
+]


### PR DESCRIPTION
Fixes for #179
- Added inputHint to responses
- Added trigger to handle EoC from the skill for parity with SimpleHostBot.
- For now hardcoded the EoC code property so the test passes but created an [issue](https://github.com/microsoft/botbuilder-dotnet/issues/4999) in the SDK to have this fixed.