### PR TITLE
[Skills Everywhere][#214] Move channel creation to bot deployment stage 

### DIFF
--- a/build/yaml/deployBotResources/common/createDirectLine.yml
+++ b/build/yaml/deployBotResources/common/createDirectLine.yml
@@ -1,0 +1,12 @@
+parameters:
+  botName: ''
+  botGroup: ''
+
+steps:
+- task: AzureCLI@1
+  displayName: 'Create DirectLine Channel'
+  inputs:
+    azureSubscription: $(AzureSubscription)
+    scriptLocation: inlineScript
+    inlineScript: |
+      call az bot directline create -n "$(HostBotName)" -g "${{ parameters.resourceGroup }}"

--- a/build/yaml/deployBotResources/common/createDirectLine.yml
+++ b/build/yaml/deployBotResources/common/createDirectLine.yml
@@ -9,4 +9,4 @@ steps:
     azureSubscription: $(AzureSubscription)
     scriptLocation: inlineScript
     inlineScript: |
-      call az bot directline create -n "$(HostBotName)" -g "${{ parameters.resourceGroup }}"
+      call az bot directline create -n "${{ parameters.botName }}" -g "${{ parameters.botGroup }}"

--- a/build/yaml/deployBotResources/dotnet/deploy.yml
+++ b/build/yaml/deployBotResources/dotnet/deploy.yml
@@ -121,3 +121,10 @@ stages:
               botName: '${{ bot.name }}'
               botGroup: '${{ parameters.resourceGroup }}'
               source: "$(System.DefaultWorkingDirectory)/build/${{ bot.name }}/${{ bot.name }}.zip"
+
+          # Create DirectLine Channel Hosts
+          - ${{ if eq(bot.type, 'Host') }}:
+            - template: ../common/createDirectLine.yml
+              parameters:
+                botName: '${{ bot.name }}'
+                botGroup: '${{ parameters.resourceGroup }}'

--- a/build/yaml/deployBotResources/dotnet/deployComposer.yml
+++ b/build/yaml/deployBotResources/dotnet/deployComposer.yml
@@ -44,3 +44,10 @@ stages:
               botName: '${{ bot.name }}'
               botGroup: '${{ parameters.resourceGroup }}'
               source: "build-composer/build.zip"
+
+          # Create DirectLine Channel Hosts
+          - ${{ if eq(bot.type, 'Host') }}:
+            - template: ../common/createDirectLine.yml
+              parameters:
+                botName: '${{ bot.name }}'
+                botGroup: '${{ parameters.resourceGroup }}'

--- a/build/yaml/deployBotResources/js/deploy.yml
+++ b/build/yaml/deployBotResources/js/deploy.yml
@@ -75,3 +75,10 @@ stages:
               botName: '${{ bot.name }}'
               botGroup: '${{ parameters.resourceGroup }}'
               source: '$(System.DefaultWorkingDirectory)/${{ bot.name }}.zip'
+
+          # Create DirectLine Channel Hosts
+          - ${{ if eq(bot.type, 'Host') }}:
+            - template: ../common/createDirectLine.yml
+              parameters:
+                botName: '${{ bot.name }}'
+                botGroup: '${{ parameters.resourceGroup }}'

--- a/build/yaml/testScenarios/runFunctionalTests.yml
+++ b/build/yaml/testScenarios/runFunctionalTests.yml
@@ -3,19 +3,17 @@ parameters:
 
 steps:
 - task: AzureCLI@1
-  displayName: 'Create DirectLine Channel'
+  displayName: 'Get Bot Keys'
   inputs:
     azureSubscription: $(AzureSubscription)
     scriptLocation: inlineScript
+    scriptType: ps
     inlineScript: |
-      call az bot directline create -n "$(HostBotName)" -g "${{ parameters.resourceGroup }}" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json"
-      
-- powershell: |
-    $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
-    $key = $json.properties.properties.sites.key;
-    echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
-    echo "##vso[task.setvariable variable=BOTID;]$(HostBotName)";
-  displayName: 'Get Bot Keys'
+      $result = call az bot directline show -n "$(HostBotName)" -g "${{ parameters.resourceGroup }}"--with-secrets true
+      $json = $result | Out-String | ConvertFrom-Json;
+      $key = $json.properties.properties.sites.key;
+      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+      echo "##vso[task.setvariable variable=BOTID;]$(HostBotName)";
 
 - template: build.yml
 

--- a/build/yaml/testScenarios/runFunctionalTests.yml
+++ b/build/yaml/testScenarios/runFunctionalTests.yml
@@ -2,18 +2,17 @@ parameters:
   resourceGroup: ''
 
 steps:
-- task: AzureCLI@1
-  displayName: 'Get Bot Keys'
+- task: AzureCLI@2
+  displayName: 'Set Bot Keys'
   inputs:
     azureSubscription: $(AzureSubscription)
-    scriptLocation: inlineScript
     scriptType: ps
+    scriptLocation: inlineScript
     inlineScript: |
-      $result = call az bot directline show -n "$(HostBotName)" -g "${{ parameters.resourceGroup }}"--with-secrets true
-      $json = $result | Out-String | ConvertFrom-Json;
-      $key = $json.properties.properties.sites.key;
-      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
-      echo "##vso[task.setvariable variable=BOTID;]$(HostBotName)";
+     $result = az bot directline show -n "$(HostBotName)" -g "${{ parameters.resourceGroup }}" --with-secrets true | ConvertFrom-Json;
+     $key = $result.properties.properties.sites.key;
+     echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+     echo "##vso[task.setvariable variable=BOTID;]$(HostBotName)";
 
 - template: build.yml
 


### PR DESCRIPTION
Fixes #214

## Description

This PR refactors the DirectLine creation task. The creation is extracted into a new template and called from the _deployBotResources_ pipeline.
The PR also updates the testScenarios pipeline to retrieve the DirectLine secret instead of creating it.

## Specific Changes

- Extracts the AzureCLI DirectLine creation task into `deployBotResources/common/createDirectLine.yml`
- Updates the following YAMLs to create the DirectLine channel when the bot is of type host:
  -  `deployBotResources/dotnet/deploy.yml`
  - `deployBotResources/dotnet/deployComposer.yml`
  - `deployBotResources/js/deploy.yml`
- Updates `testScenarios/runFunctionalSteps.yml` to retrieve the DirectLine information and set the secret as an environment variable.

## Testing
The following images shows successful pipeline executions for the changes introduced in this PR:
![image](https://user-images.githubusercontent.com/64803884/103034001-a4cd2d00-4542-11eb-97bc-3a5d8b03b620.png)