### PR TITLE
[FunctionalTests-CI] Fix build error: Use MSBuild for build bots and test project

### DIFF
--- a/build/yaml/dotnetBotsBuild-CI.yml
+++ b/build/yaml/dotnetBotsBuild-CI.yml
@@ -12,62 +12,19 @@ steps:
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet'
 
-# Start of Restore & Build excluding Composer and V3
-- task: DotNetCoreCLI@2
-  displayName: Restore bots
-  inputs:
-    command: restore
-    projects: |
-      Bots/DotNet/**/*.csproj
-      Bots/DotNet/**/Composer/**/*.csproj
-      !Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj
-    feedsToUse: 'select'
-    includeNuGetOrg: true
-    arguments: '--no-build'
-
-- task: DotNetCoreCLI@2
-  displayName: Build bots
-  inputs:
-    command: build
-    projects: |
-      Bots/DotNet/**/*.csproj
-      Bots/DotNet/**/Composer/**/*.csproj
-      !Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj
-    feedsToUse: 'select'
-    includeNuGetOrg: true
-    arguments: '-v n --configuration $(BuildConfiguration) -p:Platform="$(BuildPlatform)" --no-restore'
-# End of Restore & Build excluding Composer and V3
-           
-- task: DotNetCoreCLI@2
-  displayName: 'Build composer bots'
-  inputs:
-    command: publish
-    publishWebProjects: false
-    projects: |
-      Bots/DotNet/**/Composer/**/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj
-    modifyOutputPath: false
-    zipAfterPublish: false
-# End of Restore & Build for Composer
-
-# Start of Restore & Build for V3
 - task: NuGetCommand@2
-  displayName: 'Restore V3 bot'
+  displayName: 'NuGet restore'
   inputs:
-    restoreSolution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj'
+    restoreSolution: 'Bots/DotNet/FunctionalTestsBots.sln'
     restoreDirectory: '$(SolutionDir)packages'
-    feedsToUse: 'select'
-    includeNuGetOrg: true
-    noCache: true
-    
 
 - task: MSBuild@1
-  displayName: 'Build V3 bot'
+  displayName: 'Build'
   inputs:
-    solution: 'Bots/DotNet/Skills/CodeFirst/EchoSkillBot-v3/EchoSkillBot-v3.csproj'
-    #vsVersion: 16.0
-    platform: 'AnyCPU'
+    solution: 'Bots/DotNet/FunctionalTestsBots.sln'
+    vsVersion: 16.0
+    platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
-# End of Restore & Build for V3
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: build folder'

--- a/build/yaml/functionalTests-CI.yml
+++ b/build/yaml/functionalTests-CI.yml
@@ -1,24 +1,26 @@
 # This YAML runs all the CI pipelines Dot Net, python, JS in parallel
+variables:
+  BuildConfiguration: 'Debug'
+  BuildPlatform: 'Any CPU'
+
 jobs:
     - job: "BuildJSBots"
       steps: 
       - template: jsBotsBuildCI.yml
+
     - job: "BuildPythonBots"
       steps: 
       - template: pythonBotsBuild-CI.yml
+
     - job: "BuildDotnetBots"
       variables:
-        BuildConfiguration: 'Debug'
-        BuildPlatform: 'Any CPU'
         SolutionDir: '$(Build.SourcesDirectory)/Bots/DotNet/'
       steps: 
       - template: dotnetBotsBuild-CI.yml
-    - job: "BuildfunctionalTestsBots"
-      variables:
-        BuildConfiguration: 'Debug'
-        BuildPlatform: 'Any CPU'
-        SolutionDir: '$(Build.SourcesDirectory)/Bots/DotNet/'
+
+    - job: "BuildSkillsFunctionalTests"
       steps: 
       - template: functionalTestsBuild-CI.yml
+
 pool:
     vmImage: 'windows-2019'

--- a/build/yaml/functionalTests-CI.yml
+++ b/build/yaml/functionalTests-CI.yml
@@ -1,11 +1,11 @@
 # This YAML runs all the CI pipelines Dot Net, python, JS in parallel
 jobs:
-    -  job: "BuildJSBots"
-       steps: 
-       - template: jsBotsBuildCI.yml
-    -  job: "BuildPythonBots"
-       steps: 
-       - template: pythonBotsBuild-CI.yml
+    - job: "BuildJSBots"
+      steps: 
+      - template: jsBotsBuildCI.yml
+    - job: "BuildPythonBots"
+      steps: 
+      - template: pythonBotsBuild-CI.yml
     - job: "BuildDotnetBots"
       variables:
         BuildConfiguration: 'Debug'
@@ -17,7 +17,7 @@ jobs:
       variables:
         BuildConfiguration: 'Debug'
         BuildPlatform: 'Any CPU'
-        SolutionDir: '$(Build.SourcesDirectory)/'
+        SolutionDir: '$(Build.SourcesDirectory)/Bots/DotNet/'
       steps: 
       - template: functionalTestsBuild-CI.yml
 pool:

--- a/build/yaml/functionalTestsBuild-CI.yml
+++ b/build/yaml/functionalTestsBuild-CI.yml
@@ -10,20 +10,20 @@ steps:
     version: 3.1.x
 
 - task: NuGetToolInstaller@1
-  inputs:
-    versionSpec: 
+  displayName: 'Use NuGet'
 
 - task: NuGetCommand@2
+  displayName: 'NuGet restore'
   inputs:
-    command: 'restore'
     restoreSolution: SkillFunctionalTests.sln
 
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet build'
+- task: MSBuild@1
+  displayName: 'Build'
   inputs:
-    projects: SkillFunctionalTests.sln
-
+    solution: 'SkillFunctionalTests.sln'
+    vsVersion: 16.0
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: build folder'


### PR DESCRIPTION
## Description
This PR fixes the errors in the dotnet build step replacing the _DotNetCoreCLI_ tasks with _NuGetCommand_ for the restore step and _MSBuild_ for building the solution.

### Detailed Changes
- Updated **_dotnetBotsBuild-CI.yml_** to replace the restore and build tasks to build the entire solution with MSBuild.
- Updated _SolutionDir_ param in **_functionalTests-CI.yml_**. 
- Updated **_functionalTestsBuild-CI.yml_** to keep consistency using the same tasks to build the test project.

## Testing
This image shows the pipeline running successfully after the changes.
![image](https://user-images.githubusercontent.com/44245136/112670594-e0c4a680-8e3f-11eb-9130-8bdec1e4c675.png)