### PR TITLE
[Skills Everywhere][#183] Add Deploy Bots pipeline

### DIFF
--- a/build/templates/template-bot-resources.json
+++ b/build/templates/template-bot-resources.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appId": {
+      "type": "string",
+      "metadata": {
+        "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+      }
+    },
+    "appSecret": {
+      "type": "string",
+      "metadata": {
+        "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+      }
+    },
+    "botName": {
+      "type": "string"
+    },
+    "botLocation": {
+      "type": "string"
+    },
+    "appServicePlanName": {
+      "type": "string"
+    },
+    "appServicePlanResourceGroup": {
+      "type": "string"
+    },
+    "botSku": {
+      "type": "string",
+      "defaultValue": "F0",
+      "metadata": {
+        "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+      }
+    }
+  },
+  "variables": {
+    "siteHost": "[concat(parameters('botName'), '.azurewebsites.net')]",
+    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2018-11-01",
+      "name": "[parameters('botName')]",
+      "type": "Microsoft.Web/sites",
+      "location": "[parameters('botLocation')]",
+      "tags": {},
+      "dependsOn": [],
+      "kind": "app",
+      "properties": {
+        "name": "[parameters('botName')]",
+        "siteConfig": {
+          "appSettings": [
+            {
+                "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                "value": "10.14.1"
+            },
+            {
+              "name": "MicrosoftAppId",
+              "value": "[parameters('appId')]"
+            },
+            {
+              "name": "MicrosoftAppPassword",
+              "value": "[parameters('appSecret')]"
+            }
+          ],
+          "cors": {
+            "allowedOrigins": [
+              "https://botservice.hosting.portal.azure.net",
+              "https://hosting.onecloud.azure-test.net/"
+            ]
+          },
+          "webSocketsEnabled": true
+        },
+        "serverFarmId": "[concat('/subscriptions/', subscription().id,'/resourcegroups/', parameters('appServicePlanResourceGroup'), '/providers/Microsoft.Web/serverfarms/', parameters('appServicePlanName'))]",
+        "clientAffinityEnabled": true
+      }
+    },
+    {
+      "apiVersion": "2017-12-01",
+      "type": "Microsoft.BotService/botServices",
+      "name": "[parameters('botName')]",
+      "location": "global",
+      "kind": "bot",
+      "sku": {
+        "name": "[parameters('botSku')]"
+      },
+      "properties": {
+        "name": "[parameters('botName')]",
+        "displayName": "[parameters('botName')]",
+        "endpoint": "[variables('botEndpoint')]",
+        "msaAppId": "[parameters('appId')]",
+        "developerAppInsightsApplicationId": null,
+        "developerAppInsightKey": null,
+        "publishingCredentials": null,
+        "storageResourceId": null
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites/', parameters('botName'))]"
+      ]
+    }
+  ]
+}

--- a/build/yaml/deployBotResources/common/configureOAuth.yml
+++ b/build/yaml/deployBotResources/common/configureOAuth.yml
@@ -1,0 +1,15 @@
+parameters:
+  appId: ''
+  appSecret: ''
+  botName: ''
+  botGroup: ''
+
+steps:
+  - task: AzureCLI@1
+    displayName: 'Configure OAuth connection'
+    inputs:
+      azureSubscription: $(AzureSubscription)
+      scriptLocation: inlineScript
+      inlineScript: |
+        call az bot show -g "${{ parameters.botGroup }}" -n "${{ parameters.botName }}"
+        call az bot authsetting create -g "${{ parameters.botGroup }}" -n "${{ parameters.botName }}" -c TestOAuthProvider --client-id "${{ parameters.appId }}" --client-secret "${{ parameters.appSecret }}" --service "oauth2" --provider-scope-string '""' --parameters authorizationUrl=https://webjobs.botframework.com/api/testauthprovider/authorize tokenUrl=https://webjobs.botframework.com/api/testauthprovider/token refreshUrl=https://webjobs.botframework.com/api/testauthprovider/refresh clientId="${{ parameters.appId }}" clientSecret="${{ parameters.appSecret }}"

--- a/build/yaml/deployBotResources/common/createAppService.yml
+++ b/build/yaml/deployBotResources/common/createAppService.yml
@@ -1,0 +1,21 @@
+parameters:
+  appId: ''
+  appSecret: ''
+  botName: ''
+  botGroup: ''
+
+steps:
+  - task: AzureCLI@2
+    displayName: 'Create resources'
+    inputs:
+      azureSubscription: $(AzureSubscription)
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Set-PSDebug -Trace 1;
+
+        $botPricingTier = if($env:BotPricingTier) { "botSku=$env:BotPricingTier" };
+
+        az deployment group create --resource-group "${{ parameters.botGroup }}" --name "${{ parameters.botName }}" --template-file "build\templates\template-bot-resources.json" --parameters $botPricingTier botLocation="westus" appId="${{ parameters.appId }}" appSecret="${{ parameters.appSecret }}" botName="${{ parameters.botName }}" appServicePlanName="$(AppServicePlanName)" appServicePlanResourceGroup="$(AppServicePlanGroup)";
+
+        Set-PSDebug -Trace 0;

--- a/build/yaml/deployBotResources/common/prepareResources.yml
+++ b/build/yaml/deployBotResources/common/prepareResources.yml
@@ -1,0 +1,46 @@
+parameters:
+  resourceGroups: []
+
+stages:
+- ${{ each resourceGroup in parameters.resourceGroups }}:
+  - stage: '${{ resourceGroup.id }}'
+    displayName: '${{ resourceGroup.displayName }}'
+    dependsOn: [] # Makes this run in parallel
+    jobs:
+      - job: 'Prepare'
+        displayName: 'Prepare steps'
+        steps:
+          - task: AzureCLI@2
+            displayName: 'Delete pre-existing Resource Group'
+            inputs:
+              azureSubscription: $(AzureSubscription)
+              scriptType: ps
+              scriptLocation: inlineScript
+              inlineScript: |
+                Write-Host "Looking for '${{ resourceGroup.name }}'...";
+                $resourcesFound = $false;
+
+                if ((az group exists -n "${{ resourceGroup.name }}") -eq 'true')
+                {
+                  Write-Host "Deleting ${{ resourceGroup.name }}...";
+                  az group delete -n "${{ resourceGroup.name }}" --yes --no-wait;
+                  $resourcesFound = $true;
+                }
+
+                if ($resourcesFound)
+                {
+                  # Wait for delete(s) to finish for cases where a Deploy step is next.
+                  az group wait --deleted --interval 15 --timeout 600 --resource-group "${{ resourceGroup.name }}";
+                }
+                else
+                {
+                  Write-Host "No pre-existing resource group found.";
+                } 
+
+          - task: AzureCLI@1
+            displayName: 'Create Resource Group'
+            inputs:
+              azureSubscription: $(AzureSubscription)
+              scriptLocation: inlineScript
+              inlineScript: az group create --location westus --name "${{ resourceGroup.name }}"
+            

--- a/build/yaml/deployBotResources/common/zipDeploy.yml
+++ b/build/yaml/deployBotResources/common/zipDeploy.yml
@@ -1,0 +1,13 @@
+parameters:
+  botName: ''
+  botGroup: ''
+  source: ''
+
+steps:
+  - task: AzureCLI@1
+    displayName: 'Deploy'
+    inputs:
+      azureSubscription: $(AzureSubscription)
+      scriptLocation: inlineScript
+      inlineScript: |
+        call az webapp deployment source config-zip --resource-group "${{ parameters.botGroup }}" --name "${{ parameters.botName }}" --src "${{ parameters.source }}"

--- a/build/yaml/deployBotResources/deployBotResources.yml
+++ b/build/yaml/deployBotResources/deployBotResources.yml
@@ -1,0 +1,97 @@
+#
+# Deploys the bot resources needed for the Skills Functional Tests.
+#
+
+name: $(Build.BuildId)
+trigger: none
+pr: none
+
+pool:
+  vmImage: 'windows-2019'
+
+variables:
+  BuildConfiguration: 'Debug'
+  BuildPlatform: 'any cpu'
+  # AzureSubscription: define in Azure
+  # AppServicePlanName: define in Azure
+  # AppServicePlanGroup: define in Azure
+  # BffnSimpleHostBotDotnetAppId: define in Azure
+  # BffnSimpleHostBotDotnetAppSecret: define in Azure
+  # BffnSimpleHostBot21DotnetAppId: define in Azure
+  # BffnSimpleHostBot21DotnetAppSecret: define in Azure
+  # BffnEchoSkillBotDotnetAppId: define in Azure
+  # BffnEchoSkillBotDotnetAppSecret: define in Azure
+  # BffnEchoSkillBot21DotnetAppId: define in Azure
+  # BffnEchoSkillBot21DotnetAppSecret: define in Azure
+  # BffnEchoSkillBotV3DotnetAppId: define in Azure
+  # BffnEchoSkillBotV3DotnetAppSecret: define in Azure
+  # ResourceGroup: define in Azure
+  # BotPricingTier: (optional) define in Azure ; Acceptable values are F0 (Default) and S1.
+  # DependenciesRegistryHosts: (optional) define in Azure
+  # DependenciesRegistrySkills: (optional) define in Azure
+  # DependenciesRegistrySkillsV3: (optional) define in Azure
+  # DependeciesVersionHosts: (optional) define in Azure
+  # DependeciesVersionSkills: (optional) define in Azure
+  # DependeciesVersionSkillsV3: (optional) define in Azure
+
+stages:
+  - template: common/prepareResources.yml
+    parameters:
+      resourceGroups: 
+        - id: 'Prepare_DotNetGroup'
+          name: "$(ResourceGroup)-DotNet"
+          displayName: "Prepare DotNet's Resource Group"
+
+  - template: dotnet/deploy.yml
+    parameters:
+      dependsOn: "Prepare_DotNetGroup"
+      resourceGroup: "$(ResourceGroup)-DotNet"
+      bots:
+        - name: bffnsimplehostbotdotnet
+          type: 'Host'
+          displayName: 'DotNet Simple Host Bot'
+          appId: $(BffnSimpleHostBotDotnetAppId)
+          appSecret: $(BffnSimpleHostBotDotnetAppSecret)
+          project:
+            directory: 'Bots/DotNet/Consumers/CodeFirst/SimpleHostBot'
+            name: 'SimpleHostBot.csproj'
+            netCoreVersion: '3.1.x'
+
+        - name: bffnsimplehostbot21dotnet
+          type: 'Host'
+          displayName: 'DotNet Simple Host Bot 2.1'
+          appId: $(BffnSimpleHostBot21DotnetAppId)
+          appSecret: $(BffnSimpleHostBot21DotnetAppSecret)
+          project: 
+            directory: 'Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1'
+            name: 'SimpleHostBot-2.1.csproj'
+            netCoreVersion: '2.1.x'
+
+        - name: bffnechoskillbotdotnet
+          type: 'Skill'
+          displayName: 'DotNet Echo Skill Bot'
+          appId: $(BffnEchoSkillBotDotnetAppId)
+          appSecret: $(BffnEchoSkillBotDotnetAppSecret)
+          project: 
+            directory: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot'
+            name: 'EchoSkillBot.csproj'
+            netCoreVersion: '3.1.x'
+
+        - name: bffnechoskillbot21dotnet
+          type: 'Skill'
+          displayName: 'DotNet Echo Skill Bot 2.1'
+          appId: $(BffnEchoSkillBot21DotnetAppId)
+          appSecret: $(BffnEchoSkillBot21DotnetAppSecret)
+          project: 
+            directory: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1'
+            name: 'EchoSkillBot-2.1.csproj'
+            netCoreVersion: '2.1.x'
+
+        - name: bffnechoskillbotv3dotnet
+          type: 'SkillV3'
+          displayName: 'DotNet Echo Skill Bot v3'
+          appId: $(BffnEchoSkillBotV3DotnetAppId)
+          appSecret: $(BffnEchoSkillBotV3DotnetAppSecret)
+          project:
+            directory: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3'
+            name: 'EchoSkillBot.sln'

--- a/build/yaml/deployBotResources/dotnet/deploy.yml
+++ b/build/yaml/deployBotResources/dotnet/deploy.yml
@@ -1,0 +1,123 @@
+parameters:
+  dependsOn: ''
+  resourceGroup: ''
+  bots: []
+
+stages:
+- ${{ each bot in parameters.bots }}:
+  - stage: 'Deploy_${{ bot.name }}'
+    ${{ if eq(bot.displayName, '') }}:
+      displayName: '${{ bot.name }}'
+    ${{ if ne(bot.displayName, '') }}:
+      displayName: '${{ bot.displayName }}'
+    dependsOn: '${{ parameters.dependsOn }}'
+    jobs:
+      - job: 'Deploy'
+        displayName: 'Deploy steps'
+        steps:
+          # Use Net Core version
+          - ${{ if ne(bot.project.netCoreVersion, '') }}:
+            - task: UseDotNet@2
+              displayName: 'Use NetCore v${{ bot.project.netCoreVersion }}'
+              inputs:
+                version: '${{ bot.project.netCoreVersion }}'
+
+          # Use NuGet
+          - task: NuGetToolInstaller@1
+            displayName: 'Use NuGet'
+
+          # Run NuGet restore SkillV3
+          - ${{ if eq(bot.type, 'SkillV3') }}:
+            - task: NuGetCommand@2
+              displayName: 'NuGet restore'
+              inputs:
+                restoreSolution: '${{ bot.project.directory }}/${{ bot.project.name }}'
+
+          # Evaluate dependencies source and version
+          - template: evaluateDependenciesVariables.yml
+            parameters:
+              ${{ if eq(bot.type, 'Host') }}:
+                registry: "$env:DependenciesRegistryHosts"
+                version: "$env:DependeciesVersionHosts"
+              ${{ if eq(bot.type, 'Skill') }}:
+                registry: "$env:DependenciesRegistrySkills"
+                version: "$env:DependeciesVersionSkills"
+              ${{ if eq(bot.type, 'SkillV3') }}:
+                registry: "$env:DependenciesRegistrySkillsV3"
+                version: "$env:DependeciesVersionSkillsV3"
+              botType: '${{ bot.type }}'
+
+          # Start of DotNet Install & Build
+          - ${{ if in(bot.type, 'Host', 'Skill') }}:
+            # Install dependencies
+            - template: installDependencies.yml
+              parameters:
+                source: "$(DependenciesSource)"
+                version: "$(DependenciesVersionNumber)"
+                project: '${{ bot.project }}'
+                packages:
+                  Microsoft.Bot.Builder.Dialogs 
+                  Microsoft.Bot.Builder.Integration.AspNet.Core
+
+            # Build Bot
+            - task: DotNetCoreCLI@2
+              displayName: 'Build'
+              inputs:
+                command: publish
+                publishWebProjects: false
+                projects: '${{ bot.project.directory }}/${{ bot.project.name }}'
+                arguments: '--output $(System.DefaultWorkingDirectory)/build/${{ bot.name }}'
+                modifyOutputPath: false
+          # End of DotNet Install & Build
+
+          # Start DotNet v3 Install, Build
+          - ${{ if eq(bot.type, 'SkillV3') }}:
+            # Install dependencies
+            - template: installDependenciesV3.yml
+              parameters:
+                source: "$(DependenciesSource)"
+                version: "$(DependenciesVersionNumber)"
+                project: '${{ bot.project }}'
+                packages:
+                  Microsoft.Bot.Builder
+                  Microsoft.Bot.Builder.Azure
+                  Microsoft.Bot.Builder.History
+
+            # Build bot
+            - task: VSBuild@1
+              displayName: 'Build'
+              inputs:
+                solution: '${{ bot.project.directory }}/${{ bot.project.name }}'
+                vsVersion: 16.0
+                platform: '$(BuildPlatform)'
+                configuration: '$(BuildConfiguration)'
+
+            # Zip bot
+            - powershell: |
+                7z.exe a -tzip "$(System.DefaultWorkingDirectory)/build/${{ bot.name }}/${{ bot.name }}.zip" "$(System.DefaultWorkingDirectory)/${{ bot.project.directory }}/*" -aoa
+              displayName: 'Zip bot'
+          # End of DotNet v3 Install, Build
+
+          # Create App Service and Bot Channel Registration
+          - template: ../common/createAppService.yml
+            parameters:
+              appId: '${{ bot.appId }}'
+              appSecret: '${{ bot.appSecret }}'
+              botName: '${{ bot.name }}'
+              botGroup: '${{ parameters.resourceGroup }}'
+
+          # Configure OAuth
+          - ${{ if eq(bot.type, 'Skill') }}:
+            - template: ../common/configureOAuth.yml
+              parameters:
+                appId: '${{ bot.appId }}'
+                appSecret: '${{ bot.appSecret }}'
+                botName: '${{ bot.name }}'
+                botGroup: '${{ parameters.resourceGroup }}'
+
+          # Deploy bot
+          - template: ../common/zipDeploy.yml
+            parameters:
+              botName: '${{ bot.name }}'
+              botGroup: '${{ parameters.resourceGroup }}'
+              source: "$(System.DefaultWorkingDirectory)/build/${{ bot.name }}/${{ bot.name }}.zip"

--- a/build/yaml/deployBotResources/dotnet/evaluateDependenciesVariables.yml
+++ b/build/yaml/deployBotResources/dotnet/evaluateDependenciesVariables.yml
@@ -1,0 +1,57 @@
+parameters:
+  registry: ''
+  version: ''
+  botType: ''
+
+steps:
+  - powershell: |
+      # Get Source
+      $sourceDotNetv3MyGet = "https://botbuilder.myget.org/F/botbuilder-v3-dotnet-daily/api/v3/index.json" 
+      $sourceDotNetArtifacts = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" 
+      $sourceDotNetMyGet = "https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json"
+      switch -regex ("${{ parameters.registry }}") {
+        "^($null|)$" {
+          switch ("${{ parameters.botType }}") {
+            "SkillV3" { $source = $sourceDotNetv3MyGet } 
+            default { $source = $sourceDotNetArtifacts }
+          }
+        }
+        "Artifacts" { $source = $sourceDotNetArtifacts }
+        "MyGet" { 
+          switch ("${{ parameters.botType }}") {
+            "SkillV3" { $source = $sourceDotNetv3MyGet } 
+            default { $source = $sourceDotNetMyGet }
+          }
+        }
+        "NuGet" { $source = "" }
+        default { $source = "${{ parameters.registry }}" }
+      }
+      Write-Host "Source: $source"
+      
+      # Get Version Number
+      switch -regex ("${{ parameters.version }}") {
+        "^($null||LATEST)$" {
+          if ("${{ parameters.registry }}".ToUpper() -in "NUGET") {
+            [Console]::ForegroundColor = 'red'
+            [Console]::Error.WriteLine("Preview versions of BotBuilder are not available for this source.")
+            [Console]::ResetColor()
+            exit 1 # Force exit
+          }
+          if ("${{ parameters.botType }}" -in "Host", "Skill") {
+            $PackageList = nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$source" -PreRelease
+            $versionNumber = $PackageList.Split(" ")[-1]
+          }
+          elseif ("${{ parameters.botType }}" -in "SkillV3") {
+            $versionNumber = ""
+          }
+        }
+        STABLE { $versionNumber = "" }
+        default { $versionNumber = "${{ parameters.version }}" }
+      }
+      Write-Host "Version Number: $versionNumber"
+      
+      # Set environment variables
+      Write-Host "##vso[task.setvariable variable=DependenciesSource]$source"
+      Write-Host "##vso[task.setvariable variable=DependenciesVersionNumber]$versionNumber"
+    displayName: 'Evaluate source & version'
+    failOnStderr: true

--- a/build/yaml/deployBotResources/dotnet/installDependencies.yml
+++ b/build/yaml/deployBotResources/dotnet/installDependencies.yml
@@ -1,0 +1,28 @@
+parameters:
+  version: ''
+  source: ''
+  project: {}
+  packages: []
+
+steps:
+  - powershell: |
+      $version = ''
+      $source = ''
+
+      if(-not ([string]::IsNullOrEmpty("${{ parameters.version }}"))){
+        $version = "--version ""${{ parameters.version }}"""
+      }
+
+      if(-not ([string]::IsNullOrEmpty("${{ parameters.source }}"))){
+        $source = "--source ""${{ parameters.source }}"""
+      }
+
+      foreach ($package in "${{ parameters.packages }}".Split()) {
+        Invoke-Expression "dotnet add ""${{ parameters.project.directory }}/${{ parameters.project.name }}"" package $version $source $package"
+      }
+
+      write-host " `nPackages:"
+      foreach ($package in "${{ parameters.packages }}".Split()) {
+        write-host "  - $package"
+      }
+    displayName: 'Install dependencies' 

--- a/build/yaml/deployBotResources/dotnet/installDependenciesV3.yml
+++ b/build/yaml/deployBotResources/dotnet/installDependenciesV3.yml
@@ -1,0 +1,28 @@
+parameters:
+  version: ''
+  source: ''
+  project: {}
+  packages: []
+
+steps:
+  - powershell: |
+      $version = ''
+      $source = ''
+
+      if(-not ([string]::IsNullOrEmpty("${{ parameters.version }}"))){
+        $version = "-Version ""${{ parameters.version }}"""
+      }
+
+      if(-not ([string]::IsNullOrEmpty("${{ parameters.source }}"))){
+        $source = "-Source ""${{ parameters.source }}"""
+      }
+
+      foreach ($package in "${{ parameters.packages }}".Split()) {
+        Invoke-Expression "nuget update ""${{ parameters.project.directory }}/${{ parameters.project.name }}"" -Id $package $version $source"
+      }
+      
+      write-host "`nPackages:"
+      foreach ($package in "${{ parameters.packages }}".Split()) {
+        write-host "  - $package "
+      }
+    displayName: 'Install dependencies' 


### PR DESCRIPTION
Addresses #183

## Description

This PR adds the pipeline definition to deploy the bot resources needed for the Skills Functional Tests.
The pipeline has two sections, an initial stage to delete pre-existing resource groups and create new ones (one per language), and a batch of stages, one for each bot to be deployed.
This setup allows the user to handpick which bot to deploy or to use a pre-existing resource group through the stage selection panel before running a pipeline.

Deploys the following DotNet test bots:

- Simple Host Bot
- Simple Host Bot 2.1
- Echo Skill Bot
- Echo Skill Bot 2.1
- Echo Skill Bot v3

![image](https://user-images.githubusercontent.com/44245136/101059315-e20a5480-356c-11eb-8114-cce506aa1a38.png)

## Specific Changes

- Adds the  deployBotResources directory to host all related files
- Adds deployBotResources.yml file to define the pipeline and several YAML template files
- Adds the DotNet directory within  deployBotResources to host language specific YAML template files

## Testing

The following image shows a successful pipeline:
![image](https://user-images.githubusercontent.com/44245136/102895456-7caad480-4443-11eb-989d-59279c1c5bf0.png)



