### PR TITLE
Add botsku parameter to Python deploy steps with existing RG

### DIFF
--- a/build/yaml/pythonDeployStepsExistingRG.yml
+++ b/build/yaml/pythonDeployStepsExistingRG.yml
@@ -99,7 +99,7 @@ steps:
      az group create --location westus --name $(BotGroup);
 
      # set up bot channels registration, app service, app service plan
-     az deployment group create --resource-group "$(BotGroup)" --name "$(BotName)$(Build.BuildId)" --template-file "$(System.DefaultWorkingDirectory)/$(TemplateLocation)" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" newWebAppName="$(BotName)-$(Build.BuildId)" newAppServicePlanName="$(BotName)" appServicePlanLocation="westus" --name "$(BotName)";
+     az deployment group create --resource-group "$(BotGroup)" --name "$(BotName)$(Build.BuildId)" --template-file "$(System.DefaultWorkingDirectory)/$(TemplateLocation)" --parameters appId="$(DeployAppId)" appSecret="$(DeployAppSecret)" botId="$(BotName)" botSku=S1 newWebAppName="$(BotName)-$(Build.BuildId)" newAppServicePlanName="$(BotName)" appServicePlanLocation="westus" --name "$(BotName)";
      Set-PSDebug -Trace 0;
 
 - script: |


### PR DESCRIPTION
Fixes "Too many requests" issue in Python deployments. See the Test pipeline results [here](https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=204366&view=results).