### PR TITLE
[Skills Everywhere] Add Composer package parameterization

### DIFF
--- a/build/yaml/deployBotResources/dotnet/deployComposer.yml
+++ b/build/yaml/deployBotResources/dotnet/deployComposer.yml
@@ -15,12 +15,6 @@ stages:
       - job: 'Deploy'
         displayName: 'Deploy steps'
         steps:
-          # Delete Bot Resources
-          - template: ../common/deleteResources.yml
-            parameters:
-              resourceGroup: '${{ parameters.resourceGroup }}'
-              resourceName: '${{ bot.name }}'
-              
           # Gets Bot App Registration credentials from KeyVault or Pipeline Variables
           - template: ../common/getAppRegistration.yml
             parameters:
@@ -34,6 +28,95 @@ stages:
               displayName: 'Use NetCore v${{ bot.project.netCoreVersion }}'
               inputs:
                 version: '${{ bot.project.netCoreVersion }}'
+
+          # Evaluate dependencies source and version
+          - template: evaluateDependenciesVariables.yml
+            parameters:
+              ${{ if eq(bot.type, 'Host') }}:
+                registry: "$env:DependenciesRegistryHosts"
+                version: "$env:DependeciesVersionHosts"
+              ${{ if eq(bot.type, 'Skill') }}:
+                registry: "$env:DependenciesRegistrySkills"
+                version: "$env:DependeciesVersionSkills"
+              botType: '${{ bot.type }}'
+
+          # Install dependencies
+          - template: installDependenciesComposer.yml
+            parameters:
+              source: "$(DependenciesSource)"
+              version: "$(DependenciesVersionNumber)"
+              project: 
+                directory: '${{ bot.project.directory }}/runtime/azurewebapp/'
+                name: 'Microsoft.BotFramework.Composer.WebApp.csproj'
+              packages:
+                Microsoft.Bot.Builder
+                Microsoft.Bot.Builder.AI.Luis
+                Microsoft.Bot.Builder.AI.QnA
+                Microsoft.Bot.Builder.ApplicationInsights
+                Microsoft.Bot.Builder.Azure
+                Microsoft.Bot.Builder.Dialogs.Declarative
+                Microsoft.Bot.Builder.Dialogs.Adaptive
+                Microsoft.Bot.Builder.Dialogs.Debugging
+                Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+                Microsoft.Bot.Builder.Integration.AspNet.Core
+                Microsoft.Bot.Builder.Dialogs
+                Microsoft.Bot.Connector
+
+          # Install dependencies
+          - template: installDependenciesComposer.yml
+            parameters:
+              source: "$(DependenciesSource)"
+              version: "$(DependenciesVersionNumber)"
+              project: 
+                directory: '${{ bot.project.directory }}/runtime/azurefunctions/'
+                name: 'Microsoft.BotFramework.Composer.Functions.csproj'
+              packages:
+                Microsoft.Bot.Builder
+                Microsoft.Bot.Builder.AI.Luis
+                Microsoft.Bot.Builder.AI.QnA
+                Microsoft.Bot.Builder.ApplicationInsights
+                Microsoft.Bot.Builder.Azure
+                Microsoft.Bot.Builder.Dialogs.Adaptive
+                Microsoft.Bot.Builder.Dialogs.Debugging
+                Microsoft.Bot.Builder.Dialogs.Declarative
+                Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+                Microsoft.Bot.Builder.Integration.AspNet.Core
+                Microsoft.Bot.Builder.Dialogs
+                Microsoft.Bot.Connector
+
+          # Install dependencies
+          - template: installDependenciesComposer.yml
+            parameters:
+              source: "$(DependenciesSource)"
+              version: "$(DependenciesVersionNumber)"
+              project:
+                directory: '${{ bot.project.directory }}/runtime/customaction/'
+                name: 'Microsoft.BotFramework.Composer.CustomAction.csproj'
+              packages:
+                Microsoft.Bot.Builder.Dialogs.Adaptive
+
+          # Install dependencies
+          - template: installDependenciesComposer.yml
+            parameters:
+              source: "$(DependenciesSource)"
+              version: "$(DependenciesVersionNumber)"
+              project: 
+                directory: '${{ bot.project.directory }}/runtime/core/'
+                name: 'Microsoft.BotFramework.Composer.Core.csproj'
+              packages:
+                Microsoft.Bot.Builder
+                Microsoft.Bot.Builder.AI.Luis
+                Microsoft.Bot.Builder.AI.QnA
+                Microsoft.Bot.Builder.ApplicationInsights
+                Microsoft.Bot.Builder.Azure
+                Microsoft.Bot.Builder.Azure.Blobs
+                Microsoft.Bot.Builder.Dialogs.Adaptive
+                Microsoft.Bot.Builder.Dialogs.Debugging
+                Microsoft.Bot.Builder.Dialogs.Declarative
+                Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+                Microsoft.Bot.Builder.Integration.AspNet.Core
+                Microsoft.Bot.Builder.Dialogs
+                Microsoft.Bot.Connector
 
           # Prepare composer runtime
           - template: composerPrepare.yml

--- a/build/yaml/deployBotResources/dotnet/deployComposer.yml
+++ b/build/yaml/deployBotResources/dotnet/deployComposer.yml
@@ -46,7 +46,7 @@ stages:
                 version: "$env:DependeciesVersionSkills"
               botType: '${{ bot.type }}'
 
-          # Install dependencies
+          # Install dependencies in Microsoft.BotFramework.Composer.WebApp
           - template: installDependenciesComposer.yml
             parameters:
               source: "$(DependenciesSource)"
@@ -68,7 +68,7 @@ stages:
                 Microsoft.Bot.Builder.Dialogs
                 Microsoft.Bot.Connector
 
-          # Install dependencies
+          # Install dependencies in Microsoft.BotFramework.Composer.Functions
           - template: installDependenciesComposer.yml
             parameters:
               source: "$(DependenciesSource)"
@@ -90,7 +90,7 @@ stages:
                 Microsoft.Bot.Builder.Dialogs
                 Microsoft.Bot.Connector
 
-          # Install dependencies
+          # Install dependencies in Microsoft.BotFramework.Composer.CustomAction
           - template: installDependenciesComposer.yml
             parameters:
               source: "$(DependenciesSource)"
@@ -101,7 +101,7 @@ stages:
               packages:
                 Microsoft.Bot.Builder.Dialogs.Adaptive
 
-          # Install dependencies
+          # Install dependencies in Microsoft.BotFramework.Composer.Core
           - template: installDependenciesComposer.yml
             parameters:
               source: "$(DependenciesSource)"

--- a/build/yaml/deployBotResources/dotnet/deployComposer.yml
+++ b/build/yaml/deployBotResources/dotnet/deployComposer.yml
@@ -15,7 +15,7 @@ stages:
       - job: 'Deploy'
         displayName: 'Deploy steps'
         steps:
-          #  Delete Bot Resources
+          # Delete Bot Resources
           - template: ../common/deleteResources.yml
             parameters:
               resourceGroup: '${{ parameters.resourceGroup }}'

--- a/build/yaml/deployBotResources/dotnet/deployComposer.yml
+++ b/build/yaml/deployBotResources/dotnet/deployComposer.yml
@@ -47,7 +47,7 @@ stages:
               botType: '${{ bot.type }}'
 
           # Install dependencies in Microsoft.BotFramework.Composer.WebApp
-          - template: installDependenciesComposer.yml
+          - template: installDependencies.yml
             parameters:
               source: "$(DependenciesSource)"
               version: "$(DependenciesVersionNumber)"
@@ -69,7 +69,7 @@ stages:
                 Microsoft.Bot.Connector
 
           # Install dependencies in Microsoft.BotFramework.Composer.Functions
-          - template: installDependenciesComposer.yml
+          - template: installDependencies.yml
             parameters:
               source: "$(DependenciesSource)"
               version: "$(DependenciesVersionNumber)"
@@ -91,7 +91,7 @@ stages:
                 Microsoft.Bot.Connector
 
           # Install dependencies in Microsoft.BotFramework.Composer.CustomAction
-          - template: installDependenciesComposer.yml
+          - template: installDependencies.yml
             parameters:
               source: "$(DependenciesSource)"
               version: "$(DependenciesVersionNumber)"
@@ -102,7 +102,7 @@ stages:
                 Microsoft.Bot.Builder.Dialogs.Adaptive
 
           # Install dependencies in Microsoft.BotFramework.Composer.Core
-          - template: installDependenciesComposer.yml
+          - template: installDependencies.yml
             parameters:
               source: "$(DependenciesSource)"
               version: "$(DependenciesVersionNumber)"

--- a/build/yaml/deployBotResources/dotnet/deployComposer.yml
+++ b/build/yaml/deployBotResources/dotnet/deployComposer.yml
@@ -15,6 +15,12 @@ stages:
       - job: 'Deploy'
         displayName: 'Deploy steps'
         steps:
+          #  Delete Bot Resources
+          - template: ../common/deleteResources.yml	
+            parameters:	
+              resourceGroup: '${{ parameters.resourceGroup }}'	
+              resourceName: '${{ bot.name }}'
+
           # Gets Bot App Registration credentials from KeyVault or Pipeline Variables
           - template: ../common/getAppRegistration.yml
             parameters:

--- a/build/yaml/deployBotResources/dotnet/deployComposer.yml
+++ b/build/yaml/deployBotResources/dotnet/deployComposer.yml
@@ -16,9 +16,9 @@ stages:
         displayName: 'Deploy steps'
         steps:
           #  Delete Bot Resources
-          - template: ../common/deleteResources.yml	
-            parameters:	
-              resourceGroup: '${{ parameters.resourceGroup }}'	
+          - template: ../common/deleteResources.yml
+            parameters:
+              resourceGroup: '${{ parameters.resourceGroup }}'
               resourceName: '${{ bot.name }}'
 
           # Gets Bot App Registration credentials from KeyVault or Pipeline Variables

--- a/build/yaml/deployBotResources/dotnet/installDependencies.yml
+++ b/build/yaml/deployBotResources/dotnet/installDependencies.yml
@@ -18,11 +18,21 @@ steps:
       }
 
       foreach ($package in "${{ parameters.packages }}".Split()) {
+        if ($package -eq "Microsoft.Bot.Builder.Dialogs.Debugging"){
+          $versionAux = $version
+          $version = $version.replace("daily", "daily.preview")
+        }
+
         Invoke-Expression "dotnet add ""${{ parameters.project.directory }}/${{ parameters.project.name }}"" package $version $source $package"
+        
+        if(-not ([string]::IsNullOrEmpty("$versionAux"))){
+          $version = $versionAux
+          $versionAux = ""
+        }
       }
 
       write-host " `nPackages:"
       foreach ($package in "${{ parameters.packages }}".Split()) {
         write-host "  - $package"
       }
-    displayName: 'Install dependencies' 
+    displayName: 'Install dependencies for ${{ parameters.project.name }}' 


### PR DESCRIPTION
## Description
Adds dependencies source and version parameterization for Composer bots in the _Deploy Bot Resources_ pipeline.
Since Composer bots have runtimes made up of several projects the pipeline will update dependencies on a project by project basis.

**Note: If there are changes in the runtime dependenciess, the list of packages must be updated in the yamls as well.**

## Specific Changes

- Adds a dependencies variables evaluation step and one package installation step for each project with BotBuilder dependencies in the runtime in `dotnet\deployComposer.yml`
- Modifies `dotnet\installDependencies.yml` to add `preview`  to the package version for _Microsoft.Bot.Builder.Dialogs.Debugging_ and the step display name to output the project's name.

## Testing
The following screenshot shows the updated pipeline working highlighting the new steps introduced in this PR.
![image](https://user-images.githubusercontent.com/64803884/107228735-c3f12280-69fb-11eb-8e9d-0395d12a4995.png)