### PR TITLE
Adding Update and Delete scenarios to Waterfall skill

### DIFF
--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/activityRouterDialog.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/activityRouterDialog.js
@@ -9,6 +9,8 @@ const { FileUploadDialog } = require('./fileUpload/fileUploadDialog');
 const { MessageWithAttachmentDialog } = require('./messageWithAttachment/messageWithAttachmentDialog');
 const { WaitForProactiveDialog } = require('./proactive/waitForProactiveDialog');
 const { SsoSkillDialog } = require('./sso/ssoSkillDialog');
+const { DeleteDialog } = require('./delete/deleteDialog');
+const { UpdateDialog } = require('./update/updateDialog');
 
 const MAIN_DIALOG = 'ActivityRouterDialog';
 const WATERFALL_DIALOG = 'WaterfallDialog';
@@ -19,6 +21,8 @@ const AUTH_DIALOG = 'Auth';
 const SSO_DIALOG = 'Sso';
 const FILE_UPLOAD_DIALOG = 'FileUpload';
 const ECHO_DIALOG = 'Echo';
+const DELETE_DIALOG = 'Delete';
+const UPDATE_DIALOG = 'Update';
 
 /**
  * A root dialog that can route activities sent to the skill to different sub-dialogs.
@@ -40,6 +44,8 @@ class ActivityRouterDialog extends ComponentDialog {
             .addDialog(new AuthDialog(AUTH_DIALOG, process.env))
             .addDialog(new SsoSkillDialog(SSO_DIALOG, process.env))
             .addDialog(new FileUploadDialog(FILE_UPLOAD_DIALOG))
+            .addDialog(new DeleteDialog(DELETE_DIALOG))
+            .addDialog(new UpdateDialog(UPDATE_DIALOG))
             .addDialog(this.createEchoSkillDialog(ECHO_DIALOG, conversationState, conversationIdFactory, skillClient, process.env))
             .addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
                 this.processActivity.bind(this)
@@ -129,6 +135,8 @@ class ActivityRouterDialog extends ComponentDialog {
         case AUTH_DIALOG:
         case SSO_DIALOG:
         case FILE_UPLOAD_DIALOG:
+        case DELETE_DIALOG:
+        case UPDATE_DIALOG:
             return stepContext.beginDialog(activity.name);
 
         case ECHO_DIALOG: {

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/delete/deleteDialog.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/delete/deleteDialog.js
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { MessageFactory, InputHints } = require('botbuilder');
+const { ComponentDialog, AttachmentPrompt, ChoicePrompt, WaterfallDialog, ListStyle, ChoiceFactory, DialogTurnStatus } = require('botbuilder-dialogs');
+const fs = require('fs');
+const fetch = require('node-fetch');
+const os = require('os');
+const path = require('path');
+const stream = require('stream');
+const util = require('util');
+
+const streamPipeline = util.promisify(stream.pipeline);
+
+const ATTACHMENT_PROMPT = 'AttachmentPrompt';
+const CHOICE_PROMPT = 'ChoicePrompt';
+const WATERFALL_DIALOG = 'WaterfallDialog';
+
+class FileUploadDialog extends ComponentDialog {
+    /**
+     * @param {string} dialogId
+     */
+    constructor(dialogId) {
+        super(dialogId);
+
+        this.addDialog(new AttachmentPrompt(ATTACHMENT_PROMPT))
+            .addDialog(new ChoicePrompt(CHOICE_PROMPT))
+            .addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+                this.promptUploadStep.bind(this),
+                this.handleAttachmentStep.bind(this),
+                this.finalStep.bind(this)
+            ]));
+
+        this.initialDialogId = WATERFALL_DIALOG;
+    }
+
+    /**
+     * @param {import('botbuilder-dialogs').WaterfallStepContext} stepContext
+     */
+    async promptUploadStep(stepContext) {
+        return stepContext.prompt(ATTACHMENT_PROMPT, {
+            prompt: MessageFactory.text('Please upload a file to continue.'),
+            retryPrompt: MessageFactory.text('You must upload a file.')
+        });
+    }
+
+    /**
+     * @param {import('botbuilder-dialogs').WaterfallStepContext} stepContext
+     */
+    async handleAttachmentStep(stepContext) {
+        let filetext = '';
+
+        for (const file of stepContext.context.activity.attachments) {
+            const localFileName = path.resolve(os.tmpdir(), file.name);
+            const tempFile = fs.createWriteStream(localFileName);
+            fetch(file.contentUrl).then(response => streamPipeline(response.body, tempFile));
+
+            filetext += `Attachment "${ file.name }" has been received and saved to "${ localFileName }"\r\n`;
+        }
+
+        await stepContext.context.sendActivity(MessageFactory.text(filetext));
+
+        const messageText = 'Do you want to upload another file?';
+        const repromptMessageText = 'You must select "Yes" or "No".';
+
+        return stepContext.prompt(CHOICE_PROMPT, {
+            prompt: MessageFactory.text(messageText, messageText, InputHints.ExpectingInput),
+            retryPrompt: MessageFactory.text(repromptMessageText, repromptMessageText, InputHints.ExpectingInput),
+            choices: ChoiceFactory.toChoices(['Yes', 'No']),
+            style: ListStyle.list
+        });
+    }
+
+    /**
+     * @param {import('botbuilder-dialogs').WaterfallStepContext} stepContext
+     */
+    async finalStep(stepContext) {
+        const choice = stepContext.result.value.toLowerCase();
+
+        if (choice === 'yes') {
+            return stepContext.replaceDialog(this.initialDialogId);
+        } else {
+            return { status: DialogTurnStatus.complete };
+        }
+    }
+}
+
+module.exports.FileUploadDialog = FileUploadDialog;

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/delete/deleteDialog.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/delete/deleteDialog.js
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const { MessageFactory } = require('botbuilder');
-const { ComponentDialog, WaterfallDialog, DialogTurnStatus } = require('botbuilder-dialogs');
-const { Channels} = require('botbuilder-core');
+const { MessageFactory, InputHints } = require('botbuilder');
+const { ChoiceFactory, ChoicePrompt, ComponentDialog, WaterfallDialog, DialogTurnStatus, ListStyle } = require('botbuilder-dialogs');
+const { Channels } = require('botbuilder-core');
 
 const SLEEP_TIMER = 5000;
 const WATERFALL_DIALOG = 'WaterfallDialog';
+const CHOICE_PROMPT = 'ChoicePrompt';
 const DELETE_UNSUPPORTED = new Set([Channels.Emulator, Channels.Facebook, Channels.Webchat]);
 
 class DeleteDialog extends ComponentDialog {
@@ -16,8 +17,10 @@ class DeleteDialog extends ComponentDialog {
     constructor(dialogId) {
         super(dialogId);
 
-        this.addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
-                this.HandleDeleteDialog.bind(this)
+        this.addDialog(new ChoicePrompt(CHOICE_PROMPT))
+            .addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+                this.HandleDeleteDialog.bind(this),
+                this.FinalStep.bind(this)
             ]));
 
         this.initialDialogId = WATERFALL_DIALOG;
@@ -29,21 +32,42 @@ class DeleteDialog extends ComponentDialog {
     async HandleDeleteDialog(stepContext) {
         let channel = stepContext.context.activity.channelId;
 
-        if (DeleteDialog.isDeleteSupported(channel)){
+        if (DeleteDialog.isDeleteSupported(channel))
+        {
             var id = await stepContext.context.sendActivity(MessageFactory.text("I will delete this message in 5 seconds"));
-            DeleteDialog.sleep();
+            await DeleteDialog.sleep(SLEEP_TIMER);
             await stepContext.context.deleteActivity(id.id);
         }
-        else{
+        else
+        {
             await stepContext.context.sendActivity(MessageFactory.text(`Delete is not supported in the ${channel} channel.`))
-        }
+        }    
 
-        return { status: DialogTurnStatus.complete };
+        const messageText = 'Do you want to delete again?';
+        const repromptMessageText = 'You must select "Yes" or "No".';
+
+        return stepContext.prompt(CHOICE_PROMPT, {
+            prompt: MessageFactory.text(messageText, messageText, InputHints.ExpectingInput),
+            retryPrompt: MessageFactory.text(repromptMessageText, repromptMessageText, InputHints.ExpectingInput),
+            choices: ChoiceFactory.toChoices(['Yes', 'No']),
+            style: ListStyle.list
+        });
     }
 
-    static sleep() {
-        var e = new Date().getTime() + SLEEP_TIMER;
-        while (new Date().getTime() <= e){}
+    async FinalStep(stepContext) {
+        const choice = stepContext.result.value.toLowerCase();
+
+        if (choice === 'yes') {
+            return stepContext.replaceDialog(this.initialDialogId);
+        } else {
+            return { status: DialogTurnStatus.complete };
+        }
+    }
+
+    static sleep(milliseconds) {
+        return new Promise(resolve => {
+            setTimeout(resolve, milliseconds);
+        });
     }
 
     static isDeleteSupported(channel) {

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/update/updateDialog.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/dialogs/update/updateDialog.js
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { InputHints, MessageFactory } = require('botbuilder');
+const { ChoiceFactory, ChoicePrompt, ComponentDialog, ListStyle, WaterfallDialog, DialogTurnStatus } = require('botbuilder-dialogs');
+const { Channels } = require('botbuilder-core');
+
+const WATERFALL_DIALOG = 'WaterfallDialog';
+const UPDATE_UNSUPPORTED = new Set([Channels.Emulator, Channels.Facebook, Channels.Webchat]);
+const CHOICE_PROMPT = "ChoicePrompt";
+
+
+class UpdateDialog extends ComponentDialog {
+    /**
+     * @param {string} dialogId
+     */
+    constructor(dialogId) {
+        super(dialogId);
+
+        this.updateTracker = {};
+
+        this.addDialog(new ChoicePrompt(CHOICE_PROMPT));
+        this.addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+                this.HandleUpdateDialog.bind(this),
+                this.FinalStepAsync.bind(this)
+            ]));
+
+        this.initialDialogId = WATERFALL_DIALOG;
+    }
+
+    /**
+     * @param {import('botbuilder-dialogs').WaterfallStepContext} stepContext
+     */
+    async HandleUpdateDialog(stepContext) {
+        let channel = stepContext.context.activity.channelId;
+
+        if (UpdateDialog.isUpdateSupported(channel)){
+            const conversationId = stepContext.context.activity.conversation.id;
+
+            if (conversationId in this.updateTracker) {
+                var tuple = this.updateTracker[conversationId];
+                var activity = MessageFactory.text(`This message has been updated ${tuple[1]} time(s).`)
+                activity.id = tuple[0];
+                tuple[1]++;
+                this.updateTracker[conversationId] = tuple;
+                await stepContext.context.updateActivity(activity);
+            }
+            else
+            {
+                var id = await stepContext.context.sendActivity(MessageFactory.text("Here is the original activity"));
+                this.updateTracker[conversationId] = [id.id, 1];
+            }
+        }
+        else
+        {
+            await stepContext.context.sendActivity(MessageFactory.text(`Update is not supported in the ${channel} channel.`))
+        }
+
+        const messageText = 'Do you want to update the activity again?';
+        const repromptMessageText = 'Please select a valid option';
+        const options = {
+            prompt: MessageFactory.text(messageText, messageText, InputHints.ExpectingInput),
+            retryPrompt: MessageFactory.text(repromptMessageText, repromptMessageText, InputHints.ExpectingInput),
+            choices: ChoiceFactory.toChoices(["yes", "no"]),
+            style: ListStyle.list
+        };
+
+        // Ask the user to enter a card choice.
+        return stepContext.prompt(CHOICE_PROMPT, options);
+    }
+
+    async FinalStepAsync(stepContext){
+        const choice = stepContext.result.value;
+
+        if (choice == "yes"){
+            return stepContext.replaceDialog(this.initialDialogId);
+        }
+        
+        this.updateTracker = {};
+        return { status: DialogTurnStatus.complete };
+    }
+
+    static isUpdateSupported(channel) {
+        return !UPDATE_UNSUPPORTED.has(channel);
+    }
+}
+
+module.exports.UpdateDialog = UpdateDialog


### PR DESCRIPTION
There's a PR pending in the C# repo that adds the update and delete scenarios to the Waterfall skill. I wanted to make sure those were replicated here for the port. You can see the host PR [here](https://github.com/microsoft/BotFramework-FunctionalTests/pull/315)