### PR TITLE
[Skills Everywhere] [#257] Add support for legacy pipelines

### DIFF
--- a/build/yaml/dotnetBuildSteps.yml
+++ b/build/yaml/dotnetBuildSteps.yml
@@ -17,18 +17,21 @@ steps:
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet '
 
-- task: NuGetCommand@2
-  displayName: 'NuGet restore'
+- task: DotNetCoreCLI@2
+  displayName: 'Restore'
   inputs:
-    restoreSolution: '$(Parameters.solution)'
+    command: restore
+    projects: '$(Parameters.project)'
+    nobuild: 'true'
+    arguments: '--no-build'
 
-- task: VSBuild@1
-  displayName: 'Build solution'
+- task: DotNetCoreCLI@2
+  displayName: 'Build'
   inputs:
-    solution: '$(Parameters.solution)'
-    vsVersion: 16.0
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
+    command: build
+    publishWebProjects: false
+    projects: '$(Parameters.project)'
+    arguments: '-v n --configuration $(BuildConfiguration) -p:Platform="$(BuildPlatform)" --no-restore'
 
 - script: |
    cd ..

--- a/build/yaml/dotnetHost2DotnetV3Skill.yml
+++ b/build/yaml/dotnetHost2DotnetV3Skill.yml
@@ -115,7 +115,6 @@ stages:
       variables:
         HostBotName: $(DotNetDotNetV3HostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/dotnetHost2JavascriptSkill.yml
+++ b/build/yaml/dotnetHost2JavascriptSkill.yml
@@ -118,7 +118,6 @@ stages:
       variables:
         HostBotName: $(DotNetJsHostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/dotnetHost2JavascriptV3Skill.yml
+++ b/build/yaml/dotnetHost2JavascriptV3Skill.yml
@@ -105,7 +105,6 @@ stages:
       variables:
         HostBotName: $(DotNetJsV3HostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/dotnetHost2PythonSkill.yml
+++ b/build/yaml/dotnetHost2PythonSkill.yml
@@ -122,7 +122,6 @@ stages:
       variables:
         HostBotName: $(DotNetPyHostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/dotnetHost2dotnetSkill.yml
+++ b/build/yaml/dotnetHost2dotnetSkill.yml
@@ -136,7 +136,6 @@ stages:
       variables:
         HostBotName: $(DotNetDotNetHostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/dotnetSetPaths.yml
+++ b/build/yaml/dotnetSetPaths.yml
@@ -4,13 +4,11 @@ steps:
    {
      if("$(NetCoreSdkVersionHost)".Trim() -eq "3.1")
      {
-       $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.sln"
        $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj"
        $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/DeploymentTemplates/template-with-new-rg.json"
      }
      if("$(NetCoreSdkVersionHost)".Trim() -eq "2.1")
      {
-       $SolutionPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot.sln"
        $ProjectPath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot-2.1.csproj"
        $TemplatePath = "Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/DeploymentTemplates/template-with-new-rg.json"
      }
@@ -19,19 +17,15 @@ steps:
    {
      if("$(NetCoreSdkVersionSkill)".Trim() -eq "3.1")
      {
-       $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.sln"
        $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj"
        $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json"
      }
      if("$(NetCoreSdkVersionSkill)".Trim() -eq "2.1")
      {
-       $SolutionPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot.sln"
        $ProjectPath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot-2.1.csproj"
        $TemplatePath = "Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/DeploymentTemplates/template-with-new-rg.json"
      }
    }
-   Write-Host "##vso[task.setvariable variable=Parameters.solution;]$SolutionPath"
-   Write-Host "Solution path set to $SolutionPath"
    Write-Host "##vso[task.setvariable variable=Parameters.project;]$ProjectPath"
    Write-Host "Project path set to $ProjectPath"
    Write-Host "##vso[task.setvariable variable=TemplateLocation;]$TemplatePath"

--- a/build/yaml/functionalTestSteps.yml
+++ b/build/yaml/functionalTestSteps.yml
@@ -8,11 +8,20 @@ steps:
       call az bot directline create -n "$(HostBotName)" -g "$(HostBotName)-RG" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json"
       
 - powershell: |
-    $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
-    $key = $json.properties.properties.sites.key;
-    echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
-    echo "##vso[task.setvariable variable=BOTID;]$(HostBotName)";
-  displayName: 'Get Bot Keys'
+    $directLineFile = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+    $directLineKey = $directLineFile.properties.properties.sites.key;
+    
+    $settingsPath = "tests/SkillFunctionalTests/appsettings.json"
+    $settings = Get-Content $settingsPath | ConvertFrom-Json
+    
+    $settings.HostBotClientOptions = @{}
+    $settings.HostBotClientOptions["EchoHostBot"] = @{
+      DirectLineSecret = $directLineKey
+      BotId            = "$(HostBotName)"
+    }
+    
+    $settings | ConvertTo-Json | Set-Content $settingsPath;
+  displayName: 'Set Bot Keys'
 
 - template: dotnetBuildSteps.yml
 
@@ -21,4 +30,4 @@ steps:
   inputs:
     command: test
     projects: $(Parameters.project)
-    arguments: '-v n  --configuration $(BuildConfiguration) --no-build --no-restore --filter TestCategory!=IgnoreInAutomatedBuild$(DotNetTestFilter)'
+    arguments: '-v n  --configuration $(BuildConfiguration) -p:Platform="$(BuildPlatform)" --no-build --no-restore --filter TestCategory!=IgnoreInAutomatedBuild&TestCategory=Legacy$(DotNetTestFilter)'

--- a/build/yaml/javascriptHost2DotnetSkill.yml
+++ b/build/yaml/javascriptHost2DotnetSkill.yml
@@ -118,7 +118,6 @@ stages:
       variables:
         HostBotName: $(JsDotNetHostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/javascriptHost2DotnetV3Skill.yml
+++ b/build/yaml/javascriptHost2DotnetV3Skill.yml
@@ -97,7 +97,6 @@ stages:
       variables:
         HostBotName: $(JsDotNetV3HostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/javascriptHost2JavascriptSkill.yml
+++ b/build/yaml/javascriptHost2JavascriptSkill.yml
@@ -96,7 +96,6 @@ stages:
       variables:
         HostBotName: $(JsJsHostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/javascriptHost2JavascriptV3Skill.yml
+++ b/build/yaml/javascriptHost2JavascriptV3Skill.yml
@@ -83,7 +83,6 @@ stages:
       variables:
         HostBotName: $(JsJsV3HostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/javascriptHost2PythonSkill.yml
+++ b/build/yaml/javascriptHost2PythonSkill.yml
@@ -98,7 +98,6 @@ stages:
       variables:
         HostBotName: $(JsPyHostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/javascriptSetConfigFileSteps.yml
+++ b/build/yaml/javascriptSetConfigFileSteps.yml
@@ -2,13 +2,15 @@ steps:
 - powershell: |
     Write-host "Setting values in .env file"
     $file = "$(System.DefaultWorkingDirectory)/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/.env";
-    $content = Get-Content -Raw $file | ConvertFrom-StringData;
-
-    $content.SkillHostEndpoint = "https://$(HostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
-    $content.SkillId = "EchoSkillBot";
-    $content.SkillAppId = "$(SkillAppId)";
-    $content.SkillEndpoint = "https://$(SkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
-
-    Clear-Content $file;
-    foreach ($key in $content.keys) { Add-Content $file "$key=$($content.$key)" };
-  displayName: 'Update .env file with Skill Ids'
+    $content = Get-Content $file
+    $content = $content | ForEach-Object {
+      $line = $_
+      if ($line.Trim().Length -gt 0 -and -not $line.Trim().ToLower().StartsWith('skill')) {
+        $line
+      }
+    } 
+    $content += "SkillHostEndpoint=https://$(HostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
+    $content += "skill_EchoSkillBot_appId=$(SkillAppId)";
+    $content += "skill_EchoSkillBot_endpoint=https://$(SkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
+    $content | Set-Content $file;
+  displayName: 'Update .env file'

--- a/build/yaml/pythonHost2DotnetSkill.yml
+++ b/build/yaml/pythonHost2DotnetSkill.yml
@@ -120,7 +120,6 @@ stages:
       variables:
         HostBotName: $(PyDotNetHostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/pythonHost2DotnetV3Skill.yml
+++ b/build/yaml/pythonHost2DotnetV3Skill.yml
@@ -99,7 +99,6 @@ stages:
       variables:
         HostBotName: $(PyDotNetV3HostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/pythonHost2JavascriptSkill.yml
+++ b/build/yaml/pythonHost2JavascriptSkill.yml
@@ -98,7 +98,6 @@ stages:
       variables:
         HostBotName: $(PyJsHostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/pythonHost2JavascriptV3Skill.yml
+++ b/build/yaml/pythonHost2JavascriptV3Skill.yml
@@ -85,7 +85,6 @@ stages:
       variables:
         HostBotName: $(PyJsV3HostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/pythonHost2PythonSkill.yml
+++ b/build/yaml/pythonHost2PythonSkill.yml
@@ -104,7 +104,6 @@ stages:
       variables:
         HostBotName: $(PyPyHostBotName)
         Parameters.project: 'Tests/SkillFunctionalTests/SkillFunctionalTests.csproj'
-        Parameters.solution: 'SkillFunctionalTests.sln'
         DefaultTestFilter: ''
         DotNetTestFilter: $[ coalesce( variables['TestFilter'], variables['DefaultTestFilter'] ) ]
       steps:

--- a/build/yaml/pythonSetConfigFileSteps.yml
+++ b/build/yaml/pythonSetConfigFileSteps.yml
@@ -1,12 +1,16 @@
 steps:
 - powershell: |
-   Write-host "Setting config file"
-   $file = "$(System.DefaultWorkingDirectory)/$(Parameters.sourceLocation)/.env";
-   $content = Get-Content -Raw $file | ConvertFrom-StringData;
-   $content.SKILL_BOT_APP_ID = "$(SkillAppId)";
-   $content.SKILL_BOT_ENDPOINT = "https://$(SkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
-   $content.SKILL_HOST_ENDPOINT = "https://$(HostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
-
-   Clear-Content $file;
-   foreach ($key in $content.keys) { Add-Content $file "$key=$($content.$key)" };
+    Write-host "Setting values in .env file"
+    $file = "$(System.DefaultWorkingDirectory)/$(Parameters.sourceLocation)/.env";
+    $content = Get-Content $file
+    $content = $content | ForEach-Object {
+      $line = $_
+      if ($line.Trim().Length -gt 0 -and -not $line.Trim().ToLower().StartsWith('skill')) {
+        $line
+      }
+    } 
+    $content += "SkillHostEndpoint=https://$(HostBotName)-$(Build.BuildId).azurewebsites.net/api/skills";
+    $content += "skill_EchoSkillBot_appId=$(SkillAppId)";
+    $content += "skill_EchoSkillBot_endpoint=https://$(SkillBotName)-$(Build.BuildId).azurewebsites.net/api/messages";
+    $content | Set-Content $file;
   displayName: 'Update .env file'


### PR DESCRIPTION
Addresses #257

## Description

Updates the legacy pipeline definitions to support the most current version of the bots and test project, including new settings formats and `.sln` file cleanups.

**Note: This PR and PR #272  are related, both are required for legacy retro-compatibility.**

## Specific Changes

- Refactors the previously named `Get Bot Keys` step to set the bot keys into the test project's `appsettings.json` file using the new format.
- Updated `javascriptSetConfigFileSteps.yml` and `pythonSetConfigFileSteps.yml` to support new Consumer bot settings.
- Updated all DotNet `restore`, `build` and `package installation` processes to target _.csproj_ files instead of _.sln_ files. (Excluding DotNetV3).

## Testing
The following screenshots show a set of pipelines representing all possible scenarios where updates took place.
![image](https://user-images.githubusercontent.com/62260472/105856365-edf02100-5fc7-11eb-8f56-3f2fb195c538.png)
![image](https://user-images.githubusercontent.com/64803884/105889729-4554b800-5fed-11eb-8845-83f13ac4ea7f.png)