### PR TITLE
[Skills Everywhere] [#254] Add Echo Composer tests

### DIFF
--- a/Tests/SkillFunctionalTests/SingleTurn/EchoComposerTests.cs
+++ b/Tests/SkillFunctionalTests/SingleTurn/EchoComposerTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SkillFunctionalTests.Common;
+using TranscriptTestRunner;
+using TranscriptTestRunner.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkillFunctionalTests.SingleTurn
+{
+    [Trait("TestCategory", "SingleTurn")]
+    public class EchoComposerTests : ScriptTestBase
+    {
+        private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/SingleTurn/TestScripts";
+
+        public EchoComposerTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            var clientTypes = new List<ClientType> { ClientType.DirectLine };
+            var deliverModes = new List<string>
+            {
+                DeliveryModes.Normal
+            };
+            
+            var hostBots = new List<HostBot>
+            {
+                 HostBot.SimpleComposerHostBotDotNet
+            };
+
+            var targetSkills = new List<string>
+            {
+                SkillBotNames.ComposerSkillBotDotNet
+            };
+
+            var scripts = new List<string>
+            {
+                "HostReceivesEndOfConversation.json"
+            };
+
+            var testCaseBuilder = new TestCaseBuilder();
+
+            var testCases = testCaseBuilder.BuildTestCases(clientTypes, deliverModes, hostBots, targetSkills, scripts);
+            foreach (var testCase in testCases)
+            {
+                yield return testCase;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public async Task RunTestCases(TestCaseDataObject testData)
+        {
+            var testCase = testData.GetObject<TestCase>();
+            Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
+
+            var options = TestClientOptions[testCase.HostBot];
+            var runner = new XUnitTestRunner(new TestClientFactory(testCase.ClientType, options, Logger).GetTestClient(), TestRequestTimeout, Logger);
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #254

## Description
This PR adds Composer SingleTurn scenario for testing Composer Consumer with Composer Skill only, until we add support to configure multiple skills in the Consumer.

### Detailed Changes
- Added `EchoComposerTests.cs` file for testing Composer consumer with Composer skill.

## Testing
In the following image there is a sneak peek for the test.
![image](https://user-images.githubusercontent.com/62260472/104943930-3b9bd680-5995-11eb-9317-26e53aa080f0.png)