### PR TITLE
[Skills Everywhere] [#259] Update WaterfallHostBot to support expect replies and multiple skills

### DIFF
--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Dialogs/MainDialog.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Dialogs/MainDialog.cs
@@ -76,7 +76,10 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
 
             // Add dialog to prepare SSO on the host and test the SSO skill
             // The waterfall skillDialog created in AddSkillDialogs contains the SSO skill action.
-            var waterfallDialog = Dialogs.Find("WaterfallSkillBot");
+            var waterfallDialog = Dialogs
+                .GetDialogs()
+                .Where(e => e.Id.StartsWith("WaterfallSkill"))
+                .First();
             AddDialog(new SsoDialog(waterfallDialog, configuration));
 
             // Add main waterfall dialog for this bot.
@@ -142,6 +145,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
             {
                 Prompt = MessageFactory.Text(messageText, messageText, InputHints.ExpectingInput),
                 RetryPrompt = MessageFactory.Text(rePromptMessageText, rePromptMessageText, InputHints.ExpectingInput),
+                Style = ListStyle.SuggestedAction,
                 Choices = choices
             };
 
@@ -167,6 +171,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
             {
                 Prompt = MessageFactory.Text(messageText, messageText, InputHints.ExpectingInput),
                 RetryPrompt = MessageFactory.Text(rePromptMessageText, rePromptMessageText, InputHints.ExpectingInput),
+                Style = ListStyle.SuggestedAction,
                 Choices = choices
             };
 
@@ -182,14 +187,18 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
             // Create the PromptOptions from the skill configuration which contain the list of configured skills.
             const string messageText = "What skill would you like to call?";
             const string repromptMessageText = "That was not a valid choice, please select a valid skill.";
+
+            var choices = _skillsConfig.Skills
+                .Where(skill => skill.Key.StartsWith(skillType))
+                .Select(skill => new Choice(skill.Value.Id))
+                .ToList();
+
             var options = new PromptOptions
             {
                 Prompt = MessageFactory.Text(messageText, messageText, InputHints.ExpectingInput),
                 RetryPrompt = MessageFactory.Text(repromptMessageText, repromptMessageText, InputHints.ExpectingInput),
-                Choices = _skillsConfig.Skills
-                    .Where(skill => skill.Key.StartsWith(skillType))
-                    .Select(skill => new Choice(skill.Value.Id))
-                    .ToList()
+                Style = ListStyle.SuggestedAction,
+                Choices = choices
             };
 
             // Prompt the user to select a skill.

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Dialogs/MainDialog.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Dialogs/MainDialog.cs
@@ -127,7 +127,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
         private async Task<DialogTurnResult> SelectDeliveryModeStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             // Create the PromptOptions with the delivery modes supported.
-            const string messageText = "What delivery mode would you like to use?";
+            var messageText = stepContext.Options?.ToString() ?? "What delivery mode would you like to use?";
             const string rePromptMessageText = "That was not a valid choice, please select a valid delivery mode.";
             var choices = new List<Choice>
             {
@@ -149,15 +149,14 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
         private async Task<DialogTurnResult> SelectSkillStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             // Set delivery mode.
-            // await _deliveryModeProperty.SetAsync(stepContext.Context, ((FoundChoice)stepContext.Result).Value, cancellationToken);
             var deliveryMode = ((FoundChoice)stepContext.Result).Value;
 
-            // Remember the skill selected by the user.
+            // Remember the delivery mode selected by the user.
             stepContext.Values[_deliveryMode] = deliveryMode;
 
             // Create the PromptOptions from the skill configuration which contain the list of configured skills.
-            var messageText = stepContext.Options?.ToString() ?? "What skill would you like to call?";
-            var repromptMessageText = "That was not a valid choice, please select a valid skill.";
+            const string messageText = "What skill would you like to call?";
+            const string repromptMessageText = "That was not a valid choice, please select a valid skill.";
             var options = new PromptOptions
             {
                 Prompt = MessageFactory.Text(messageText, messageText, InputHints.ExpectingInput),

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/SkillsConfiguration.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/SkillsConfiguration.cs
@@ -46,13 +46,13 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
             SkillDefinition skillDefinition;
             switch (skill.Id)
             {
-                case "EchoSkillBot":
+                case string id when id.StartsWith("EchoSkillBot"):
                     skillDefinition = ObjectPath.Assign<EchoSkill>(new EchoSkill(), skill);
                     break;
-                case "WaterfallSkillBot":
+                case string id when id.StartsWith("WaterfallSkillBot"):
                     skillDefinition = ObjectPath.Assign<WaterfallSkill>(new WaterfallSkill(), skill);
                     break;
-                case "TeamsSkillBot":
+                case string id when id.StartsWith("TeamsSkillBot"):
                     skillDefinition = ObjectPath.Assign<TeamsSkill>(new TeamsSkill(), skill);
                     break;
                 default:

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/appsettings.json
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/appsettings.json
@@ -15,9 +15,34 @@
   "SkillHostEndpoint": "http://localhost:35020/api/skills/",
   "BotFrameworkSkills": [
     {
-      "Id": "EchoSkillBot",
+      "Id": "EchoSkillBotDotNet",
       "AppId": "",
       "SkillEndpoint": "http://localhost:35400/api/messages"
+    },
+    {
+      "Id": "EchoSkillBotDotNet21",
+      "AppId": "",
+      "SkillEndpoint": "http://localhost:35405/api/messages"
+    },
+    {
+      "Id": "EchoSkillBotV3DotNet",
+      "AppId": "",
+      "SkillEndpoint": "http://localhost:35407/api/messages"
+    },
+    {
+      "Id": "EchoSkillBotJS",
+      "AppId": "",
+      "SkillEndpoint": "http://localhost:36400/api/messages"
+    },
+    {
+      "Id": "EchoSkillBotV3JS",
+      "AppId": "",
+      "SkillEndpoint": "http://localhost:36407/api/messages"
+    },
+    {
+      "Id": "EchoSkillBotPython",
+      "AppId": "",
+      "SkillEndpoint": "http://localhost:37400/api/messages"
     },
     {
       "Id": "WaterfallSkillBot",

--- a/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Dialogs/ActivityRouterDialog.cs
+++ b/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Dialogs/ActivityRouterDialog.cs
@@ -127,6 +127,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs
                 case "Echo":
                     // Start the EchoSkillBot
                     var messageActivity = MessageFactory.Text("I'm the echo skill bot");
+                    messageActivity.DeliveryMode = stepContext.Context.Activity.DeliveryMode;
                     return await stepContext.BeginDialogAsync(FindDialog(_echoSkill).Id, new BeginSkillDialogOptions { Activity = messageActivity }, cancellationToken);
 
                 default:

--- a/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Dialogs/Proactive/WaitForProactiveDialog.cs
+++ b/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Dialogs/Proactive/WaitForProactiveDialog.cs
@@ -70,7 +70,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs.Proact
                 OAuthScope = turnContext.TurnState.Get<string>(BotAdapter.OAuthScopeKey)
             };
 
-            _continuationParametersStore.AddOrUpdate(turnContext.Activity.From.Id, continuationParameters, (_, _) => continuationParameters);
+            _continuationParametersStore.AddOrUpdate(turnContext.Activity.From.Id, continuationParameters, (_, __) => continuationParameters);
         }
     }
 }


### PR DESCRIPTION
Addresses #259 

## Description
This PR updates the **_WaterfallHostBot_** to support normal and expectReplies delivery modes, and multiple Echo Skill bots.
The bot now prompts the user to select the delivery mode and after selecting the type of skill (EchoSkill or WaterfllSkill), it shows the different target skills available for each type.
Also, a validation to avoid using ExpectReplies with V3 skill bots was added.

### Specific Changes
- Updated **_MainDialog_** class to include new prompts for Delivery Mode and target skills.
- Included a validation for ExpectReplies and V3 skill bots.
- Added all available echo skill bots with their configuration in **_appSettings.json_**.
- Updated _ActivityRouterDialog_ class of **_WaterfallSkillBot_** to pass the selected delivery mode to the echo skill.

## Testing
These images show the new Dialog flow.
![image](https://user-images.githubusercontent.com/44245136/105900853-5d333880-5ffb-11eb-982a-0d1f31203386.png)
