### PR TITLE
Interbranch: updates to the TeamsSkillBot branch

### DIFF
--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Dialogs/MainDialog.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Dialogs/MainDialog.cs
@@ -14,6 +14,7 @@ using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs.Sso;
+using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Skills;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 
@@ -27,20 +28,19 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
         // State property key that stores the active skill (used in AdapterWithErrorHandler to terminate the skills on error).
         public static readonly string ActiveSkillPropertyName = $"{typeof(MainDialog).FullName}.ActiveSkillProperty";
 
-        // Constants used for selecting actions on the skill.
-        private const string JustForwardTheActivity = "JustForwardTurnContext.Activity";
-        private const string SsoDialog = "SsoDialog";
-        private const string TeamsSsoDialog = "TeamsSsoDialog";
-
+        private const string SsoDialogPrefix = "Sso";
         private readonly IStatePropertyAccessor<BotFrameworkSkill> _activeSkillProperty;
         private readonly string _deliveryMode = $"{typeof(MainDialog).FullName}.DeliveryMode";
         private readonly string _selectedSkillKey = $"{typeof(MainDialog).FullName}.SelectedSkillKey";
         private readonly SkillsConfiguration _skillsConfig;
+        private readonly IConfiguration _configuration;
 
         // Dependency injection uses this constructor to instantiate MainDialog.
         public MainDialog(ConversationState conversationState, SkillConversationIdFactoryBase conversationIdFactory, SkillHttpClient skillClient, SkillsConfiguration skillsConfig, IConfiguration configuration)
             : base(nameof(MainDialog))
         {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+
             var botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
 
             _skillsConfig = skillsConfig ?? throw new ArgumentNullException(nameof(skillsConfig));
@@ -67,38 +67,23 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
             // Add ChoicePrompt to render available delivery modes.
             AddDialog(new ChoicePrompt("DeliveryModePrompt"));
 
-            // Add ChoicePrompt to render available types of skill.
-            AddDialog(new ChoicePrompt("SkillTypePrompt"));
+            // Add ChoicePrompt to render available groups of skills.
+            AddDialog(new ChoicePrompt("SkillGroupPrompt"));
 
             // Add ChoicePrompt to render available skills.
             AddDialog(new ChoicePrompt("SkillPrompt"));
 
             // Add ChoicePrompt to render skill actions.
-            AddDialog(new ChoicePrompt("SkillActionPrompt", SkillActionPromptValidator));
+            AddDialog(new ChoicePrompt("SkillActionPrompt"));
 
-            // Add dialog to prepare SSO on the host and test the SSO skill
-            // The waterfall skillDialog created in AddSkillDialogs contains the SSO skill action.
-            var waterfallDialog = Dialogs
-                .GetDialogs()
-                .Where(e => e.Id.StartsWith("WaterfallSkill"))
-                .First();
-
-            var connectionName = configuration.GetSection("SsoConnectionName")?.Value;
-            var t = new SsoDialog(SsoDialog, waterfallDialog, connectionName);
-            AddDialog(t);
-
-            var teamsWaterfallDialog = Dialogs
-                .GetDialogs()
-                .Where(e => e.Id.StartsWith("TeamsWaterfallSkill"))
-                .First();
-            connectionName = configuration.GetSection("TeamsSsoConnectionName")?.Value;
-            AddDialog(new SsoDialog(TeamsSsoDialog, teamsWaterfallDialog, connectionName));
+            // Special case: register SSO dialogs for skills that support SSO actions.
+            AddSsoDialogs(configuration);
 
             // Add main waterfall dialog for this bot.
             var waterfallSteps = new WaterfallStep[]
             {
                 SelectDeliveryModeStepAsync,
-                SelectSkillTypeStepAsync,
+                SelectSkillGroupStepAsync,
                 SelectSkillStepAsync,
                 SelectSkillActionStepAsync,
                 CallSkillActionStepAsync,
@@ -147,7 +132,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
         {
             // Create the PromptOptions with the delivery modes supported.
             var messageText = stepContext.Options?.ToString() ?? "What delivery mode would you like to use?";
-            const string rePromptMessageText = "That was not a valid choice, please select a valid delivery mode.";
+            const string retryMessageText = "That was not a valid choice, please select a valid delivery mode.";
             var choices = new List<Choice>
             {
                 new Choice(DeliveryModes.Normal),
@@ -156,8 +141,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
             var options = new PromptOptions
             {
                 Prompt = MessageFactory.Text(messageText, messageText, InputHints.ExpectingInput),
-                RetryPrompt = MessageFactory.Text(rePromptMessageText, rePromptMessageText, InputHints.ExpectingInput),
-                Style = stepContext.Context.Activity.ChannelId != Bot.Connector.Channels.Msteams ? ListStyle.SuggestedAction : ListStyle.List,
+                RetryPrompt = MessageFactory.Text(retryMessageText, retryMessageText, InputHints.ExpectingInput),
                 Choices = choices
             };
 
@@ -165,52 +149,52 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
             return await stepContext.PromptAsync("DeliveryModePrompt", options, cancellationToken);
         }
 
-        // Render a prompt to select the type of skill to use.
-        private async Task<DialogTurnResult> SelectSkillTypeStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        // Render a prompt to select the group of skills to use.
+        private async Task<DialogTurnResult> SelectSkillGroupStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             // Remember the delivery mode selected by the user.
             stepContext.Values[_deliveryMode] = ((FoundChoice)stepContext.Result).Value;
 
             // Create the PromptOptions with the types of supported skills.
-            const string messageText = "What type of skill would you like to use?";
-            const string rePromptMessageText = "That was not a valid choice, please select a valid skill type.";
-            var choices = new List<Choice>
-            {
-                new Choice("EchoSkill"),
-                new Choice("WaterfallSkill"),
-                new Choice("TeamsWaterfallSkill")
-            };
+            const string messageText = "What group of skills would you like to use?";
+            const string retryMessageText = "That was not a valid choice, please select a valid skill group.";
+
+            // Use linq to get a list of the groups for the skills in skillsConfig.
+            var choices = _skillsConfig.Skills
+                .GroupBy(skill => skill.Value.Group)
+                .Select(skillGroup => new Choice(skillGroup.First().Value.Group))
+                .ToList();
+
             var options = new PromptOptions
             {
                 Prompt = MessageFactory.Text(messageText, messageText, InputHints.ExpectingInput),
-                RetryPrompt = MessageFactory.Text(rePromptMessageText, rePromptMessageText, InputHints.ExpectingInput),
-                Style = stepContext.Context.Activity.ChannelId != Bot.Connector.Channels.Msteams ? ListStyle.SuggestedAction : ListStyle.List,
+                RetryPrompt = MessageFactory.Text(retryMessageText, retryMessageText, InputHints.ExpectingInput),
                 Choices = choices
             };
 
             // Prompt the user to select a type of skill.
-            return await stepContext.PromptAsync("SkillTypePrompt", options, cancellationToken);
+            return await stepContext.PromptAsync("SkillGroupPrompt", options, cancellationToken);
         }
 
         // Render a prompt to select the skill to call.
         private async Task<DialogTurnResult> SelectSkillStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            var skillType = ((FoundChoice)stepContext.Result).Value;
+            var skillGroup = ((FoundChoice)stepContext.Result).Value;
 
             // Create the PromptOptions from the skill configuration which contain the list of configured skills.
             const string messageText = "What skill would you like to call?";
-            const string repromptMessageText = "That was not a valid choice, please select a valid skill.";
+            const string retryMessageText = "That was not a valid choice, please select a valid skill.";
 
+            // Use linq to return the skills for the selected group.
             var choices = _skillsConfig.Skills
-                .Where(skill => skill.Key.StartsWith(skillType))
+                .Where(skill => skill.Value.Group == skillGroup)
                 .Select(skill => new Choice(skill.Value.Id))
                 .ToList();
 
             var options = new PromptOptions
             {
                 Prompt = MessageFactory.Text(messageText, messageText, InputHints.ExpectingInput),
-                RetryPrompt = MessageFactory.Text(repromptMessageText, repromptMessageText, InputHints.ExpectingInput),
-                Style = stepContext.Context.Activity.ChannelId != Bot.Connector.Channels.Msteams ? ListStyle.SuggestedAction : ListStyle.List,
+                RetryPrompt = MessageFactory.Text(retryMessageText, retryMessageText, InputHints.ExpectingInput),
                 Choices = choices
             };
 
@@ -240,64 +224,57 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
             // Remember the skill selected by the user.
             stepContext.Values[_selectedSkillKey] = selectedSkill;
 
+            var skillActionChoices = selectedSkill.GetActions().Select(action => new Choice(action)).ToList();
+            if (skillActionChoices.Count == 1)
+            {
+                // The skill only supports one action (e.g. Echo), skip the prompt.
+                return await stepContext.NextAsync(new FoundChoice { Value = skillActionChoices[0].Value }, cancellationToken);
+            }
+
             // Create the PromptOptions with the actions supported by the selected skill.
-            var messageText = $"Select an action # to send to **{selectedSkill.Id}**.\n\nOr just type in a message and it will be forwarded to the skill as a message activity.";
+            var messageText = $"Select an action to send to **{selectedSkill.Id}**.";
             var options = new PromptOptions
             {
                 Prompt = MessageFactory.Text(messageText, messageText, InputHints.ExpectingInput),
-                Choices = selectedSkill.GetActions().Select(action => new Choice(action)).ToList()
+                Choices = skillActionChoices
             };
 
             // Prompt the user to select a skill action.
             return await stepContext.PromptAsync("SkillActionPrompt", options, cancellationToken);
         }
 
-        // This validator defaults to Message if the user doesn't select an existing option.
-        private Task<bool> SkillActionPromptValidator(PromptValidatorContext<FoundChoice> promptContext, CancellationToken cancellationToken)
-        {
-            if (!promptContext.Recognized.Succeeded)
-            {
-                // Assume the user wants to send a message if an item in the list is not selected.
-                promptContext.Recognized.Value = new FoundChoice { Value = JustForwardTheActivity };
-            }
-
-            return Task.FromResult(true);
-        }
-
         // Starts the SkillDialog based on the user's selections.
         private async Task<DialogTurnResult> CallSkillActionStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            var selectedSkill = (BotFrameworkSkill)stepContext.Values[_selectedSkillKey];
+            var selectedSkill = (SkillDefinition)stepContext.Values[_selectedSkillKey];
 
-            var skillActivity = CreateBeginActivity(stepContext.Context, selectedSkill.Id, ((FoundChoice)stepContext.Result).Value);
+            // Save active skill in state.
+            await _activeSkillProperty.SetAsync(stepContext.Context, selectedSkill, cancellationToken);
+            
+            // Create the initial activity to call the skill.
+            var skillActivity = selectedSkill.CreateBeginActivity(((FoundChoice)stepContext.Result).Value);
+            if (skillActivity.Name == "Sso")
+            {
+                // Special case, we start the SSO dialog to prepare the host to call the skill.
+                return await stepContext.BeginDialogAsync($"{SsoDialogPrefix}{selectedSkill.Id}", cancellationToken: cancellationToken);
+            }
+
+            // We are manually creating the activity to send to the skill; ensure we add the ChannelData and Properties 
+            // from the original activity so the skill gets them.
+            // Note: this is not necessary if we are just forwarding the current activity from context. 
+            skillActivity.ChannelData = stepContext.Context.Activity.ChannelData;
+            skillActivity.Properties = stepContext.Context.Activity.Properties;
 
             // Create the BeginSkillDialogOptions and assign the activity to send.
             var skillDialogArgs = new BeginSkillDialogOptions { Activity = skillActivity };
 
-            var deliveryMode = stepContext.Values[_deliveryMode].ToString();
-
-            if (deliveryMode == DeliveryModes.ExpectReplies)
+            if (stepContext.Values[_deliveryMode].ToString() == DeliveryModes.ExpectReplies)
             {
                 skillDialogArgs.Activity.DeliveryMode = DeliveryModes.ExpectReplies;
             }
-
-            // Save active skill in state.
-            await _activeSkillProperty.SetAsync(stepContext.Context, selectedSkill, cancellationToken);
-
-            if (skillActivity.Name == "Sso")
-            {
-                // Special case, we start the SSO dialog to prepare the host to call the skill.
-                return await stepContext.BeginDialogAsync(SsoDialog, cancellationToken: cancellationToken);
-            }
-            else if (skillActivity.Name == "TeamsSso")
-            {
-                return await stepContext.BeginDialogAsync(TeamsSsoDialog, cancellationToken: cancellationToken);
-            }
-            else
-            {
-                // Start the skillDialog instance with the arguments. 
-                return await stepContext.BeginDialogAsync(selectedSkill.Id, skillDialogArgs, cancellationToken);
-            }    
+            
+            // Start the skillDialog instance with the arguments. 
+            return await stepContext.BeginDialogAsync(selectedSkill.Id, skillDialogArgs, cancellationToken);
         }
 
         // The SkillDialog has ended, render the results (if any) and restart MainDialog.
@@ -347,26 +324,22 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs
             }
         }
 
-        // Helper method to create the activity to be sent to the DialogSkillBot using selected type and values.
-        private Activity CreateBeginActivity(ITurnContext turnContext, string skillId, string selectedOption)
+        // Special case.
+        // SSO needs a dialog in the host to allow the user to sign in.
+        // We create and several SsoDialog instances for each skill that supports SSO.
+        private void AddSsoDialogs(IConfiguration configuration)
         {
-            if (selectedOption.Equals(JustForwardTheActivity, StringComparison.CurrentCultureIgnoreCase))
+            var connectionName = configuration.GetSection("SsoConnectionName")?.Value;
+            foreach (var ssoSkillDialog in Dialogs.GetDialogs().Where(dialog => dialog.Id.StartsWith("WaterfallSkillBot")).ToList())
             {
-                // Note message activities also support input parameters but we are not using them in this example.
-                // Return a deep clone of the activity so we don't risk altering the original one 
-                return ObjectPath.Clone(turnContext.Activity);
+                AddDialog(new SsoDialog($"{SsoDialogPrefix}{ssoSkillDialog.Id}", ssoSkillDialog, connectionName));
             }
 
-            // Get the begin activity from the skill instance.
-            var activity = _skillsConfig.Skills[skillId].CreateBeginActivity(selectedOption);
-
-            // We are manually creating the activity to send to the skill; ensure we add the ChannelData and Properties 
-            // from the original activity so the skill gets them.
-            // Note: this is not necessary if we are just forwarding the current activity from context. 
-            activity.ChannelData = turnContext.Activity.ChannelData;
-            activity.Properties = turnContext.Activity.Properties;
-
-            return activity;
+            connectionName = configuration.GetSection("SsoConnectionNameTeams")?.Value;
+            foreach (var ssoSkillDialog in Dialogs.GetDialogs().Where(dialog => dialog.Id.StartsWith("TeamsWaterfallSkillBot")).ToList())
+            {
+                AddDialog(new SsoDialog($"{SsoDialogPrefix}{ssoSkillDialog.Id}", ssoSkillDialog, connectionName));
+            }
         }
     }
 }

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Dialogs/Sso/SsoDialog.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Dialogs/Sso/SsoDialog.cs
@@ -9,7 +9,6 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs.Sso
 {
@@ -21,15 +20,15 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs.Sso
         private readonly string _connectionName;
         private readonly string _skillDialogId;
 
-        public SsoDialog(string dialogName, Dialog skillDialog, string connectionName)
-            : base(dialogName)
+        public SsoDialog(string dialogId, Dialog ssoSkillDialog, string connectionName)
+            : base(dialogId)
         {
             _connectionName = connectionName;
-            _skillDialogId = skillDialog.Id;
+            _skillDialogId = ssoSkillDialog.Id;
 
             AddDialog(new ChoicePrompt("ActionStepPrompt"));
             AddDialog(new SsoSignInDialog(_connectionName));
-            AddDialog(skillDialog);
+            AddDialog(ssoSkillDialog);
 
             var waterfallSteps = new WaterfallStep[]
             {
@@ -68,7 +67,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs.Sso
             if (token == null)
             {
                 promptChoices.Add(new Choice("Login"));
-                
+
                 // Token exchange will fail when the host is not logged on and the skill should 
                 // show a regular OAuthPrompt
                 promptChoices.Add(new Choice("Call Skill (without SSO)"));

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Dialogs/Sso/SsoSignInDialog.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Dialogs/Sso/SsoSignInDialog.cs
@@ -18,7 +18,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs.Sso
                 new OAuthPromptSettings
             {
                 ConnectionName = connectionName,
-                Text = "Sign in to the host bot using AAD for SSO",
+                Text = $"Sign in to the host bot using AAD for SSO and connection {connectionName}",
                 Title = "Sign In",
                 Timeout = 60000
             }));

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Skills/EchoSkill.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Skills/EchoSkill.cs
@@ -9,24 +9,29 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Skills
 {
     public class EchoSkill : SkillDefinition
     {
-        private const string SkillActionMessage = "Message";
+        private enum SkillAction
+        {
+            Message
+        }
 
         public override IList<string> GetActions()
         {
-            return new List<string> { SkillActionMessage };
+            return new List<string> { SkillAction.Message.ToString() };
         }
 
         public override Activity CreateBeginActivity(string actionId)
         {
-            if (actionId.Equals(SkillActionMessage, StringComparison.CurrentCultureIgnoreCase))
+            if (!Enum.TryParse<SkillAction>(actionId, true, out _))
             {
-                var activity = (Activity)Activity.CreateMessageActivity();
-                activity.Name = SkillActionMessage;
-                activity.Text = "Begin the Echo Skill.";
-                return activity;
+                throw new InvalidOperationException($"Unable to create begin activity for \"{actionId}\".");
             }
 
-            throw new InvalidOperationException($"Unable to create begin activity for \"{actionId}\".");
+            // We only support one activity for Echo so no further checks are needed
+            return new Activity(ActivityTypes.Message)
+            {
+                Name = SkillAction.Message.ToString(),
+                Text = "Begin the Echo Skill."
+            };
         }
     }
 }

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Skills/SkillDefinition.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Skills/SkillDefinition.cs
@@ -10,6 +10,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Skills
 {
     /// <summary>
     /// Extends <see cref="BotFrameworkSkill"/> and provides methods to return the actions and the begin activity to start a skill.
+    /// This class also exposes a group property to render skill groups and narrow down the available options.
     /// </summary>
     /// <remarks>
     /// This is just a temporary implementation, ideally, this should be replaced by logic that parses a manifest and creates
@@ -17,6 +18,8 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Skills
     /// </remarks>
     public class SkillDefinition : BotFrameworkSkill
     {
+        public string Group { get; set; }
+
         public virtual IList<string> GetActions()
         {
             throw new NotImplementedException();

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Skills/TeamsSkill.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Skills/TeamsSkill.cs
@@ -9,129 +9,37 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Skills
 {
     public class TeamsSkill : SkillDefinition
     {
-        private const string SkillActionTeamsTaskModule = "TeamsTaskModule";
-        private const string SkillActionTeamsCardAction = "TeamsCardAction";
-        private const string SkillActionTeamsConversation = "TeamsConversation";
-        private const string SkillActionTeamsCards = "Cards";
-        private const string SkillActionTeamsProactive = "Proactive";
-        private const string SkillActionTeamsAttachment = "Attachment";
-        private const string SkillActionTeamsAuth = "Auth";
-        private const string SkillActionTeamsSso = "TeamsSso";
-        private const string SkillActionTeamsEcho = "Echo";
-        private const string SkillActionTeamsFileUpload = "FileUpload";
-        private const string SkillActionDelete = "Delete";
-        private const string SkillActionUpdate = "Update";
+        private enum SkillAction
+        {
+            TeamsTaskModule,
+            TeamsCardAction,
+            TeamsConversation,
+            Cards,
+            Proactive,
+            Attachment,
+            Auth,
+            Sso,
+            Echo,
+            FileUpload,
+            Delete,
+            Update,
+        }
 
         public override IList<string> GetActions()
         {
-            return new List<string>
-            {
-                SkillActionTeamsTaskModule,
-                SkillActionTeamsCardAction,
-                SkillActionTeamsConversation,
-                SkillActionTeamsCards,
-                SkillActionTeamsProactive,
-                SkillActionTeamsAttachment,
-                SkillActionTeamsAuth,
-                SkillActionTeamsSso,
-                SkillActionTeamsEcho,
-                SkillActionTeamsFileUpload,
-                SkillActionDelete,
-                SkillActionUpdate
-            };
+            return Enum.GetNames(typeof(SkillAction));
         }
 
         public override Activity CreateBeginActivity(string actionId)
         {
-            Activity activity;
-
-            if (actionId.Equals(SkillActionTeamsTaskModule, StringComparison.CurrentCultureIgnoreCase))
+            if (!Enum.TryParse<SkillAction>(actionId, true, out var skillAction))
             {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionTeamsTaskModule;
-                return activity;
+                throw new InvalidOperationException($"Unable to create begin activity for \"{actionId}\".");
             }
 
-            if (actionId.Equals(SkillActionTeamsCardAction, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionTeamsCardAction;
-                return activity;
-            }
-
-            if (actionId.Equals(SkillActionTeamsConversation, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionTeamsConversation;
-                return activity;
-            }
-
-            if (actionId.Equals(SkillActionTeamsCards, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionTeamsCards;
-                return activity;
-            }
-
-            if (actionId.Equals(SkillActionTeamsProactive, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionTeamsProactive;
-                return activity;
-            }
-
-            if (actionId.Equals(SkillActionTeamsAttachment, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionTeamsAttachment;
-                return activity;
-            }
-
-            if (actionId.Equals(SkillActionTeamsAuth, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionTeamsAuth;
-                return activity;
-            }
-
-            if (actionId.Equals(SkillActionTeamsSso, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionTeamsSso;
-                return activity;
-            }
-
-            if (actionId.Equals(SkillActionTeamsEcho, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionTeamsEcho;
-                return activity;
-            }
-
-            if (actionId.Equals(SkillActionTeamsFileUpload, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionTeamsFileUpload;
-                return activity;
-            }
-
-            // Send an event activity to the skill with "Delete" in the name.
-            if (actionId.Equals(SkillActionDelete, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionDelete;
-                return activity;
-            }
-
-            // Send an event activity to the skill with "Update" in the name.
-            if (actionId.Equals(SkillActionUpdate, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionUpdate;
-                return activity;
-            }
-
-            throw new InvalidOperationException($"Unable to create begin activity for \"{actionId}\".");
+            // We don't support special parameters in these skills so a generic event with the right name
+            // will do in this case.
+            return new Activity(ActivityTypes.Event) { Name = skillAction.ToString() };
         }
     }
 }

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Skills/WaterfallSkill.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Skills/WaterfallSkill.cs
@@ -9,109 +9,34 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Skills
 {
     public class WaterfallSkill : SkillDefinition
     {
-        private const string SkillActionCards = "Cards";
-        private const string SkillActionProactive = "Proactive";
-        private const string SkillActionAuth = "Auth";
-        private const string SkillActionMessageWithAttachment = "MessageWithAttachment";
-        private const string SkillActionSso = "Sso";
-        private const string SkillActionFileUpload = "FileUpload";
-        private const string SkillActionCallEchoSkill = "Echo";
-        private const string SkillActionDelete = "Delete";
-        private const string SkillActionUpdate = "Update";
+        private enum SkillAction
+        {
+            Cards,
+            Proactive,
+            Auth,
+            MessageWithAttachment,
+            Sso,
+            FileUpload,
+            Echo,
+            Delete,
+            Update
+        }
 
         public override IList<string> GetActions()
         {
-            return new List<string>
-            {
-                SkillActionCards,
-                SkillActionProactive,
-                SkillActionAuth,
-                SkillActionMessageWithAttachment,
-                SkillActionSso,
-                SkillActionFileUpload,
-                SkillActionCallEchoSkill,
-                SkillActionDelete,
-                SkillActionUpdate
-            };
+            return Enum.GetNames(typeof(SkillAction));
         }
 
         public override Activity CreateBeginActivity(string actionId)
         {
-            Activity activity;
-
-            // Send an event activity to the skill with "Cards" in the name.
-            if (actionId.Equals(SkillActionCards, StringComparison.CurrentCultureIgnoreCase))
+            if (!Enum.TryParse<SkillAction>(actionId, true, out var skillAction))
             {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionCards;
-                return activity;
+                throw new InvalidOperationException($"Unable to create begin activity for \"{actionId}\".");
             }
 
-            // Send an event activity to the skill with "Proactive" in the name.
-            if (actionId.Equals(SkillActionProactive, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionProactive;
-                return activity;
-            }
-
-            // Send an event activity to the skill with "Auth" in the name.
-            if (actionId.Equals(SkillActionAuth, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionAuth;
-                return activity;
-            }
-
-            // Send an event activity to the skill with "Attachment" in the name.
-            if (actionId.Equals(SkillActionMessageWithAttachment, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionMessageWithAttachment;
-                return activity;
-            }
-
-            // Send an event activity to the skill with "Sso" in the name.
-            if (actionId.Equals(SkillActionSso, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionSso;
-                return activity;
-            }
-
-            // Send an event activity to the skill with "FileUpload" in the name.
-            if (actionId.Equals(SkillActionFileUpload, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionFileUpload;
-                return activity;
-            }
-
-            // Send an event activity to the skill with "Echo" in the name.
-            if (actionId.Equals(SkillActionCallEchoSkill, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionCallEchoSkill;
-                return activity;
-            }
-
-            // Send an event activity to the skill with "Delete" in the name.
-            if (actionId.Equals(SkillActionDelete, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionDelete;
-                return activity;
-            }
-
-            // Send an event activity to the skill with "Update" in the name.
-            if (actionId.Equals(SkillActionUpdate, StringComparison.CurrentCultureIgnoreCase))
-            {
-                activity = (Activity)Activity.CreateEventActivity();
-                activity.Name = SkillActionUpdate;
-                return activity;
-            }
-
-            throw new InvalidOperationException($"Unable to create begin activity for \"{actionId}\".");
+            // We don't support special parameters in these skills so a generic event with the right name
+            // will do in this case.
+            return new Activity(ActivityTypes.Event) { Name = skillAction.ToString() };
         }
     }
 }

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/SkillsConfiguration.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/SkillsConfiguration.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Skills;
 using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Skills;
 using Microsoft.Extensions.Configuration;
 
@@ -13,12 +12,16 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
     /// <summary>
     /// A helper class that loads Skills information from configuration.
     /// </summary>
+    /// <remarks>
+    /// This class loads the skill settings from config and casts them into derived types of <see cref="SkillDefinition"/>
+    /// so we can render prompts with the skills and in their groups.
+    /// </remarks>
     public class SkillsConfiguration
     {
         public SkillsConfiguration(IConfiguration configuration)
         {
             var section = configuration?.GetSection("BotFrameworkSkills");
-            var skills = section?.Get<BotFrameworkSkill[]>();
+            var skills = section?.Get<SkillDefinition[]>();
             if (skills != null)
             {
                 foreach (var skill in skills)
@@ -38,21 +41,21 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
 
         public Dictionary<string, SkillDefinition> Skills { get; } = new Dictionary<string, SkillDefinition>();
 
-        private static SkillDefinition CreateSkillDefinition(BotFrameworkSkill skill)
+        private static SkillDefinition CreateSkillDefinition(SkillDefinition skill)
         {
             // Note: we hard code this for now, we should dynamically create instances based on the manifests.
-            // For now, this code creates a strong typed version of the SkillDefinition and copies the info from
-            // settings into it. 
+            // For now, this code creates a strong typed version of the SkillDefinition based on the skill group
+            // and copies the info from settings into it. 
             SkillDefinition skillDefinition;
-            switch (skill.Id)
+            switch (skill.Group)
             {
-                case string id when id.StartsWith("EchoSkillBot"):
+                case "Echo":
                     skillDefinition = ObjectPath.Assign<EchoSkill>(new EchoSkill(), skill);
                     break;
-                case string id when id.StartsWith("WaterfallSkillBot"):
+                case "Waterfall":
                     skillDefinition = ObjectPath.Assign<WaterfallSkill>(new WaterfallSkill(), skill);
                     break;
-                case string id when id.StartsWith("TeamsWaterfallSkillBot"):
+                case "Teams":
                     skillDefinition = ObjectPath.Assign<TeamsSkill>(new TeamsSkill(), skill);
                     break;
                 default:

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/TokenExchangeSkillHandler.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/TokenExchangeSkillHandler.cs
@@ -111,7 +111,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
                             context.TurnState.Add<IIdentity>("BotIdentity", claimsIdentity);
 
                             // We need to know what connection name to use for the token exchange so we figure that out here
-                            var connectionName = targetSkill.Id == Constants.WaterfallSkillBotDotNet ? _configuration.GetSection("SsoConnectionName").Value : _configuration.GetSection("TeamsSsoConnectionName").Value;
+                            var connectionName = targetSkill.Id == Constants.WaterfallSkillBotDotNet ? _configuration.GetSection("SsoConnectionName").Value : _configuration.GetSection("SsoConnectionNameTeams").Value;
                             
                             if (string.IsNullOrEmpty(connectionName))
                             {

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/appsettings.json
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/appsettings.json
@@ -11,48 +11,80 @@
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
   "SsoConnectionName": "",
-  "TeamsSsoConnection": "",
+  "SsoConnectionNameTeams": "",
   "SkillHostEndpoint": "http://localhost:35020/api/skills/",
   "BotFrameworkSkills": [
     {
       "Id": "EchoSkillBotDotNet",
+      "Group": "Echo",
       "AppId": "",
       "SkillEndpoint": "http://localhost:35400/api/messages"
     },
     {
       "Id": "EchoSkillBotDotNet21",
+      "Group": "Echo",
       "AppId": "",
       "SkillEndpoint": "http://localhost:35405/api/messages"
     },
     {
       "Id": "EchoSkillBotDotNetV3",
+      "Group": "Echo",
       "AppId": "",
       "SkillEndpoint": "http://localhost:35407/api/messages"
     },
     {
       "Id": "EchoSkillBotJS",
+      "Group": "Echo",
       "AppId": "",
       "SkillEndpoint": "http://localhost:36400/api/messages"
     },
     {
       "Id": "EchoSkillBotJSV3",
+      "Group": "Echo",
       "AppId": "",
       "SkillEndpoint": "http://localhost:36407/api/messages"
     },
     {
       "Id": "EchoSkillBotPython",
+      "Group": "Echo",
       "AppId": "",
       "SkillEndpoint": "http://localhost:37400/api/messages"
     },
     {
       "Id": "WaterfallSkillBotDotNet",
+      "Group": "Waterfall",
       "AppId": "",
       "SkillEndpoint": "http://localhost:35420/api/messages"
     },
     {
-      "Id": "TeamsWaterfallSkillBot",
+      "Id": "WaterfallSkillBotJS",
+      "Group": "Waterfall",
+      "AppId": "",
+      "SkillEndpoint": "http://localhost:36420/api/messages"
+    },
+    {
+      "Id": "WaterfallSkillBotPython",
+      "Group": "Waterfall",
+      "AppId": "",
+      "SkillEndpoint": "http://localhost:37420/api/messages"
+    },
+    {
+      "Id": "TeamsWaterfallSkillBotDotNet",
+      "Group": "Teams",
       "AppId": "",
       "SkillEndpoint": "http://localhost:35430/api/messages"
+    },
+    {
+      "Id": "TeamsWaterfallSkillBotJS",
+      "Group": "Teams",
+      "AppId": "",
+      "SkillEndpoint": "http://localhost:36430/api/messages"
+    },
+    {
+      "Id": "TeamsWaterfallSkillBotPython",
+      "Group": "Teams",
+      "AppId": "",
+      "SkillEndpoint": "http://localhost:37430/api/messages"
     }
   ]
 }

--- a/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Dialogs/ActivityRouterDialog.cs
+++ b/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/Dialogs/ActivityRouterDialog.cs
@@ -56,10 +56,6 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallSkillBot.Dialogs
         private static SkillDialog CreateEchoSkillDialog(ConversationState conversationState, SkillConversationIdFactoryBase conversationIdFactory, SkillHttpClient skillClient, IConfiguration configuration)
         {
             var botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
-            if (string.IsNullOrWhiteSpace(botId))
-            {
-                throw new ArgumentException($"{MicrosoftAppCredentials.MicrosoftAppIdKey} is not in configuration");
-            }
 
             var skillHostEndpoint = configuration.GetSection("SkillHostEndpoint")?.Value;
             if (string.IsNullOrWhiteSpace(botId))


### PR DESCRIPTION
- Added Group property in SkillDefintion and updated appsettings.json with the property so we can render skill groups dynamically (there are still some assumptions on their names in SkillsConfiguration)
- Updated maindialog with new wording for skill groups, special case logic for SSO and to skip prompting for actions for skills that only have one action (echo).
- Removed explicity ListStyle for some choice prompts so this is handled by the SDK defaults.
- Refactored SkillDefintion and derived classes to use enums and make the code less repetitive.
- Renamed TeamsSsoConnectionName to SsoConnectionNameTeams (it sorts better)
- Updated SsoSignInDialog to display the connection name being used.
- Some renames in SsoDialog to align with the SDK naming