### PR TITLE
Add ShouldExclude parameter to TestCaseBuilder

### DIFF
--- a/Bots/JavaScript/.gitignore
+++ b/Bots/JavaScript/.gitignore
@@ -1,0 +1,3 @@
+
+# Ignore web.config files generated to deploy JS to IIS on Windows
+**/web.config

--- a/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/bots/hostBot.js
+++ b/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/bots/hostBot.js
@@ -17,9 +17,6 @@ class HostBot extends ActivityHandler {
         this.dialogStateProperty = this.conversationState.createProperty('DialogState');
 
         this.botId = process.env.MicrosoftAppId;
-        if (!this.botId) {
-            throw new Error('[HostBot] MicrosoftAppId is not set in configuration');
-        }
 
         // Create state property to track the delivery mode and active skill.
         this.deliveryModeProperty = this.conversationState.createProperty(HostBot.DeliveryModePropertyName);

--- a/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/package.json
+++ b/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/package.json
@@ -16,19 +16,18 @@
     "url": "https://github.com"
   },
   "dependencies": {
-    "botbuilder": "~4.8.0",
+    "botbuilder": "~4.11.0",
     "botbuilder-dialogs": "~4.11.0",
-    "botframework-connector": "~4.8.0",
-    "dotenv": "^8.2.0",
-    "restify": "~8.4.0"
+    "dotenv": "~8.2.0",
+    "restify": "~8.5.1"
   },
   "devDependencies": {
-    "eslint": "^6.6.0",
-    "eslint-config-standard": "^14.1.0",
-    "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-node": "^10.0.0",
+    "eslint": "^7.0.0",
+    "eslint-config-standard": "^14.1.1",
+    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
-    "nodemon": "~1.19.4"
+    "nodemon": "~2.0.4"
   }
 }

--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/package.json
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/package.json
@@ -1,34 +1,33 @@
 {
-    "name": "echo-skill-bot",
-    "version": "1.0.0",
-    "description": "Bot Builder v4 echo skill bot sample",
-    "author": "Microsoft",
-    "license": "MIT",
-    "main": "index.js",
-    "scripts": {
-        "start": "node ./index.js",
-        "watch": "nodemon ./index.js",
-        "lint": "eslint .",
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com"
-    },
-    "dependencies": {
-        "botbuilder": "~4.8.0",
-        "botbuilder-dialogs": "~4.8.0",
-        "botframework-connector": "~4.8.0",
-        "dotenv": "^8.2.0",
-        "restify": "~8.4.0"
-    },
-    "devDependencies": {
-        "eslint": "^6.6.0",
-        "eslint-config-standard": "^14.1.0",
-        "eslint-plugin-import": "^2.18.2",
-        "eslint-plugin-node": "^10.0.0",
-        "eslint-plugin-promise": "^4.2.1",
-        "eslint-plugin-standard": "^4.0.1",
-        "nodemon": "~1.19.4"
-    }
+  "name": "echo-skill-bot",
+  "version": "1.0.0",
+  "description": "Bot Builder v4 echo skill bot sample",
+  "author": "Microsoft",
+  "license": "MIT",
+  "main": "index.js",
+  "scripts": {
+    "start": "node ./index.js",
+    "watch": "nodemon ./index.js",
+    "lint": "eslint .",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com"
+  },
+  "dependencies": {
+    "botbuilder": "~4.11.0",
+    "botbuilder-dialogs": "~4.11.0",
+    "dotenv": "^8.2.0",
+    "restify": "~8.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^7.0.0",
+    "eslint-config-standard": "^14.1.1",
+    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^4.0.1",
+    "nodemon": "~2.0.4"
+  }
 }

--- a/Bots/Python/.gitignore
+++ b/Bots/Python/.gitignore
@@ -1,0 +1,3 @@
+
+# Ignore .deployment files generated to deploy Python to linux from VSCode
+**/.deployment

--- a/Bots/Python/Consumers/CodeFirst/SimpleHostBot/config.py
+++ b/Bots/Python/Consumers/CodeFirst/SimpleHostBot/config.py
@@ -16,8 +16,8 @@ class DefaultConfig:
     load_dotenv()
 
     PORT = 37000
-    APP_ID = os.environ.get("MicrosoftAppId", "")
-    APP_PASSWORD = os.environ.get("MicrosoftAppPassword", "")
+    APP_ID = os.getenv("MicrosoftAppId")
+    APP_PASSWORD = os.getenv("MicrosoftAppPassword")
     SKILL_HOST_ENDPOINT = os.getenv("SkillHostEndpoint")
     SKILLS = []
 

--- a/Tests/SkillFunctionalTests/Common/TestCaseBuilder.cs
+++ b/Tests/SkillFunctionalTests/Common/TestCaseBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using TranscriptTestRunner;
 
@@ -8,7 +9,7 @@ namespace SkillFunctionalTests.Common
 {
     public class TestCaseBuilder
     {
-        public IEnumerable<object[]> BuildTestCases(List<ClientType> clientTypes, List<string> deliveryModes, List<HostBot> hostBots, List<string> targetSkills, List<string> scripts)
+        public IEnumerable<object[]> BuildTestCases(List<ClientType> clientTypes, List<string> deliveryModes, List<HostBot> hostBots, List<string> targetSkills, List<string> scripts, Func<TestCase, bool> shouldExclude = null)
         {
             var testCases = new List<object[]>();
             var count = 1;
@@ -33,8 +34,11 @@ namespace SkillFunctionalTests.Common
                                     Script = script
                                 };
 
-                                testCases.Add(new object[] { new TestCaseDataObject(testCase.Id, testCase) });
-                                count++;
+                                if (!ExcludeTestCase(shouldExclude, testCase))
+                                {
+                                    testCases.Add(new object[] { new TestCaseDataObject(testCase.Id, testCase) });
+                                    count++;
+                                }
                             }
                         }
                     }
@@ -42,6 +46,16 @@ namespace SkillFunctionalTests.Common
             }
 
             return testCases;
+        }
+
+        private bool ExcludeTestCase(Func<TestCase, bool> shouldExclude, TestCase testCase)
+        {
+            if (shouldExclude == null)
+            {
+                return false;
+            }
+
+            return shouldExclude(testCase);
         }
     }
 }

--- a/Tests/SkillFunctionalTests/SingleTurn/EchoTests.cs
+++ b/Tests/SkillFunctionalTests/SingleTurn/EchoTests.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
@@ -35,14 +35,14 @@ namespace SkillFunctionalTests.SingleTurn
                 DeliveryModes.Normal,
                 DeliveryModes.ExpectReplies
             };
-            
+
             var hostBots = new List<HostBot>
             {
                 HostBot.SimpleHostBotDotNet,
                 HostBot.SimpleHostBotDotNet21,
                 HostBot.SimpleHostBotJS,
                 HostBot.SimpleHostBotPython,
-                
+
                 // TODO: Enable when composer bots support multiple skills.
                 // HostBot.SimpleComposerHostBotDotNet
             };
@@ -57,14 +57,25 @@ namespace SkillFunctionalTests.SingleTurn
                 SkillBotNames.EchoSkillBotPython
             };
 
-            var scripts = new List<string>
-            {
-                "EchoMultiSkill.json"
-            };
+            var scripts = new List<string> { "EchoMultiSkill.json" };
 
             var testCaseBuilder = new TestCaseBuilder();
 
-            var testCases = testCaseBuilder.BuildTestCases(clientTypes, deliverModes, hostBots, targetSkills, scripts);
+            // This local function is used to exclude ExpectReplies test cases for v3 bots
+            static bool ShouldExclude(TestCase testCase)
+            {
+                if (testCase.DeliveryMode == DeliveryModes.ExpectReplies)
+                {
+                    if (testCase.TargetSkill == SkillBotNames.EchoSkillBotV3DotNet || testCase.TargetSkill == SkillBotNames.EchoSkillBotV3JS)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            var testCases = testCaseBuilder.BuildTestCases(clientTypes, deliverModes, hostBots, targetSkills, scripts, ShouldExclude);
             foreach (var testCase in testCases)
             {
                 yield return testCase;


### PR DESCRIPTION
Fixes TBD

Added optional Func<TestCase, bool> parameter to TestCaseBuilder so the dev can inject a code block to evaluate if the TestCase needs to be excluded from the list of test cases.

Update EchoTests to use this parameter and exclude V3 skills for expect replies.