### PR TITLE
Misc fixes and refactorings for DL client and TestRunner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,9 @@ virtualenv/
 
 # Local appsettings
 appsettings.Development.json
+
+# VS code settings
+.vscode/
+
+# PyCharm settings
+.idea/

--- a/Bots/Python/Consumers/CodeFirst/SimpleHostBot/requirements.txt
+++ b/Bots/Python/Consumers/CodeFirst/SimpleHostBot/requirements.txt
@@ -1,2 +1,2 @@
-botbuilder-integration-aiohttp>=4.8.0
+botbuilder-integration-aiohttp>=4.11.0
 python-dotenv

--- a/Bots/Python/Skills/CodeFirst/EchoSkillBot/requirements.txt
+++ b/Bots/Python/Skills/CodeFirst/EchoSkillBot/requirements.txt
@@ -1,2 +1,2 @@
-botbuilder-integration-aiohttp>=4.8.0
-botbuilder-dialogs>=4.8.0
+botbuilder-integration-aiohttp>=4.11.0
+botbuilder-dialogs>=4.11.0

--- a/Libraries/TranscriptTestRunner/TestRunner.cs
+++ b/Libraries/TranscriptTestRunner/TestRunner.cs
@@ -72,7 +72,7 @@ namespace TranscriptTestRunner
 
             _logger.LogInformation($"======== Running script: {transcriptPath} ========");
 
-            if (transcriptPath.EndsWith(".transcript", StringComparison.Ordinal))
+            if (transcriptPath.EndsWith(".transcript", StringComparison.OrdinalIgnoreCase))
             {
                 ConvertTranscript(transcriptPath);
             }
@@ -133,7 +133,7 @@ namespace TranscriptTestRunner
                 while (activity != null);
 
                 // Wait a bit for the bot
-                await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken).ConfigureAwait(false);
 
                 if (timeoutCheck.ElapsedMilliseconds > _replyTimeout)
                 {

--- a/Libraries/TranscriptTestRunner/XUnit/XUnitTestRunner.cs
+++ b/Libraries/TranscriptTestRunner/XUnit/XUnitTestRunner.cs
@@ -40,7 +40,7 @@ namespace TranscriptTestRunner.XUnit
             {
                 var (result, error) = Expression.Parse(assertion).TryEvaluate<bool>(actualActivity);
 
-                Assert.True(result, $"The bot's response was different than expected. The assertion: \"{assertion}\" was evaluated as false.\nActual Activity:\n{JsonConvert.SerializeObject(actualActivity, Formatting.Indented)}");
+                Assert.True(result, $"The bot's response was different than expected. The assertion: \"{assertion}\" was evaluated as false.\nExpected Activity:\n{JsonConvert.SerializeObject(expectedActivity, Formatting.Indented)}\nActual Activity:\n{JsonConvert.SerializeObject(actualActivity, Formatting.Indented)}");
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
- Refactored DirectLineTestClient to defer retrieval of token until the conversation starts (and not in the constructor).
- Modified DirectLineTestClient.cs to discard the first activity sent to the bot if it is a ConversationUpdate (this is done implicitly by DL when a conversation starts)
- Modified DirectLineTestClient to use _conversation instead of  _tokenInfo to make thing consistent.
- Increased TestRunner polling to 250 ms
- Modified XUnitTestRunner to show expected activity in addition to the actual activity on failures.
- Added .vscode and .idea folders to gitignore file.
- Updated Python bots to reference 4.11.0