### PR TITLE
Removes workaround for composer bots not sending EoC code.

### DIFF
--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurefunctions/Microsoft.BotFramework.Composer.Functions.csproj
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurefunctions/Microsoft.BotFramework.Composer.Functions.csproj
@@ -13,18 +13,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.11.0-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.12.0-daily.preview.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.12.0-daily.20210205.210249.a163e05" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />

--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj
@@ -17,18 +17,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.11.0-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.12.0-daily.preview.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.12.0-daily.20210205.210249.a163e05" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.66">
       <PrivateAssets>all</PrivateAssets>

--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/core/Microsoft.BotFramework.Composer.Core.csproj
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/core/Microsoft.BotFramework.Composer.Core.csproj
@@ -13,19 +13,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.11.0-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.12.0-daily.preview.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.12.0-daily.20210205.210249.a163e05" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/customaction/Microsoft.BotFramework.Composer.CustomAction.csproj
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/customaction/Microsoft.BotFramework.Composer.CustomAction.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.0-daily.20210205.210249.a163e05" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurefunctions/Microsoft.BotFramework.Composer.Functions.csproj
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurefunctions/Microsoft.BotFramework.Composer.Functions.csproj
@@ -13,18 +13,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.11.0-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.12.0-daily.preview.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.12.0-daily.20210205.210249.a163e05" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj
@@ -17,18 +17,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.11.0-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.12.0-daily.preview.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.12.0-daily.20210205.210249.a163e05" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.66">
       <PrivateAssets>all</PrivateAssets>

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/core/Microsoft.BotFramework.Composer.Core.csproj
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/core/Microsoft.BotFramework.Composer.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -13,19 +13,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.11.0-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.12.0-daily.preview.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.0-daily.20210205.210249.a163e05" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.12.0-daily.20210205.210249.a163e05" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/customaction/Microsoft.BotFramework.Composer.CustomAction.csproj
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/customaction/Microsoft.BotFramework.Composer.CustomAction.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.0-daily.20210205.210249.a163e05" />
   </ItemGroup>
 
 </Project>

--- a/Tests/SkillFunctionalTests/SingleTurn/EchoTests.cs
+++ b/Tests/SkillFunctionalTests/SingleTurn/EchoTests.cs
@@ -98,29 +98,6 @@ namespace SkillFunctionalTests.SingleTurn
                 { "TargetSkill", testCase.TargetSkill }
             };
 
-            // BUG: Composer skills don't return status code, remove this and related placeholder in script once https://github.com/microsoft/BotFramework-FunctionalTests/issues/278 is fixed
-            if (testCase.TargetSkill == SkillBotNames.EchoSkillBotComposerDotNet)
-            {
-                switch (testCase.HostBot)
-                {
-                    case HostBot.SimpleHostBotJS:
-                        testParams.Add("ExpectedEocCode", "undefined");
-                        break;
-
-                    case HostBot.SimpleHostBotPython:
-                        testParams.Add("ExpectedEocCode", "None");
-                        break;
-
-                    default:
-                        testParams.Add("ExpectedEocCode", string.Empty);
-                        break;
-                }
-            }
-            else
-            {
-                testParams.Add("ExpectedEocCode", "completedSuccessfully");
-            }
-
             await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
         }
     }

--- a/Tests/SkillFunctionalTests/SingleTurn/TestScripts/EchoMultiSkill.json
+++ b/Tests/SkillFunctionalTests/SingleTurn/TestScripts/EchoMultiSkill.json
@@ -119,12 +119,12 @@
     {
       "type": "message",
       "role": "bot",
-      "text": "Received endOfConversation.\n\nCode: ${ExpectedEocCode}.",
+      "text": "Received endOfConversation.\n\nCode: completedSuccessfully.",
       "assertions": [
         "type == 'message'",
         "from.role == 'bot'",
         "recipient.role == 'user'",
-        "text == 'Received endOfConversation.\n\nCode: ${ExpectedEocCode}.'",
+        "text == 'Received endOfConversation.\n\nCode: completedSuccessfully.'",
         "inputHint == 'acceptingInput'"
       ]
     },

--- a/build/yaml/deployBotResources/dotnet/deployComposer.yml
+++ b/build/yaml/deployBotResources/dotnet/deployComposer.yml
@@ -20,7 +20,7 @@ stages:
             parameters:
               resourceGroup: '${{ parameters.resourceGroup }}'
               resourceName: '${{ bot.name }}'
-              
+
           # Gets Bot App Registration credentials from KeyVault or Pipeline Variables
           - template: ../common/getAppRegistration.yml
             parameters:
@@ -34,6 +34,95 @@ stages:
               displayName: 'Use NetCore v${{ bot.project.netCoreVersion }}'
               inputs:
                 version: '${{ bot.project.netCoreVersion }}'
+
+          # Evaluate dependencies source and version
+          - template: evaluateDependenciesVariables.yml
+            parameters:
+              ${{ if eq(bot.type, 'Host') }}:
+                registry: "$env:DependenciesRegistryHosts"
+                version: "$env:DependeciesVersionHosts"
+              ${{ if eq(bot.type, 'Skill') }}:
+                registry: "$env:DependenciesRegistrySkills"
+                version: "$env:DependeciesVersionSkills"
+              botType: '${{ bot.type }}'
+
+          # Install dependencies in Microsoft.BotFramework.Composer.WebApp
+          - template: installDependencies.yml
+            parameters:
+              source: "$(DependenciesSource)"
+              version: "$(DependenciesVersionNumber)"
+              project: 
+                directory: '${{ bot.project.directory }}/runtime/azurewebapp/'
+                name: 'Microsoft.BotFramework.Composer.WebApp.csproj'
+              packages:
+                Microsoft.Bot.Builder
+                Microsoft.Bot.Builder.AI.Luis
+                Microsoft.Bot.Builder.AI.QnA
+                Microsoft.Bot.Builder.ApplicationInsights
+                Microsoft.Bot.Builder.Azure
+                Microsoft.Bot.Builder.Dialogs.Declarative
+                Microsoft.Bot.Builder.Dialogs.Adaptive
+                Microsoft.Bot.Builder.Dialogs.Debugging
+                Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+                Microsoft.Bot.Builder.Integration.AspNet.Core
+                Microsoft.Bot.Builder.Dialogs
+                Microsoft.Bot.Connector
+
+          # Install dependencies in Microsoft.BotFramework.Composer.Functions
+          - template: installDependencies.yml
+            parameters:
+              source: "$(DependenciesSource)"
+              version: "$(DependenciesVersionNumber)"
+              project: 
+                directory: '${{ bot.project.directory }}/runtime/azurefunctions/'
+                name: 'Microsoft.BotFramework.Composer.Functions.csproj'
+              packages:
+                Microsoft.Bot.Builder
+                Microsoft.Bot.Builder.AI.Luis
+                Microsoft.Bot.Builder.AI.QnA
+                Microsoft.Bot.Builder.ApplicationInsights
+                Microsoft.Bot.Builder.Azure
+                Microsoft.Bot.Builder.Dialogs.Adaptive
+                Microsoft.Bot.Builder.Dialogs.Debugging
+                Microsoft.Bot.Builder.Dialogs.Declarative
+                Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+                Microsoft.Bot.Builder.Integration.AspNet.Core
+                Microsoft.Bot.Builder.Dialogs
+                Microsoft.Bot.Connector
+
+          # Install dependencies in Microsoft.BotFramework.Composer.CustomAction
+          - template: installDependencies.yml
+            parameters:
+              source: "$(DependenciesSource)"
+              version: "$(DependenciesVersionNumber)"
+              project:
+                directory: '${{ bot.project.directory }}/runtime/customaction/'
+                name: 'Microsoft.BotFramework.Composer.CustomAction.csproj'
+              packages:
+                Microsoft.Bot.Builder.Dialogs.Adaptive
+
+          # Install dependencies in Microsoft.BotFramework.Composer.Core
+          - template: installDependencies.yml
+            parameters:
+              source: "$(DependenciesSource)"
+              version: "$(DependenciesVersionNumber)"
+              project: 
+                directory: '${{ bot.project.directory }}/runtime/core/'
+                name: 'Microsoft.BotFramework.Composer.Core.csproj'
+              packages:
+                Microsoft.Bot.Builder
+                Microsoft.Bot.Builder.AI.Luis
+                Microsoft.Bot.Builder.AI.QnA
+                Microsoft.Bot.Builder.ApplicationInsights
+                Microsoft.Bot.Builder.Azure
+                Microsoft.Bot.Builder.Azure.Blobs
+                Microsoft.Bot.Builder.Dialogs.Adaptive
+                Microsoft.Bot.Builder.Dialogs.Debugging
+                Microsoft.Bot.Builder.Dialogs.Declarative
+                Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+                Microsoft.Bot.Builder.Integration.AspNet.Core
+                Microsoft.Bot.Builder.Dialogs
+                Microsoft.Bot.Connector
 
           # Prepare composer runtime
           - template: composerPrepare.yml

--- a/build/yaml/deployBotResources/dotnet/installDependencies.yml
+++ b/build/yaml/deployBotResources/dotnet/installDependencies.yml
@@ -18,11 +18,21 @@ steps:
       }
 
       foreach ($package in "${{ parameters.packages }}".Split()) {
+        if ($package -eq "Microsoft.Bot.Builder.Dialogs.Debugging"){
+          $versionAux = $version
+          $version = $version.replace("daily", "daily.preview")
+        }
+
         Invoke-Expression "dotnet add ""${{ parameters.project.directory }}/${{ parameters.project.name }}"" package $version $source $package"
+        
+        if(-not ([string]::IsNullOrEmpty("$versionAux"))){
+          $version = $versionAux
+          $versionAux = ""
+        }
       }
 
       write-host " `nPackages:"
       foreach ($package in "${{ parameters.packages }}".Split()) {
         write-host "  - $package"
       }
-    displayName: 'Install dependencies' 
+    displayName: 'Install dependencies for ${{ parameters.project.name }}' 


### PR DESCRIPTION
This PR also updates the composer projects to reference 4.12.0-daily.20210205.210249.a163e05 which is the build that includes the EoC fix (we should use one or higher going forward)

Fixes #278