### PR TITLE
##[error]WARNING: Value for scheme.headers does not match.

### DIFF
--- a/build/yaml/pythonBotsBuild-CI.yml
+++ b/build/yaml/pythonBotsBuild-CI.yml
@@ -9,6 +9,6 @@
     inputs:
      targetType: 'inline'
      script: |
-      python -m pip install pip==21.1;
-      find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.1 -r "{}" \;
+      python -m pip install pip==20.0.1;
+      find ./Bots -type f -name "requirements.txt" -exec pip install pip==20.0.1 -r "{}" \;
      failOnStderr: true

--- a/build/yaml/pythonBotsBuild-CI.yml
+++ b/build/yaml/pythonBotsBuild-CI.yml
@@ -9,6 +9,6 @@
     inputs:
      targetType: 'inline'
      script: |
-      python -m pip install pip==21.0.1;
-      find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.0.1 -r "{}" \;
+      python -m pip install pip==21.1;
+      find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.1 -r "{}" \;
      failOnStderr: true

--- a/build/yaml/pythonBotsBuild-CI.yml
+++ b/build/yaml/pythonBotsBuild-CI.yml
@@ -9,6 +9,6 @@
     inputs:
      targetType: 'inline'
      script: |
-      python -m pip install pip==21.3;
-      find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.3 -r "{}" \;
+      python -m pip install pip==21.1;
+      find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.1 -r "{}" \;
      failOnStderr: true

--- a/build/yaml/pythonBotsBuild-CI.yml
+++ b/build/yaml/pythonBotsBuild-CI.yml
@@ -9,6 +9,6 @@
     inputs:
      targetType: 'inline'
      script: |
-      python -m pip install pip==20.0.1;
-      find ./Bots -type f -name "requirements.txt" -exec pip install pip==20.0.1 -r "{}" \;
+      python -m pip install pip==20.3.4;
+      find ./Bots -type f -name "requirements.txt" -exec pip install pip==20.3.4-r "{}" \;
      failOnStderr: true

--- a/build/yaml/pythonBotsBuild-CI.yml
+++ b/build/yaml/pythonBotsBuild-CI.yml
@@ -10,5 +10,5 @@
      targetType: 'inline'
      script: |
       python -m pip install pip==21.0.1;
-      find ./Bots -type f -name "requirements.txt" -exec pip install -r "{}" \;
+      find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.0.1 -r "{}" \;
      failOnStderr: true

--- a/build/yaml/pythonBotsBuild-CI.yml
+++ b/build/yaml/pythonBotsBuild-CI.yml
@@ -9,6 +9,6 @@
     inputs:
      targetType: 'inline'
      script: |
-      python -m pip install pip==21.0.1;
-      find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.0.1 -r "{}" \;
+      python -m pip install pip==21.0;
+      find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.0 -r "{}" \;
      failOnStderr: true

--- a/build/yaml/pythonBotsBuild-CI.yml
+++ b/build/yaml/pythonBotsBuild-CI.yml
@@ -9,6 +9,5 @@
     inputs:
      targetType: 'inline'
      script: |
-      python -m pip install pip==21.1;
-      find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.1 -r "{}" \;
-     failOnStderr: true
+      python -m pip install pip==21.0.1;
+      find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.0.1 -r "{}" \;

--- a/build/yaml/pythonBotsBuild-CI.yml
+++ b/build/yaml/pythonBotsBuild-CI.yml
@@ -9,6 +9,6 @@
     inputs:
      targetType: 'inline'
      script: |
-      python -m pip install pip==21.0;
-      find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.0 -r "{}" \;
+      python -m pip install pip==21.0.1;
+      find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.0.1 -r "{}" \;
      failOnStderr: true

--- a/build/yaml/pythonBotsBuild-CI.yml
+++ b/build/yaml/pythonBotsBuild-CI.yml
@@ -9,6 +9,6 @@
     inputs:
      targetType: 'inline'
      script: |
-      python -m pip install --upgrade pip;
+      python -m pip install pip==21.0.1;
       find ./Bots -type f -name "requirements.txt" -exec pip install -r "{}" \;
      failOnStderr: true

--- a/build/yaml/pythonBotsBuild-CI.yml
+++ b/build/yaml/pythonBotsBuild-CI.yml
@@ -11,3 +11,4 @@
      script: |
       python -m pip install pip==21.0.1;
       find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.0.1 -r "{}" \;
+     failOnStderr: true

--- a/build/yaml/pythonBotsBuild-CI.yml
+++ b/build/yaml/pythonBotsBuild-CI.yml
@@ -11,4 +11,4 @@
      script: |
       python -m pip install pip==21.0.1;
       find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.0.1 -r "{}" \;
-     failOnStderr: true
+     

--- a/build/yaml/pythonBotsBuild-CI.yml
+++ b/build/yaml/pythonBotsBuild-CI.yml
@@ -9,6 +9,6 @@
     inputs:
      targetType: 'inline'
      script: |
-      python -m pip install pip==20.3.4;
-      find ./Bots -type f -name "requirements.txt" -exec pip install pip==20.3.4 -r "{}" \;
+      python -m pip install pip==21.3;
+      find ./Bots -type f -name "requirements.txt" -exec pip install pip==21.3 -r "{}" \;
      failOnStderr: true

--- a/build/yaml/pythonBotsBuild-CI.yml
+++ b/build/yaml/pythonBotsBuild-CI.yml
@@ -10,5 +10,5 @@
      targetType: 'inline'
      script: |
       python -m pip install pip==20.3.4;
-      find ./Bots -type f -name "requirements.txt" -exec pip install pip==20.3.4-r "{}" \;
+      find ./Bots -type f -name "requirements.txt" -exec pip install pip==20.3.4 -r "{}" \;
      failOnStderr: true


### PR DESCRIPTION
CI pipeline, failing at the install packages Python step caused by a warning introduced in the last pip version. downgrading to an earlier version of pip (pip==21.0.1) fixed the issues.

https://pip.pypa.io/en/stable/news/

https://stackoverflow.com/questions/67244301/warning-messages-when-i-update-pip-or-install-packages/67250419#67250419