### PR TITLE
[Skills Everywhere][#282] Fix EchoSkillBotDotNetV3 pipelines deployment

### DIFF
--- a/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj
+++ b/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj
@@ -46,84 +46,84 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac, Version=4.6.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>packages\Autofac.4.6.0\lib\net45\Autofac.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Autofac.4.6.0\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Chronic, Version=0.3.2.0, Culture=neutral, PublicKeyToken=3bd1f1ef638b0d3c, processorArchitecture=MSIL">
-      <HintPath>packages\Chronic.Signed.0.3.2\lib\net40\Chronic.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Chronic.Signed.0.3.2\lib\net40\Chronic.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Documents.Client, Version=1.22.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Azure.DocumentDB.1.22.0\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Azure.DocumentDB.1.22.0\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bot.Builder, Version=3.30.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bot.Builder.3.30.0\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Bot.Builder.3.30.0\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.30.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bot.Builder.3.30.0\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Bot.Builder.3.30.0\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Bot.Builder.Azure, Version=3.16.3.40383, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bot.Builder.Azure.3.16.3.40383\lib\net46\Microsoft.Bot.Builder.Azure.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Bot.Builder.Azure.3.16.3.40383\lib\net46\Microsoft.Bot.Builder.Azure.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bot.Builder.History, Version=3.30.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bot.Builder.History.3.30.0\lib\net46\Microsoft.Bot.Builder.History.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Bot.Builder.History.3.30.0\lib\net46\Microsoft.Bot.Builder.History.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector, Version=3.30.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bot.Connector.3.30.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Bot.Connector.3.30.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Data.Edm.5.7.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.Edm.5.7.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.OData, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Data.OData.5.7.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.OData.5.7.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Services.Client, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Data.Services.Client.5.7.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.Services.Client.5.7.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=4.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.IdentityModel.Clients.ActiveDirectory.4.4.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.IdentityModel.Clients.ActiveDirectory.4.4.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Logging, Version=1.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.IdentityModel.Logging.1.1.4\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.IdentityModel.Logging.1.1.4\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.40306.1554, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.4.403061554\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.4.403061554\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Protocols, Version=2.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.IdentityModel.Protocols.2.1.4\lib\net451\Microsoft.IdentityModel.Protocols.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.IdentityModel.Protocols.2.1.4\lib\net451\Microsoft.IdentityModel.Protocols.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=2.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.2.1.4\lib\net451\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.2.1.4\lib\net451\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.IdentityModel.Tokens.5.1.4\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.IdentityModel.Tokens.5.1.4\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Rest.ClientRuntime.2.3.8\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Rest.ClientRuntime.2.3.8\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.CoreUtility">
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=7.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\WindowsAzure.Storage.7.2.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\WindowsAzure.Storage.7.2.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -134,21 +134,21 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\System.IdentityModel.Tokens.Jwt.5.1.4\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\System.IdentityModel.Tokens.Jwt.5.1.4\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Spatial, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\System.Spatial.5.7.0\lib\net40\System.Spatial.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\System.Spatial.5.7.0\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />

--- a/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj
+++ b/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj
@@ -176,11 +176,6 @@
     <Content Include="packages.config">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="DeploymentTemplates\new-rg-parameters.json" />
-    <Content Include="DeploymentTemplates\preexisting-rg-parameters.json" />
-    <Content Include="DeploymentTemplates\template-with-new-rg.json" />
-    <Content Include="DeploymentTemplates\template-with-preexisting-rg.json" />
-    <None Include="Properties\PublishProfiles\EricV3SkillsEchoBot - Web Deploy.pubxml" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>
@@ -189,7 +184,9 @@
     </None>
     <Content Include="manifests\echoskillbotv3-manifest-1.0.json" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Properties\PublishProfiles\" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/build/yaml/deployBotResources/dotnet/deploy.yml
+++ b/build/yaml/deployBotResources/dotnet/deploy.yml
@@ -12,6 +12,10 @@ stages:
       displayName: '${{ bot.displayName }}'
     dependsOn: '${{ parameters.dependsOn }}'
     jobs:
+      ${{ if eq(bot.type, 'SkillV3') }}:
+        variables:
+          SolutionDir: "$(Build.SourcesDirectory)/Bots/DotNet/"
+
       - job: 'Deploy'
         displayName: 'Deploy steps'
         steps:
@@ -54,7 +58,7 @@ stages:
               displayName: 'NuGet restore'
               inputs:
                 restoreSolution: '${{ bot.project.directory }}/${{ bot.project.name }}'
-                restoreDirectory: 'packages'
+                restoreDirectory: '$(SolutionDir)packages'
 
           # Evaluate dependencies source and version
           - template: evaluateDependenciesVariables.yml
@@ -134,7 +138,7 @@ stages:
 
             # Get BotBuilder version
             - powershell: |
-                $result = @(Get-ChildItem "${{ bot.project.directory }}\packages\Microsoft.Bot.Builder.[0-9]*" -directory | Sort LastWriteTime -Descending)
+                $result = @(Get-ChildItem "$(SolutionDir)packages\Microsoft.Bot.Builder.[0-9]*" -directory | Sort LastWriteTime -Descending)
                 $version = $result[0].Name.Replace("Microsoft.Bot.Builder.", "")
                 Write-Host "##vso[task.setvariable variable=BotBuilderVersionNumber]$($version)";
               displayName: 'Get BotBuilder Version'

--- a/build/yaml/deployBotResources/dotnet/installDependenciesV3.yml
+++ b/build/yaml/deployBotResources/dotnet/installDependenciesV3.yml
@@ -18,7 +18,7 @@ steps:
       }
 
       foreach ($package in "${{ parameters.packages }}".Split()) {
-        Invoke-Expression "nuget update ""${{ parameters.project.directory }}/packages.config"" -Id $package $version $source -RepositoryPath ""${{ parameters.project.directory }}/packages"""
+        Invoke-Expression "nuget update ""${{ parameters.project.directory }}/packages.config"" -Id $package $version $source"
       }
       
       write-host "`nPackages:"

--- a/build/yaml/dotnetHost2DotnetV3Skill.yml
+++ b/build/yaml/dotnetHost2DotnetV3Skill.yml
@@ -67,6 +67,7 @@ stages:
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.solution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj'
         Parameters.packages: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3'
+        SolutionDir: "$(Build.SourcesDirectory)/Bots/DotNet/"
       steps:
       - template: dotnetV3BuildSteps.yml
       - template: dotnetV3TagBotBuilderVersion.yml
@@ -105,6 +106,7 @@ stages:
         Parameters.solution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj'
         Parameters.packages: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3'
         Parameters.sourceLocation: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/'
+        SolutionDir: "$(Build.SourcesDirectory)/Bots/DotNet/"
       steps:
       - template: dotnetV3DeploySteps.yml
 

--- a/build/yaml/dotnetV3BuildSteps.yml
+++ b/build/yaml/dotnetV3BuildSteps.yml
@@ -9,7 +9,7 @@ steps:
   displayName: 'NuGet restore'
   inputs:
     restoreSolution: '$(Parameters.solution)'
-    restoreDirectory: 'packages'
+    restoreDirectory: '$(SolutionDir)packages'
 
 - template: 'dotnetV3InstallPackagesSteps.yml'
 

--- a/build/yaml/dotnetV3InstallPackagesSteps.yml
+++ b/build/yaml/dotnetV3InstallPackagesSteps.yml
@@ -50,16 +50,16 @@ steps:
   displayName: 'Install Microsoft.Bot.Builder'
   inputs:
     command: custom
-    arguments: 'update $(Parameters.packages)/packages.config -Id Microsoft.Bot.Builder $(InstallPackageParameters) -RepositoryPath $(Parameters.packages)/packages'
+    arguments: 'update $(Parameters.packages)/packages.config -Id Microsoft.Bot.Builder $(InstallPackageParameters)'
 
 - task: NuGetCommand@2
   displayName: 'Install Microsoft.Bot.Builder.Azure'
   inputs:
     command: custom
-    arguments: 'update $(Parameters.packages)/packages.config -Id Microsoft.Bot.Builder.Azure $(InstallPackageParameters) -RepositoryPath $(Parameters.packages)/packages'
+    arguments: 'update $(Parameters.packages)/packages.config -Id Microsoft.Bot.Builder.Azure $(InstallPackageParameters)'
 
 - task: NuGetCommand@2
   displayName: 'Install Microsoft.Bot.Builder.History'
   inputs:
     command: custom
-    arguments: 'update $(Parameters.packages)/packages.config -Id Microsoft.Bot.Builder.History $(InstallPackageParameters) -RepositoryPath $(Parameters.packages)/packages'
+    arguments: 'update $(Parameters.packages)/packages.config -Id Microsoft.Bot.Builder.History $(InstallPackageParameters)'

--- a/build/yaml/dotnetV3TagBotBuilderVersion.yml
+++ b/build/yaml/dotnetV3TagBotBuilderVersion.yml
@@ -1,6 +1,6 @@
 steps:
 - powershell: |
-    $result = Get-ChildItem "$(Build.SourcesDirectory)\Bots\DotNet\Skills\CodeFirst\EchoSkillBot-v3\packages\Microsoft.Bot.Builder.[0-9]*" -directory | Sort LastWriteTime -Descending
+    $result = Get-ChildItem "$(SolutionDir)packages\Microsoft.Bot.Builder.[0-9]*" -directory | Sort LastWriteTime -Descending
     
     $version = $result[0].Name.Replace("Microsoft.Bot.Builder.", "")
     $versionTag = ""

--- a/build/yaml/javascriptHost2DotnetV3Skill.yml
+++ b/build/yaml/javascriptHost2DotnetV3Skill.yml
@@ -49,6 +49,7 @@ stages:
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.solution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj'
         Parameters.packages: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3'
+        SolutionDir: "$(Build.SourcesDirectory)/Bots/DotNet/"
       steps:
       - template: dotnetV3BuildSteps.yml
       - template: dotnetV3TagBotBuilderVersion.yml
@@ -88,6 +89,7 @@ stages:
         Parameters.packages: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3'
         Parameters.sourceLocation: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/'
         TemplateLocation: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/DeploymentTemplates/template-with-new-rg.json'
+        SolutionDir: "$(Build.SourcesDirectory)/Bots/DotNet/"
       steps:
       - template: dotnetV3DeploySteps.yml
 

--- a/build/yaml/pythonHost2DotnetV3Skill.yml
+++ b/build/yaml/pythonHost2DotnetV3Skill.yml
@@ -51,6 +51,7 @@ stages:
         BotBuilderPackageVersion: $[variables.BotBuilderPackageVersionSkill]
         Parameters.solution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj'
         Parameters.packages: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3'
+        SolutionDir: "$(Build.SourcesDirectory)/Bots/DotNet/"
       steps:
       - template: dotnetV3BuildSteps.yml
       - template: dotnetV3TagBotBuilderVersion.yml
@@ -90,6 +91,7 @@ stages:
         Parameters.packages: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3'
         Parameters.sourceLocation: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/'
         TemplateLocation: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/DeploymentTemplates/template-with-new-rg.json'
+        SolutionDir: "$(Build.SourcesDirectory)/Bots/DotNet/"
       steps:
       - template: dotnetV3DeploySteps.yml
 


### PR DESCRIPTION
Addresses #282

## Description
This PR fixes issues for running legacy and new pipelines when restoring and building the EchoSkillBotDotNetV3 bot project.

### Specific Changes
- Added a new `SolutionDir` variable pointing out to the root bots' solution directory.
- Updated packages path references to the new `SolutionDir` folder.

## Testing
In the following image there is a sneak peek for the pipelines.
![imagen](https://user-images.githubusercontent.com/62260472/106800588-677ab580-663f-11eb-9f21-03358e00a221.png)