### PR TITLE
[FunctionalTests-CI] Fix issue: unable to find packages

### DIFF
--- a/Bots/DotNet/nuget.config
+++ b/Bots/DotNet/nuget.config
@@ -1,6 +1,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="SDK" value="https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/Bots/DotNet/nuget.config
+++ b/Bots/DotNet/nuget.config
@@ -1,7 +1,0 @@
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="SDK" value="https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/build/yaml/FunctionalTestsBotsbuild.yml
+++ b/build/yaml/FunctionalTestsBotsbuild.yml
@@ -11,25 +11,211 @@ steps:
     version: 3.1.x
 
 - task: NuGetToolInstaller@1
-  inputs:
-    versionSpec: 
+  displayName: 'Use NuGet'
 
+# Start of Restore & Build excluding Composer and V3
+- task: DotNetCoreCLI@2
+  displayName: Restore bots
+  inputs:
+    command: restore
+    projects: |
+      Bots/DotNet/**/*.csproj
+      !Bots/DotNet/**/Composer/**/*.csproj
+      !Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj
+    feedsToUse: 'select'
+    includeNuGetOrg: true
+
+- task: DotNetCoreCLI@2
+  displayName: Build bots
+  inputs:
+    command: build
+    projects: |
+      Bots/DotNet/**/*.csproj
+      !Bots/DotNet/**/Composer/**/*.csproj
+      !Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj
+    feedsToUse: 'select'
+    includeNuGetOrg: true
+# End of Restore & Build excluding Composer and V3
+
+# Start of Restore & Build for Composer
+- template: deployBotResources/dotnet/evaluateDependenciesVariables.yml
+  parameters:
+    botType: "Host"
+
+- template: deployBotResources/dotnet/installDependencies.yml
+  parameters:
+    source: "$(DependenciesSource)"
+    version: "$(DependenciesVersionNumber)"
+    project: 
+      directory: 'Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurewebapp/'
+      name: 'Microsoft.BotFramework.Composer.WebApp.csproj'
+    packages:
+      Microsoft.Bot.Builder
+      Microsoft.Bot.Builder.AI.Luis
+      Microsoft.Bot.Builder.AI.QnA
+      Microsoft.Bot.Builder.ApplicationInsights
+      Microsoft.Bot.Builder.Azure
+      Microsoft.Bot.Builder.Dialogs.Declarative
+      Microsoft.Bot.Builder.Dialogs.Adaptive
+      Microsoft.Bot.Builder.Dialogs.Debugging
+      Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+      Microsoft.Bot.Builder.Integration.AspNet.Core
+      Microsoft.Bot.Builder.Dialogs
+      Microsoft.Bot.Connector
+
+- template: deployBotResources/dotnet/installDependencies.yml
+  parameters:
+    source: "$(DependenciesSource)"
+    version: "$(DependenciesVersionNumber)"
+    project: 
+      directory: 'Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurefunctions/'
+      name: 'Microsoft.BotFramework.Composer.Functions.csproj'
+    packages:
+      Microsoft.Bot.Builder
+      Microsoft.Bot.Builder.AI.Luis
+      Microsoft.Bot.Builder.AI.QnA
+      Microsoft.Bot.Builder.ApplicationInsights
+      Microsoft.Bot.Builder.Azure
+      Microsoft.Bot.Builder.Dialogs.Adaptive
+      Microsoft.Bot.Builder.Dialogs.Debugging
+      Microsoft.Bot.Builder.Dialogs.Declarative
+      Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+      Microsoft.Bot.Builder.Integration.AspNet.Core
+      Microsoft.Bot.Builder.Dialogs
+      Microsoft.Bot.Connector
+
+- template: deployBotResources/dotnet/installDependencies.yml
+  parameters:
+    source: "$(DependenciesSource)"
+    version: "$(DependenciesVersionNumber)"
+    project:
+      directory: 'Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/customaction/'
+      name: 'Microsoft.BotFramework.Composer.CustomAction.csproj'
+    packages:
+      Microsoft.Bot.Builder.Dialogs.Adaptive
+
+- template: deployBotResources/dotnet/installDependencies.yml
+  parameters:
+    source: "$(DependenciesSource)"
+    version: "$(DependenciesVersionNumber)"
+    project: 
+      directory: 'Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/core/'
+      name: 'Microsoft.BotFramework.Composer.Core.csproj'
+    packages:
+      Microsoft.Bot.Builder
+      Microsoft.Bot.Builder.AI.Luis
+      Microsoft.Bot.Builder.AI.QnA
+      Microsoft.Bot.Builder.ApplicationInsights
+      Microsoft.Bot.Builder.Azure
+      Microsoft.Bot.Builder.Azure.Blobs
+      Microsoft.Bot.Builder.Dialogs.Adaptive
+      Microsoft.Bot.Builder.Dialogs.Debugging
+      Microsoft.Bot.Builder.Dialogs.Declarative
+      Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+      Microsoft.Bot.Builder.Integration.AspNet.Core
+      Microsoft.Bot.Builder.Dialogs
+      Microsoft.Bot.Connector
+
+- template: deployBotResources/dotnet/installDependencies.yml
+  parameters:
+    source: "$(DependenciesSource)"
+    version: "$(DependenciesVersionNumber)"
+    project: 
+      directory: 'Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurewebapp/'
+      name: 'Microsoft.BotFramework.Composer.WebApp.csproj'
+    packages:
+      Microsoft.Bot.Builder
+      Microsoft.Bot.Builder.AI.Luis
+      Microsoft.Bot.Builder.AI.QnA
+      Microsoft.Bot.Builder.ApplicationInsights
+      Microsoft.Bot.Builder.Azure
+      Microsoft.Bot.Builder.Dialogs.Declarative
+      Microsoft.Bot.Builder.Dialogs.Adaptive
+      Microsoft.Bot.Builder.Dialogs.Debugging
+      Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+      Microsoft.Bot.Builder.Integration.AspNet.Core
+      Microsoft.Bot.Builder.Dialogs
+      Microsoft.Bot.Connector
+
+- template: deployBotResources/dotnet/installDependencies.yml
+  parameters:
+    source: "$(DependenciesSource)"
+    version: "$(DependenciesVersionNumber)"
+    project: 
+      directory: 'Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurefunctions/'
+      name: 'Microsoft.BotFramework.Composer.Functions.csproj'
+    packages:
+      Microsoft.Bot.Builder
+      Microsoft.Bot.Builder.AI.Luis
+      Microsoft.Bot.Builder.AI.QnA
+      Microsoft.Bot.Builder.ApplicationInsights
+      Microsoft.Bot.Builder.Azure
+      Microsoft.Bot.Builder.Dialogs.Adaptive
+      Microsoft.Bot.Builder.Dialogs.Debugging
+      Microsoft.Bot.Builder.Dialogs.Declarative
+      Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+      Microsoft.Bot.Builder.Integration.AspNet.Core
+      Microsoft.Bot.Builder.Dialogs
+      Microsoft.Bot.Connector
+
+- template: deployBotResources/dotnet/installDependencies.yml
+  parameters:
+    source: "$(DependenciesSource)"
+    version: "$(DependenciesVersionNumber)"
+    project:
+      directory: 'Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/customaction/'
+      name: 'Microsoft.BotFramework.Composer.CustomAction.csproj'
+    packages:
+      Microsoft.Bot.Builder.Dialogs.Adaptive
+
+- template: deployBotResources/dotnet/installDependencies.yml
+  parameters:
+    source: "$(DependenciesSource)"
+    version: "$(DependenciesVersionNumber)"
+    project: 
+      directory: 'Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/core/'
+      name: 'Microsoft.BotFramework.Composer.Core.csproj'
+    packages:
+      Microsoft.Bot.Builder
+      Microsoft.Bot.Builder.AI.Luis
+      Microsoft.Bot.Builder.AI.QnA
+      Microsoft.Bot.Builder.ApplicationInsights
+      Microsoft.Bot.Builder.Azure
+      Microsoft.Bot.Builder.Azure.Blobs
+      Microsoft.Bot.Builder.Dialogs.Adaptive
+      Microsoft.Bot.Builder.Dialogs.Debugging
+      Microsoft.Bot.Builder.Dialogs.Declarative
+      Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+      Microsoft.Bot.Builder.Integration.AspNet.Core
+      Microsoft.Bot.Builder.Dialogs
+      Microsoft.Bot.Connector
+
+- task: DotNetCoreCLI@2
+  displayName: 'Build composer bots'
+  inputs:
+    command: publish
+    publishWebProjects: false
+    projects: |
+      Bots/DotNet/**/Composer/**/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj
+    modifyOutputPath: false
+    zipAfterPublish: false
+# End of Restore & Build for Composer
+
+# Start of Restore & Build for V3
 - task: NuGetCommand@2
+  displayName: 'Restore V3 bot'
   inputs:
-    command: 'restore'
-    restoreSolution: 'Bots/DotNet/FunctionalTestsBots.sln'
+    restoreSolution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj'
     restoreDirectory: '$(SolutionDir)packages'
-    feedsToUse: config
-    nugetConfigPath: Bots/DotNet/nuget.config
-
 
 - task: MSBuild@1
-  displayName: 'Build'
+  displayName: 'Build V3 bot'
   inputs:
-    solution: 'Bots/DotNet/FunctionalTestsBots.sln'
+    solution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj'
     vsVersion: 16.0
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
+# End of Restore & Build for V3
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: build folder'
@@ -43,4 +229,3 @@ steps:
   displayName: 'Dir workspace'
   continueOnError: true
   condition: succeededOrFailed()
-

--- a/build/yaml/FunctionalTestsBotsbuild.yml
+++ b/build/yaml/FunctionalTestsBotsbuild.yml
@@ -18,13 +18,18 @@ steps:
   inputs:
     command: 'restore'
     restoreSolution: 'Bots/DotNet/FunctionalTestsBots.sln'
+    restoreDirectory: '$(SolutionDir)packages'
+    feedsToUse: config
+    nugetConfigPath: Bots/DotNet/nuget.config
 
 
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet build'
+- task: MSBuild@1
+  displayName: 'Build'
   inputs:
-    projects: Bots/DotNet/FunctionalTestsBots.sln
-
+    solution: 'Bots/DotNet/FunctionalTestsBots.sln'
+    vsVersion: 16.0
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: build folder'

--- a/build/yaml/FunctionalTestsBotsbuild.yml
+++ b/build/yaml/FunctionalTestsBotsbuild.yml
@@ -24,6 +24,7 @@ steps:
       !Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj
     feedsToUse: 'select'
     includeNuGetOrg: true
+    arguments: '--no-build'
 
 - task: DotNetCoreCLI@2
   displayName: Build bots
@@ -35,6 +36,7 @@ steps:
       !Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj
     feedsToUse: 'select'
     includeNuGetOrg: true
+    arguments: '-v n --configuration $(BuildConfiguration) -p:Platform="$(BuildPlatform)" --no-restore'
 # End of Restore & Build excluding Composer and V3
 
 # Start of Restore & Build for Composer
@@ -213,7 +215,7 @@ steps:
   inputs:
     solution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj'
     vsVersion: 16.0
-    platform: '$(BuildPlatform)'
+    platform: 'AnyCPU'
     configuration: '$(BuildConfiguration)'
 # End of Restore & Build for V3
 

--- a/build/yaml/SkillFunctionalTestsbuild.yml
+++ b/build/yaml/SkillFunctionalTestsbuild.yml
@@ -17,7 +17,7 @@ steps:
 - task: NuGetCommand@2
   inputs:
     command: 'restore'
-    restoreSolution: SkillFunctionalTests-standard.sln
+    restoreSolution: SkillFunctionalTests.sln
 
 
 - task: DotNetCoreCLI@2

--- a/build/yaml/functionaltests-CI,yml
+++ b/build/yaml/functionaltests-CI,yml
@@ -1,6 +1,6 @@
 # This runs under BotBuilder-Js-CI-yaml. Replaces classic build BotBuilder-JS-master-CI-node12.
 
-variables
+variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'AnyCPU'
 

--- a/build/yaml/functionaltests-CI,yml
+++ b/build/yaml/functionaltests-CI,yml
@@ -2,7 +2,7 @@
 
 variables:
   BuildConfiguration: 'Debug'
-  BuildPlatform: 'AnyCPU'
+  BuildPlatform: 'Any CPU'
 
 jobs:
     - job: SkillFunctionalTestsbuild

--- a/build/yaml/functionaltests-CI,yml
+++ b/build/yaml/functionaltests-CI,yml
@@ -1,5 +1,9 @@
 # This runs under BotBuilder-Js-CI-yaml. Replaces classic build BotBuilder-JS-master-CI-node12.
 
+variables
+  BuildConfiguration: 'Debug'
+  BuildPlatform: 'AnyCPU'
+
 jobs:
     - job: SkillFunctionalTestsbuild
       steps:
@@ -16,8 +20,6 @@ jobs:
     - job: FunctionalTestsBotsbuild
       variables:
         SolutionDir: '$(Build.SourcesDirectory)/Bots/DotNet/'
-        BuildConfiguration: 'Debug'
-        BuildPlatform: 'Any CPU'
       steps:
       - template: FunctionalTestsBotsbuild.yml
 pool:

--- a/build/yaml/functionaltests-CI,yml
+++ b/build/yaml/functionaltests-CI,yml
@@ -14,7 +14,11 @@ jobs:
       - template: pythonfunctional.yml
 
     - job: FunctionalTestsBotsbuild
+      variables:
+        SolutionDir: '$(Build.SourcesDirectory)/Bots/DotNet/'
+        BuildConfiguration: 'Debug'
+        BuildPlatform: 'Any CPU'
       steps:
       - template: FunctionalTestsBotsbuild.yml
 pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'windows-2019'


### PR DESCRIPTION
## Description
This PR addresses an issue where [build/yaml/functionaltests-CI,yml](https://github.com/microsoft/BotFramework-FunctionalTests/blob/hates/build/yaml/functionaltests-CI,yml) fails to find the required packages to build the project.
[Composer Bots](https://github.com/microsoft/BotFramework-FunctionalTests/blob/main/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj#L20) are using the non-stable version `4.12.0-daily.20210205.210249.a163e05`, which can't be found in **Nuget.org**. 
To solve this, we updated the pipeline to install all dependencies and build the composer bots independently from the rest, following the same format as the [02 - Deploy Bot Resources pipeline](https://github.com/microsoft/BotFramework-FunctionalTests/tree/main/build/yaml/deployBotResources).
We also updated the pipeline to use `windows` based agents instead of `mac` for compatibility issues.
`SolutionDir` is added to restore V3 bots.

## Specific Changes
- **build/yaml/FunctionalTestsBotsbuild.yml**
  - Added `SolutionDir` for DotNet V3 Bots.
  - Changed from `DotNetCoreCLI@2` to `MSBuild@1` task and added the proper configuration.
  - Added independent restore and build steps for composer and V3 bots.
- **build/yaml/SkillFunctionalTestsbuild.yml**
  - Removed `-standard` to work in windows pool image.
- **build/yaml/functionaltests-CI,yml**
  - Changed pool vmImage from `macOS-10.14` to `windows-2019`
  - Added required variables for `build/yaml/FunctionalTestsBotsbuild.yml`.
- **Bots/DotNet/nuget.config**
  - Removed since it will conflict with Composer install packages steps.

## Testing
The following image shows the pipeline restoring and building all the bots successfully with the changes introduced in the PR.
![image](https://user-images.githubusercontent.com/64803884/109854885-5751f800-7c36-11eb-8f43-b311e8cd12b4.png)