### PR TITLE
[Legacy Pipelines] Fix error in install packages step

### DIFF
--- a/build/yaml/dotnetInstallPackagesSteps.yml
+++ b/build/yaml/dotnetInstallPackagesSteps.yml
@@ -79,6 +79,11 @@ steps:
   displayName: 'Set Registry Url'
   name: 'Set_Registry_Url'
 
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk 5.0.103'
+  inputs:
+    version: 5.0.103
+
 - task: DotNetCoreCLI@2
   displayName: 'Add custom Bot.Builder.Integration.AspNet.Core version'  
   inputs:


### PR DESCRIPTION
## Description
This PR fixes the error found in the `Add custom Bot.Builder.Integration.AspNet.Core version` adding a task to install an older version of the NetCore SDK (5.0.103) as the failure happens with the latest version of the SDK (5.0.201) used in the pipeline's agent.

### Detailed Changes
- Added **_UseDotNet_** task in [_dotnetInstallPackagesSteps.yml_](https://github.com/microsoft/BotFramework-FunctionalTests/blob/main/build/yaml/dotnetInstallPackagesSteps.yml) to install version 5.0.103.

## Testing
These images show the pipeline running successfully with the new task added.
![image](https://user-images.githubusercontent.com/44245136/111326265-2d8fcc80-864b-11eb-8ae7-996e8e1ac616.png)
![image](https://user-images.githubusercontent.com/44245136/111326343-3e404280-864b-11eb-8262-009450a48a04.png)


