### PR TITLE
[Skills Everywhere][#259] Update Waterfall tests to support expect replies

### DIFF
--- a/Tests/SkillFunctionalTests/CardActions/CardActionsTests.cs
+++ b/Tests/SkillFunctionalTests/CardActions/CardActionsTests.cs
@@ -31,7 +31,8 @@ namespace SkillFunctionalTests.CardActions
             
             var deliverModes = new List<string>
             {
-                DeliveryModes.Normal
+                DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
             };
 
             var hostBots = new List<HostBot>
@@ -89,8 +90,14 @@ namespace SkillFunctionalTests.CardActions
             var options = TestClientOptions[testCase.HostBot];
             var runner = new XUnitTestRunner(new TestClientFactory(testCase.ClientType, options, Logger).GetTestClient(), TestRequestTimeout, Logger);
 
-            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "WaterfallGreeting.json"));
-            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script));
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "WaterfallGreeting.json"), testParams);
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
         }
     }
 }

--- a/Tests/SkillFunctionalTests/MessageWithAttachment/MessageWithAttachmentTests.cs
+++ b/Tests/SkillFunctionalTests/MessageWithAttachment/MessageWithAttachmentTests.cs
@@ -31,6 +31,7 @@ namespace SkillFunctionalTests.MessageWithAttachment
             var deliverModes = new List<string>
             {
                 DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
             };
 
             var hostBots = new List<HostBot>
@@ -77,7 +78,13 @@ namespace SkillFunctionalTests.MessageWithAttachment
             var options = TestClientOptions[testCase.HostBot];
             var runner = new XUnitTestRunner(new TestClientFactory(testCase.ClientType, options, Logger).GetTestClient(), TestRequestTimeout, Logger);
 
-            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script));
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
         }
     }
 }

--- a/Tests/SkillFunctionalTests/ProactiveMessages/ProactiveTests.cs
+++ b/Tests/SkillFunctionalTests/ProactiveMessages/ProactiveTests.cs
@@ -32,6 +32,7 @@ namespace SkillFunctionalTests.ProactiveMessages
             var deliverModes = new List<string>
             {
                 DeliveryModes.Normal,
+                DeliveryModes.ExpectReplies
             };
 
             var hostBots = new List<HostBot>
@@ -81,8 +82,14 @@ namespace SkillFunctionalTests.ProactiveMessages
             var options = TestClientOptions[testCase.HostBot];
             var runner = new XUnitTestRunner(new TestClientFactory(testCase.ClientType, options, Logger).GetTestClient(), TestRequestTimeout, Logger);
             
+            var testParamsStart = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
             // Execute the first part of the conversation.
-            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script));
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParamsStart);
 
             await runner.AssertReplyAsync(activity =>
             {
@@ -100,13 +107,14 @@ namespace SkillFunctionalTests.ProactiveMessages
                 await client.GetAsync(url).ConfigureAwait(false);
             }
 
-            var testParams = new Dictionary<string, string>
+            var testParamsEnd = new Dictionary<string, string>
             {
-                { "UserId", userId }
+                { "UserId", userId },
+                { "TargetSkill", testCase.TargetSkill }
             };
 
             // Execute the rest of the conversation passing the messageId.
-            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "ProactiveEnd.json"), testParams);
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "ProactiveEnd.json"), testParamsEnd);
         }
     }
 }


### PR DESCRIPTION
Addresses #259

## Description
This PR updates all tests related to CardActions, ProactiveMessages and MessageWithAttachment to support the latest changes in WaterfallHostBot with expectReplies delivery mode and multiple skills.

### Specific Changes
- Updated `CardActions/CardActionsTests.cs`, `ProactiveMessages/ProactiveTests.cs` and `MessageWithAttachment/MessageWithAttachmentTests.cs` adding support for delivery mode expectReplies and multiple skills.

## Testing
In the following image there is a sneak peek for the tests including normal and expect replies.
![image](https://user-images.githubusercontent.com/62260472/106149308-de541200-6158-11eb-8442-0a4e0fa8b8ae.png)