### PR TITLE
Refactored ProactiveMessages

### DIFF
--- a/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Bots/SkillBot.cs
+++ b/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Bots/SkillBot.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Security.Principal;
 using System.Threading;
@@ -11,31 +10,25 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Proactive;
 
 namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Bots
 {
     public class SkillBot<T> : ActivityHandler
         where T : Dialog
     {
-        private readonly ConcurrentDictionary<string, ContinuationParameters> _continuationParameters;
         private readonly ConversationState _conversationState;
         private readonly Dialog _mainDialog;
         private readonly Uri _serverUrl;
 
-        public SkillBot(ConversationState conversationState, T mainDialog, ConcurrentDictionary<string, ContinuationParameters> continuationParameters, IHttpContextAccessor httpContextAccessor)
+        public SkillBot(ConversationState conversationState, T mainDialog, IHttpContextAccessor httpContextAccessor)
         {
             _conversationState = conversationState;
             _mainDialog = mainDialog;
-            _continuationParameters = continuationParameters;
             _serverUrl = new Uri($"{httpContextAccessor.HttpContext.Request.Scheme}://{httpContextAccessor.HttpContext.Request.Host.Value}");
         }
 
         public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
         {
-            // Store continuation parameters for proactive messages.
-            AddOrUpdateContinuationParameters(turnContext);
-
             if (turnContext.Activity.Type == ActivityTypes.ConversationUpdate)
             {
                 // Let the base class handle the activity (this will trigger OnMembersAddedAsync).
@@ -64,22 +57,6 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Bots
                     await turnContext.SendActivityAsync($"You can check the skill manifest to see what it supports here: {_serverUrl}manifests/waterfallskillbot-manifest-1.0.json", cancellationToken: cancellationToken);
                 }
             }
-        }
-
-        /// <summary>
-        /// Helper to extract and store parameters we need to continue a conversation from a proactive message.
-        /// </summary>
-        /// <param name="turnContext">A turnContext instance with the parameters we need.</param>
-        private void AddOrUpdateContinuationParameters(ITurnContext turnContext)
-        {
-            var continuationParameters = new ContinuationParameters
-            {
-                ClaimsIdentity = turnContext.TurnState.Get<IIdentity>(BotAdapter.BotIdentityKey),
-                ConversationReference = turnContext.Activity.GetConversationReference(),
-                OAuthScope = turnContext.TurnState.Get<string>(BotAdapter.OAuthScopeKey)
-            };
-
-            _continuationParameters.AddOrUpdate(continuationParameters.ConversationReference.User.Id, continuationParameters, (key, newValue) => continuationParameters);
         }
     }
 }

--- a/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Controllers/ProactiveController.cs
+++ b/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Controllers/ProactiveController.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Threading;
@@ -22,27 +21,29 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Controllers
     public class ProactiveController : ControllerBase
     {
         private readonly IBotFrameworkHttpAdapter _adapter;
-        private readonly ConcurrentDictionary<string, ContinuationParameters> _continuationParameters;
+        private readonly ConcurrentDictionary<string, ContinuationParameters> _continuationParametersStore;
         private readonly ConversationState _conversationState;
         private readonly ActivityRouterDialog _mainDialog;
 
-        public ProactiveController(ConversationState conversationState, ActivityRouterDialog mainDialog, BotFrameworkHttpAdapter adapter, ConcurrentDictionary<string, ContinuationParameters> continuationParameters)
+        public ProactiveController(ConversationState conversationState, ActivityRouterDialog mainDialog, BotFrameworkHttpAdapter adapter, ConcurrentDictionary<string, ContinuationParameters> continuationParametersStore)
         {
             _conversationState = conversationState;
             _adapter = adapter;
-            _continuationParameters = continuationParameters;
+            _continuationParametersStore = continuationParametersStore;
             _mainDialog = mainDialog;
         }
 
         // Note: in production scenarios, this controller should be secured.
-        public async Task<IActionResult> Get(string message)
+        public async Task<IActionResult> Get(string user)
         {
-            if (!_continuationParameters.Any())
+            _continuationParametersStore.TryGetValue(user, out var continuationParameters);
+
+            if (continuationParameters == null)
             {
                 // Let the caller know a proactive messages have been sent
                 return new ContentResult
                 {
-                    Content = "<html><body><h1>No messages sent</h1> <br/> There are no conversations registered to receive proactive messages.</body></html>",
+                    Content = $"<html><body><h1>No messages sent</h1> <br/>There are no conversations registered to receive proactive messages for {user}.</body></html>",
                     ContentType = "text/html",
                     StatusCode = (int)HttpStatusCode.OK,
                 };
@@ -51,32 +52,22 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Controllers
             Exception exception = null;
             try
             {
-                // Clone the dictionary so we can modify it as we respond.
-                var continuationClone = new ConcurrentDictionary<string, ContinuationParameters>(_continuationParameters);
-                foreach (var continuationParameters in continuationClone)
+                async Task ContinuationBotCallback(ITurnContext context, CancellationToken cancellationToken)
                 {
-                    var continuationItem = continuationParameters.Value;
+                    await context.SendActivityAsync($"Got proactive message for user: {user}", cancellationToken: cancellationToken);
 
-                    async Task BotCallback(ITurnContext context, CancellationToken cancellationToken)
-                    {
-                        await context.SendActivityAsync($"Got proactive message with value: {message}", cancellationToken: cancellationToken);
+                    // If we didn't have dialogs we could remove the code below, but we want to continue the dialog to clear the 
+                    // dialog stack.
+                    // Run the main dialog to continue WaitForProactiveDialog and send an EndOfConversation when that one is done.
+                    // ContinueDialogAsync in WaitForProactiveDialog will get a ContinueConversation event when this is called.
+                    await _mainDialog.RunAsync(context, _conversationState.CreateProperty<DialogState>("DialogState"), cancellationToken);
 
-                        // If we didn't have dialogs we could remove the code below, but we want to continue the dialog to clear the 
-                        // dialog stack.
-                        // Run the main dialog to continue WaitForProactiveDialog and send an EndOfConversation when that one is done.
-                        // ContinueDialogAsync in WaitForProactiveDialog will get a ContinueConversation event when this is called.
-                        await _mainDialog.RunAsync(context, _conversationState.CreateProperty<DialogState>("DialogState"), cancellationToken);
-
-                        // Save any state changes so the dialog stack is persisted.
-                        await _conversationState.SaveChangesAsync(context, false, cancellationToken);
-                    }
-
-                    // Forget the reference so we don't try to start the dialog again once is done.
-                    _continuationParameters.TryRemove(continuationParameters.Key, out _);
-
-                    // Continue the conversation with the proactive message
-                    await ((BotFrameworkAdapter)_adapter).ContinueConversationAsync((ClaimsIdentity)continuationItem.ClaimsIdentity, continuationItem.ConversationReference, continuationItem.OAuthScope, BotCallback, default);
+                    // Save any state changes so the dialog stack is persisted.
+                    await _conversationState.SaveChangesAsync(context, false, cancellationToken);
                 }
+
+                // Continue the conversation with the proactive message
+                await ((BotFrameworkAdapter)_adapter).ContinueConversationAsync((ClaimsIdentity)continuationParameters.ClaimsIdentity, continuationParameters.ConversationReference, continuationParameters.OAuthScope, ContinuationBotCallback, default);
             }
             catch (Exception ex)
             {

--- a/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Dialogs/ActivityRouterDialog.cs
+++ b/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Dialogs/ActivityRouterDialog.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Net.Http;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -31,11 +31,11 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs
     {
         private static readonly string _echoSkill = "EchoSkill";
 
-        public ActivityRouterDialog(IConfiguration configuration, IHttpClientFactory clientFactory, IHttpContextAccessor httpContextAccessor, ConversationState conversationState, SkillConversationIdFactoryBase conversationIdFactory, SkillHttpClient skillClient)
+        public ActivityRouterDialog(IConfiguration configuration, IHttpContextAccessor httpContextAccessor, ConversationState conversationState, SkillConversationIdFactoryBase conversationIdFactory, SkillHttpClient skillClient, ConcurrentDictionary<string, ContinuationParameters> continuationParametersStore)
             : base(nameof(ActivityRouterDialog))
         {
             AddDialog(new CardDialog(httpContextAccessor));
-            AddDialog(new WaitForProactiveDialog(httpContextAccessor));
+            AddDialog(new WaitForProactiveDialog(httpContextAccessor, continuationParametersStore));
             AddDialog(new MessageWithAttachmentDialog());
             AddDialog(new AuthDialog(configuration));
             AddDialog(new SsoSkillDialog(configuration));

--- a/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Dialogs/Proactive/WaitForProactiveDialog.cs
+++ b/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Dialogs/Proactive/WaitForProactiveDialog.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -14,25 +17,34 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Proact
     public class WaitForProactiveDialog : Dialog
     {
         // Message to send to users when the bot receives a Conversation Update event
-        private const string NotifyMessage = "Navigate to {0}api/notify?message={1} to proactively message everyone who has previously messaged this bot.";
+        private const string NotifyMessage = "Navigate to {0}api/notify?user={1} to proactively message the user.";
 
         private readonly Uri _serverUrl;
-        
-        public WaitForProactiveDialog(IHttpContextAccessor httpContextAccessor)
+        private readonly ConcurrentDictionary<string, ContinuationParameters> _continuationParametersStore;
+
+        public WaitForProactiveDialog(IHttpContextAccessor httpContextAccessor, ConcurrentDictionary<string, ContinuationParameters> continuationParametersStore)
         {
+            _continuationParametersStore = continuationParametersStore;
             _serverUrl = new Uri($"{httpContextAccessor.HttpContext.Request.Scheme}://{httpContextAccessor.HttpContext.Request.Host.Value}");
         }
 
-        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = new CancellationToken())
+        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default)
         {
-            await dc.Context.SendActivityAsync(MessageFactory.Text(string.Format(NotifyMessage, _serverUrl, Guid.NewGuid())), cancellationToken);
+            // Store a reference to the conversation.
+            AddOrUpdateContinuationParameters(dc.Context);
+
+            // Render message with continuation link.
+            await dc.Context.SendActivityAsync(MessageFactory.Text(string.Format(NotifyMessage, _serverUrl, dc.Context.Activity.From.Id)), cancellationToken);
             return EndOfTurn;
         }
 
-        public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = new CancellationToken())
+        public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
             if (dc.Context.Activity.Type == ActivityTypes.Event && dc.Context.Activity.Name == ActivityEventNames.ContinueConversation)
             {
+                // We continued the conversation, forget the proactive reference.
+                _continuationParametersStore.TryRemove(dc.Context.Activity.From.Id, out _);
+
                 // The continue conversation activity comes from the ProactiveController when the notification is received
                 await dc.Context.SendActivityAsync("We received a proactive message, ending the dialog", cancellationToken: cancellationToken);
 
@@ -41,9 +53,25 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Proact
             }
 
             // Keep waiting for a call to the ProactiveController.
-            await dc.Context.SendActivityAsync($"We are waiting for a proactive message. {string.Format(NotifyMessage, _serverUrl, Guid.NewGuid())}", cancellationToken: cancellationToken);
+            await dc.Context.SendActivityAsync($"We are waiting for a proactive message. {string.Format(NotifyMessage, _serverUrl, dc.Context.Activity.From.Id)}", cancellationToken: cancellationToken);
 
             return EndOfTurn;
+        }
+
+        /// <summary>
+        /// Helper to extract and store parameters we need to continue a conversation from a proactive message.
+        /// </summary>
+        /// <param name="turnContext">A turnContext instance with the parameters we need.</param>
+        private void AddOrUpdateContinuationParameters(ITurnContext turnContext)
+        {
+            var continuationParameters = new ContinuationParameters
+            {
+                ClaimsIdentity = turnContext.TurnState.Get<IIdentity>(BotAdapter.BotIdentityKey),
+                ConversationReference = turnContext.Activity.GetConversationReference(),
+                OAuthScope = turnContext.TurnState.Get<string>(BotAdapter.OAuthScopeKey)
+            };
+
+            _continuationParametersStore.AddOrUpdate(turnContext.Activity.From.Id, continuationParameters, (key, newValue) => continuationParameters);
         }
     }
 }

--- a/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Dialogs/Proactive/WaitForProactiveDialog.cs
+++ b/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Dialogs/Proactive/WaitForProactiveDialog.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Globalization;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,9 +17,9 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Proact
     {
         // Message to send to users when the bot receives a Conversation Update event
         private const string NotifyMessage = "Navigate to {0}api/notify?user={1} to proactively message the user.";
+        private readonly ConcurrentDictionary<string, ContinuationParameters> _continuationParametersStore;
 
         private readonly Uri _serverUrl;
-        private readonly ConcurrentDictionary<string, ContinuationParameters> _continuationParametersStore;
 
         public WaitForProactiveDialog(IHttpContextAccessor httpContextAccessor, ConcurrentDictionary<string, ContinuationParameters> continuationParametersStore)
         {
@@ -71,7 +70,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Proact
                 OAuthScope = turnContext.TurnState.Get<string>(BotAdapter.OAuthScopeKey)
             };
 
-            _continuationParametersStore.AddOrUpdate(turnContext.Activity.From.Id, continuationParameters, (key, newValue) => continuationParameters);
+            _continuationParametersStore.AddOrUpdate(turnContext.Activity.From.Id, continuationParameters, (_, _) => continuationParameters);
         }
     }
 }

--- a/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Startup.cs
+++ b/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Startup.cs
@@ -68,7 +68,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot
             // The Bot needs an HttpClient to download and upload files. 
             services.AddHttpClient();
 
-            // Create a global hashset for our ConversationReferences
+            // Create a global dictionary for our ConversationReferences (used by proactive)
             services.AddSingleton<ConcurrentDictionary<string, ContinuationParameters>>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.

--- a/Tests/SkillFunctionalTests/ProactiveMessages/ProactiveTests.cs
+++ b/Tests/SkillFunctionalTests/ProactiveMessages/ProactiveTests.cs
@@ -72,7 +72,7 @@ namespace SkillFunctionalTests.ProactiveMessages
         [MemberData(nameof(TestCases))]
         public async Task RunTestCases(TestCaseDataObject testData)
         {
-            var messageId = string.Empty;
+            var userId = string.Empty;
             var url = string.Empty;
 
             var testCase = testData.GetObject<TestCase>();
@@ -91,10 +91,10 @@ namespace SkillFunctionalTests.ProactiveMessages
 
                 var message = activity.Text.Split(" ");
                 url = message[2];
-                messageId = url.Split("message=")[1];
+                userId = url.Split("user=")[1];
             });
 
-            // Get to the message's url
+            // Send a get request to the message's url to continue the conversation.
             using (var client = new HttpClient())
             {
                 await client.GetAsync(url).ConfigureAwait(false);
@@ -102,7 +102,7 @@ namespace SkillFunctionalTests.ProactiveMessages
 
             var testParams = new Dictionary<string, string>
             {
-                { "MessageId", messageId }
+                { "UserId", userId }
             };
 
             // Execute the rest of the conversation passing the messageId.

--- a/Tests/SkillFunctionalTests/ProactiveMessages/TestScripts/ProactiveEnd.json
+++ b/Tests/SkillFunctionalTests/ProactiveMessages/TestScripts/ProactiveEnd.json
@@ -3,12 +3,12 @@
     {
       "type": "message",
       "role": "bot",
-      "text": "Got proactive message with value: ${MessageId}",
+      "text": "Got proactive message for user: ${UserId}",
       "assertions": [
         "type == 'message'",
         "from.role == 'bot'",
         "recipient.role == 'user'",
-        "text == 'Got proactive message with value: ${MessageId}'",
+        "text == 'Got proactive message for user: ${UserId}'",
         "inputHint == 'acceptingInput'"
       ]
     },

--- a/Tests/SkillFunctionalTests/ProactiveMessages/TestScripts/ProactiveEnd.transcript
+++ b/Tests/SkillFunctionalTests/ProactiveMessages/TestScripts/ProactiveEnd.transcript
@@ -16,7 +16,7 @@
       "role": "user"
     },
     "locale": "",
-    "text": "Got proactive message with value: ${MessageId}",
+    "text": "Got proactive message for user: ${UserId}",
     "inputHint": "acceptingInput",
     "replyToId": "555308d5-334b-4189-bdf7-f15753c52270",
     "id": "857d41e0-4f62-11eb-9aff-410b1b0e908c",


### PR DESCRIPTION
Fixes #250

Modified proactive messages so the messages are sent only to the user that requested it rather than broadcasting messages to any user that has used the bot.
Updated related test.