### PR TITLE
[Skills Everywhere][#144] Add Waterfall Python bots to test project and pipelines

### DIFF
--- a/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/appsettings.json
+++ b/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/appsettings.json
@@ -1,7 +1,7 @@
 {
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
-  "ConnectionName": "",
+  "ConnectionName": "TestOAuthProvider",
   "SsoConnectionName": "",
   "ChannelService": "",
   // This is a comma separate list with the App IDs that will have access to the skill.

--- a/Tests/SkillFunctionalTests/CardActions/CardActionsTests.cs
+++ b/Tests/SkillFunctionalTests/CardActions/CardActionsTests.cs
@@ -74,7 +74,23 @@ namespace SkillFunctionalTests.CardActions
             };
 
             var testCaseBuilder = new TestCaseBuilder();
-            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts);
+
+            // This local function is used to exclude ExpectReplies, O365 and WaterfallSkillBotPython test cases
+            static bool ShouldExclude(TestCase testCase)
+            {
+                if (testCase.Script == "O365.json")
+                {
+                    // BUG: O365 fails with ExpectReplies for WaterfallSkillBotPython (remove when https://github.com/microsoft/BotFramework-FunctionalTests/issues/XXX is fixed).
+                    if (testCase.TargetSkill == SkillBotNames.WaterfallSkillBotPython && testCase.DeliveryMode == DeliveryModes.ExpectReplies)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            var testCases = testCaseBuilder.BuildTestCases(channelIds, deliverModes, hostBots, targetSkills, scripts, ShouldExclude);
             foreach (var testCase in testCases)
             {
                 yield return testCase;

--- a/Tests/SkillFunctionalTests/CardActions/CardActionsTests.cs
+++ b/Tests/SkillFunctionalTests/CardActions/CardActionsTests.cs
@@ -39,20 +39,20 @@ namespace SkillFunctionalTests.CardActions
             var hostBots = new List<HostBot>
             {
                 HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotPython,
 
-                // TODO: Enable these when the ports to JS, Python and composer are ready
-                //HostBotNames.WaterfallHostBotJS,
-                //HostBotNames.WaterfallHostBotPython,
-                //HostBotNames.ComposerHostBotDotNet
+                // TODO: Enable these when the ports to JS, and composer are ready
+                //HostBot.WaterfallHostBotJS,
+                //HostBot.ComposerHostBotDotNet
             };
 
             var targetSkills = new List<string>
             {
                 SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotPython,
 
-                // TODO: Enable these when the ports to JS, Python and composer are ready
+                // TODO: Enable these when the ports to JS, and composer are ready
                 //SkillBotNames.WaterfallSkillBotJS,
-                //SkillBotNames.WaterfallSkillBotPython,
                 //SkillBotNames.ComposerSkillBotDotNet
             };
 

--- a/Tests/SkillFunctionalTests/MessageWithAttachment/MessageWithAttachmentTests.cs
+++ b/Tests/SkillFunctionalTests/MessageWithAttachment/MessageWithAttachmentTests.cs
@@ -38,20 +38,20 @@ namespace SkillFunctionalTests.MessageWithAttachment
             var hostBots = new List<HostBot>
             {
                 HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotPython,
 
-                // TODO: Enable these when the ports to JS, Python and composer are ready
-                //HostBotNames.WaterfallHostBotJS,
-                //HostBotNames.WaterfallHostBotPython,
-                //HostBotNames.ComposerHostBotDotNet
+                // TODO: Enable these when the ports to JS, and composer are ready
+                //HostBot.WaterfallHostBotJS,
+                //HostBot.ComposerHostBotDotNet
             };
 
             var targetSkills = new List<string>
             {
                 SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotPython,
 
-                // TODO: Enable these when the ports to JS, Python and composer are ready
+                // TODO: Enable these when the ports to JS, and composer are ready
                 //SkillBotNames.WaterfallSkillBotJS,
-                //SkillBotNames.WaterfallSkillBotPython,
                 //SkillBotNames.ComposerSkillBotDotNet
             };
 

--- a/Tests/SkillFunctionalTests/ProactiveMessages/ProactiveTests.cs
+++ b/Tests/SkillFunctionalTests/ProactiveMessages/ProactiveTests.cs
@@ -39,20 +39,20 @@ namespace SkillFunctionalTests.ProactiveMessages
             var hostBots = new List<HostBot>
             {
                 HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotPython,
 
-                // TODO: Enable these when the ports to JS, Python and composer are ready
-                //HostBotNames.WaterfallHostBotJS,
-                //HostBotNames.WaterfallHostBotPython,
-                //HostBotNames.ComposerHostBotDotNet
+                // TODO: Enable these when the ports to JS, and composer are ready
+                //HostBot.WaterfallHostBotJS,
+                //HostBot.ComposerHostBotDotNet
             };
 
             var targetSkills = new List<string>
             {
                 SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotPython,
 
-                // TODO: Enable these when the ports to JS, Python and composer are ready
+                // TODO: Enable these when the ports to JS, and composer are ready
                 //SkillBotNames.WaterfallSkillBotJS,
-                //SkillBotNames.WaterfallSkillBotPython,
                 //SkillBotNames.ComposerSkillBotDotNet
             };
 
@@ -95,7 +95,7 @@ namespace SkillFunctionalTests.ProactiveMessages
             await runner.AssertReplyAsync(activity =>
             {
                 Assert.Equal(ActivityTypes.Message, activity.Type);
-                Assert.Contains("Navigate to https:", activity.Text);
+                Assert.Contains("Navigate to http", activity.Text);
 
                 var message = activity.Text.Split(" ");
                 url = message[2];

--- a/Tests/SkillFunctionalTests/SignIn/SignInTests.cs
+++ b/Tests/SkillFunctionalTests/SignIn/SignInTests.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 
 namespace SkillFunctionalTests.SignIn
 {
+    [Trait("TestCategory", "SignIn")]
     public class SignInTests : ScriptTestBase
     {
         private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/SignIn/TestScripts";
@@ -38,20 +39,20 @@ namespace SkillFunctionalTests.SignIn
             var hostBots = new List<HostBot>
             {
                 HostBot.WaterfallHostBotDotNet,
+                HostBot.WaterfallHostBotPython,
 
-                // TODO: Enable these when the ports to JS, Python and composer are ready
-                //HostBotNames.WaterfallHostBotJS,
-                //HostBotNames.WaterfallHostBotPython,
-                //HostBotNames.ComposerHostBotDotNet
+                // TODO: Enable these when the ports to JS, and composer are ready
+                //HostBot.WaterfallHostBotJS,
+                //HostBot.ComposerHostBotDotNet
             };
 
             var targetSkills = new List<string>
             {
                 SkillBotNames.WaterfallSkillBotDotNet,
+                SkillBotNames.WaterfallSkillBotPython,
                 
-                // TODO: Enable these when the ports to JS, Python and composer are ready
+                // TODO: Enable these when the ports to JS, and composer are ready
                 //SkillBotNames.WaterfallSkillBotJS,
-                //SkillBotNames.WaterfallSkillBotPython,
                 //SkillBotNames.ComposerSkillBotDotNet
             };
 
@@ -80,8 +81,14 @@ namespace SkillFunctionalTests.SignIn
             var options = TestClientOptions[testCase.HostBot];
             var runner = new XUnitTestRunner(new TestClientFactory(testCase.ChannelId, options, Logger).GetTestClient(), TestRequestTimeout, Logger);
 
+            var testParams = new Dictionary<string, string>
+            {
+                { "DeliveryMode", testCase.DeliveryMode },
+                { "TargetSkill", testCase.TargetSkill }
+            };
+
             // Execute the first part of the conversation.
-            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script));
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
 
             await runner.AssertReplyAsync(activity =>
             {
@@ -98,7 +105,7 @@ namespace SkillFunctionalTests.SignIn
             await runner.ClientSignInAsync(signInUrl);
 
             // Execute the rest of the conversation passing the messageId.
-            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "SignIn2.json"));
+            await runner.RunTestAsync(Path.Combine(_testScriptsFolder, "SignIn2.json"), testParams);
         }
     }
 }

--- a/Tests/SkillFunctionalTests/SignIn/TestScripts/SignIn1.json
+++ b/Tests/SkillFunctionalTests/SignIn/TestScripts/SignIn1.json
@@ -52,7 +52,7 @@
     {
       "type": "message",
       "role": "user",
-      "text": "normal"
+      "text": "${DeliveryMode}"
     },
     {
       "type": "message",
@@ -95,7 +95,7 @@
     {
       "type": "message",
       "role": "user",
-	  "text": "WaterfallSkillBotDotNet"
+      "text": "${TargetSkill}"
     },
     {
       "type": "message",

--- a/Tests/SkillFunctionalTests/SignIn/TestScripts/SignIn2.json
+++ b/Tests/SkillFunctionalTests/SignIn/TestScripts/SignIn2.json
@@ -57,13 +57,13 @@
     {
       "type": "message",
       "role": "bot",
-      "text": "Done with \"WaterfallSkillBotDotNet\". \n\n What delivery mode would you like to use?",
+      "text": "Done with \"${TargetSkill}\". \n\n What delivery mode would you like to use?",
       "assertions": [
         "type == 'message'",
         "from.role == 'bot'",
         "recipient.role == 'user'",
-        "text == 'Done with \"WaterfallSkillBotDotNet\". \n\n What delivery mode would you like to use?'",
-        "speak == 'Done with \"WaterfallSkillBotDotNet\". \n\n What delivery mode would you like to use?'",
+        "text == 'Done with \"${TargetSkill}\". \n\n What delivery mode would you like to use?'",
+        "speak == 'Done with \"${TargetSkill}\". \n\n What delivery mode would you like to use?'",
         "inputHint == 'expectingInput'",
         "suggestedActions.actions[0].type == 'imBack'",
         "suggestedActions.actions[0].title == 'normal'",

--- a/build/yaml/deployBotResources/deployBotResources.yml
+++ b/build/yaml/deployBotResources/deployBotResources.yml
@@ -50,6 +50,10 @@ variables:
   # BffnWaterfallHostBotDotNetAppSecret: (optional) define in Azure
   # BffnWaterfallSkillBotDotNetAppId: (optional) define in Azure
   # BffnWaterfallSkillBotDotNetAppSecret: (optional) define in Azure
+  # BffnWaterfallHostBotPythonAppId: (optional) define in Azure
+  # BffnWaterfallHostBotPythonAppSecret: (optional) define in Azure
+  # BffnWaterfallSkillBotPythonAppId: (optional) define in Azure
+  # BffnWaterfallSkillBotPythonAppSecret: (optional) define in Azure
   # BotPricingTier: (optional) define in Azure
   # DependenciesRegistryHosts: (optional) define in Azure
   # DependenciesRegistrySkills: (optional) define in Azure
@@ -226,3 +230,19 @@ stages:
           appSecret: $(BffnEchoSkillBotPythonAppSecret)
           project: 
             directory: 'Bots/Python/Skills/CodeFirst/EchoSkillBot'
+
+        - name: bffnwaterfallhostbotpython
+          type: 'Host'
+          displayName: 'Python Waterfall Host Bot'
+          appId: $env:BffnWaterfallHostBotPythonAppId
+          appSecret: $env:BffnWaterfallHostBotPythonAppSecret
+          project:
+            directory: 'Bots/Python/Consumers/CodeFirst/WaterfallHostBot'
+
+        - name: bffnwaterfallskillbotpython
+          type: 'Skill'
+          displayName: 'Python Waterfall Skill Bot'
+          appId: $env:BffnWaterfallSkillBotPythonAppId
+          appSecret: $env:BffnWaterfallSkillBotPythonAppSecret
+          project: 
+            directory: 'Bots/Python/Skills/CodeFirst/WaterfallSkillBot'

--- a/build/yaml/sharedResources/createAppRegistrations.yml
+++ b/build/yaml/sharedResources/createAppRegistrations.yml
@@ -73,15 +73,17 @@ steps:
           @{ appName = "bffnechoskillbotdotnet"; variables = @{ appId = "BffnEchoSkillBotDotNetAppId"; appSecret = "BffnEchoSkillBotDotNetAppSecret"; objectId = "BffnEchoSkillBotDotNetAppObjectId" }},
           @{ appName = "bffnechoskillbotdotnet21"; variables = @{ appId = "BffnEchoSkillBotDotNet21AppId"; appSecret = "BffnEchoSkillBotDotNet21AppSecret"; objectId = "BffnEchoSkillBotDotNet21AppObjectId" }},
           @{ appName = "bffnechoskillbotdotnetv3"; variables = @{ appId = "BffnEchoSkillBotDotNetV3AppId"; appSecret = "BffnEchoSkillBotDotNetV3AppSecret"; objectId = "BffnEchoSkillBotDotNetV3AppObjectId" }},
-          @{ appName = "bffnsimplehostbotcomposerdotnet"; variables = @{ appId = "BffnSimpleHostBotComposerDotNetAppId"; appSecret = "BffnSimpleHostBotComposerDotNetAppSecret"; objectId = "BffnSimpleHostBotComposerDotNetAppObjectId" }}
-          @{ appName = "bffnechoskillbotcomposerdotnet"; variables = @{ appId = "BffnEchoSkillBotComposerDotNetAppId"; appSecret = "BffnEchoSkillBotComposerDotNetAppSecret"; objectId = "BffnEchoSkillBotComposerDotNetAppObjectId" }}
-          @{ appName = "bffnwaterfallhostbotdotnet"; variables = @{ appId = "BffnWaterfallHostBotDotNetAppId"; appSecret = "BffnWaterfallHostBotDotNetAppSecret"; objectId = "BffnWaterfallHostBotDotNetAppObjectId" }}
-          @{ appName = "bffnwaterfallskillbotdotnet"; variables = @{ appId = "BffnWaterfallSkillBotDotNetAppId"; appSecret = "BffnWaterfallSkillBotDotNetAppSecret"; objectId = "BffnWaterfallSkillBotDotNetAppObjectId" }}
+          @{ appName = "bffnsimplehostbotcomposerdotnet"; variables = @{ appId = "BffnSimpleHostBotComposerDotNetAppId"; appSecret = "BffnSimpleHostBotComposerDotNetAppSecret"; objectId = "BffnSimpleHostBotComposerDotNetAppObjectId" }},
+          @{ appName = "bffnechoskillbotcomposerdotnet"; variables = @{ appId = "BffnEchoSkillBotComposerDotNetAppId"; appSecret = "BffnEchoSkillBotComposerDotNetAppSecret"; objectId = "BffnEchoSkillBotComposerDotNetAppObjectId" }},
+          @{ appName = "bffnwaterfallhostbotdotnet"; variables = @{ appId = "BffnWaterfallHostBotDotNetAppId"; appSecret = "BffnWaterfallHostBotDotNetAppSecret"; objectId = "BffnWaterfallHostBotDotNetAppObjectId" }},
+          @{ appName = "bffnwaterfallskillbotdotnet"; variables = @{ appId = "BffnWaterfallSkillBotDotNetAppId"; appSecret = "BffnWaterfallSkillBotDotNetAppSecret"; objectId = "BffnWaterfallSkillBotDotNetAppObjectId" }},
           @{ appName = "bffnsimplehostbotjs"; variables = @{ appId = "BffnSimpleHostBotJSAppId"; appSecret = "BffnSimpleHostBotJSAppSecret"; objectId = "BffnSimpleHostBotJSAppObjectId" }},
           @{ appName = "bffnechoskillbotjs"; variables = @{ appId = "BffnEchoSkillBotJSAppId"; appSecret = "BffnEchoSkillBotJSAppSecret"; objectId = "BffnEchoSkillBotJSAppObjectId" }},
           @{ appName = "bffnechoskillbotjsv3"; variables = @{ appId = "BffnEchoSkillBotJSV3AppId"; appSecret = "BffnEchoSkillBotJSV3AppSecret"; objectId = "BffnEchoSkillBotJSV3AppObjectId" }},
           @{ appName = "bffnsimplehostbotpython"; variables = @{ appId = "BffnSimpleHostBotPythonAppId"; appSecret = "BffnSimpleHostBotPythonAppSecret"; objectId = "BffnSimpleHostBotPythonAppObjectId" }},
-          @{ appName = "bffnechoskillbotpython"; variables = @{ appId = "BffnEchoSkillBotPythonAppId"; appSecret = "BffnEchoSkillBotPythonAppSecret"; objectId = "BffnEchoSkillBotPythonAppObjectId" }}
+          @{ appName = "bffnechoskillbotpython"; variables = @{ appId = "BffnEchoSkillBotPythonAppId"; appSecret = "BffnEchoSkillBotPythonAppSecret"; objectId = "BffnEchoSkillBotPythonAppObjectId" }},
+          @{ appName = "bffnwaterfallhostbotpython"; variables = @{ appId = "BffnWaterfallHostBotPythonAppId"; appSecret = "BffnWaterfallHostBotPythonAppSecret"; objectId = "BffnWaterfallHostBotPythonAppObjectId" }},
+          @{ appName = "bffnwaterfallskillbotpython"; variables = @{ appId = "BffnWaterfallSkillBotPythonAppId"; appSecret = "BffnWaterfallSkillBotPythonAppSecret"; objectId = "BffnWaterfallSkillBotPythonAppObjectId" }}
         )
 
         $token = GetToken;

--- a/build/yaml/testScenarios/configureConsumers.yml
+++ b/build/yaml/testScenarios/configureConsumers.yml
@@ -61,6 +61,12 @@ steps:
               resourceGroup = $groups.Python
               configType    = $types.Env
           }
+          @{
+              key           = 'WaterfallHostBotPython'
+              botName       = 'bffnwaterfallhostbotpython'
+              resourceGroup = $groups.Python
+              configType    = $types.Env
+          }
         )
 
         $skills = @(
@@ -120,6 +126,13 @@ steps:
               appId         = "$env:BffnEchoSkillBotPythonAppId"
               resourceGroup = $groups.Python
           }
+          @{
+              key           = 'WaterfallSkillBotPython'
+              keyComposer   = 'waterfallSkillBotPython' 
+              botName       = 'bffnwaterfallskillbotpython'
+              appId         = "$env:BffnWaterfallSkillBotPythonAppId"
+              resourceGroup = $groups.Python
+          }
         )
 
         # Bots Test Scenarios
@@ -146,10 +159,12 @@ steps:
           @{ 
               name      = 'Waterfall'; 
               consumers = @(
-                'WaterfallHostBotDotNet'
+                'WaterfallHostBotDotNet',
+                'WaterfallHostBotPython'
               );
               skills    = @(
-                'WaterfallSkillBotDotNet'
+                'WaterfallSkillBotDotNet',
+                'WaterfallSkillBotPython'
               );
           }
         )

--- a/build/yaml/testScenarios/runTestScenarios.yml
+++ b/build/yaml/testScenarios/runTestScenarios.yml
@@ -21,6 +21,7 @@ variables:
   # BffnEchoSkillBotJSV3AppId: (optional) define in Azure
   # BffnEchoSkillBotPythonAppId: (optional) define in Azure
   # BffnWaterfallSkillBotDotNetAppId: (optional) define in Azure
+  # BffnWaterfallSkillBotPythonAppId: (optional) define in Azure
   # ResourceSuffix: (optional) define in Azure
 
 pool:
@@ -35,6 +36,7 @@ stages:
             - Attachments
             - CardActions
             - ProactiveMessages
+            - SignIn
 
         - name: SingleTurn
           testCategories:


### PR DESCRIPTION
Addresses # 144

Note: This PR depends on PRs #326 and #327 

## Description
This PR adds the WaterfallHostBot Python and WaterfallSkillBot Python to the YAMLs and functional test project.

## Specific changes
- Enabled Waterfall Python bots in tests.
    - `CardActionTests.cs` _(Python WaterfallSkill and ExpectReplies test case was excluded due to issue #328 )_
    - `MessageWithAttachmentTests.cs`
    - `SignInTests.cs`
    - `ProactiveTests.cs`

- Added WaterfallHostBot Python and WaterfallSkillBot Python in the YAML files
    - `deployBotResources/deployBotResources.yml`
    - `sharedResources/createAppRegistrations.yml`
    - `testScenarios/configureConsumers.yml`
   
- Updated ProactiveTests assertion to support http and https URLs.

## Testing

 These images show the pipelines working with the changes.
![image](https://user-images.githubusercontent.com/44245136/110129420-b3d42500-7da6-11eb-8bf2-28ac042431ab.png)
