### PR TITLE
[Pipelines Support] Add validation in configuration script to prevent KeyNotFound errors

### DIFF
--- a/build/yaml/testScenarios/configureConsumers.yml
+++ b/build/yaml/testScenarios/configureConsumers.yml
@@ -177,12 +177,11 @@ steps:
 
               if ($exists) {
                 Write-Host $(AddTimeStamp -text "$($bot.key): Resource '$($bot.resourceBotName)' found.");
-              } 
+                return $bot;
+              }
               else {
                 Write-Host $(AddTimeStamp -text "$($bot.key): Unable to find the resource '$($bot.resourceBotName)'.");
               }
-
-              return $bot;
             }
           };
         }

--- a/build/yaml/testScenarios/configureConsumers.yml
+++ b/build/yaml/testScenarios/configureConsumers.yml
@@ -279,23 +279,23 @@ steps:
             while($tries -gt 0) {
               $directLine = (az bot directline show --name $bot.resourceBotName --resource-group $bot.resourceGroup --with-secrets true 2>$null | ConvertFrom-Json).properties.properties.sites.key;
               if (-not [string]::IsNullOrEmpty($directLine)) {
+                $appSettings.HostBotClientOptions[$bot.key] = @{
+                  DirectLineSecret = $directLine
+                  BotId            = $bot.botName
+                }
                 break;
               }
               $tries--;
             }
+          }
 
-            if ([string]::IsNullOrEmpty($directLine)) {
-              [Console]::ForegroundColor = "red"
-              $errorMessage = AddTimeStamp -text "$($bot.key): DirectLine channel not configured."
-              [Console]::Error.WriteLine($errorMessage)
-              [Console]::ResetColor()
-              exit 1 # Force exit
-            }
-
-            $appSettings.HostBotClientOptions[$bot.key] = @{
-              DirectLineSecret = $directLine
-              BotId            = $bot.botName
-            }
+          if ($appSettings.HostBotClientOptions.count -ne $bots.length) {
+            [Console]::ForegroundColor = "red"
+            [Console]::Error.WriteLine("Some host bots' DirectLine secrets couldn't be retrieved from Azure.")
+            $config = $appSettings.HostBotClientOptions | Out-String
+            [Console]::Error.WriteLine($config)
+            [Console]::ResetColor()
+            exit 1 # Force exit
           }
 
           $appSettings | ConvertTo-Json | Set-Content $appsettingsPath;

--- a/build/yaml/testScenarios/configureConsumers.yml
+++ b/build/yaml/testScenarios/configureConsumers.yml
@@ -273,8 +273,25 @@ steps:
             $bot = $_;
 
             Write-Host $(AddTimeStamp -text "$($bot.key): Getting the DirectLine secret.");
-            $directLine = (az bot directline show --name $bot.resourceBotName --resource-group $bot.resourceGroup --with-secrets true 2>$null | ConvertFrom-Json).properties.properties.sites.key;
-                    
+            $tries = 3;
+            $directLine = "";
+
+            while($tries -gt 0) {
+              $directLine = (az bot directline show --name $bot.resourceBotName --resource-group $bot.resourceGroup --with-secrets true 2>$null | ConvertFrom-Json).properties.properties.sites.key;
+              if (-not [string]::IsNullOrEmpty($directLine)) {
+                break;
+              }
+              $tries--;
+            }
+
+            if ([string]::IsNullOrEmpty($directLine)) {
+              [Console]::ForegroundColor = "red"
+              $errorMessage = AddTimeStamp -text "$($bot.key): DirectLine channel not configured."
+              [Console]::Error.WriteLine($errorMessage)
+              [Console]::ResetColor()
+              exit 1 # Force exit
+            }
+
             $appSettings.HostBotClientOptions[$bot.key] = @{
               DirectLineSecret = $directLine
               BotId            = $bot.botName

--- a/build/yaml/testScenarios/configureConsumers.yml
+++ b/build/yaml/testScenarios/configureConsumers.yml
@@ -290,11 +290,9 @@ steps:
           }
 
           if ($appSettings.HostBotClientOptions.count -ne $bots.length) {
-            [Console]::ForegroundColor = "red"
-            [Console]::Error.WriteLine("Some host bots' DirectLine secrets couldn't be retrieved from Azure.")
+            Write-Host "##vso[task.logissue type=error]Some host bots' DirectLine secrets couldn't be retrieved from Azure."
             $config = $appSettings.HostBotClientOptions | Out-String
-            [Console]::Error.WriteLine($config)
-            [Console]::ResetColor()
+            Write-Host "##vso[task.logissue type=error]$config"
             exit 1 # Force exit
           }
 


### PR DESCRIPTION
## Description
This PR adds an extra validation to catch errors during the Test Project configuration. If one or more of the DirectLine secrets can't be found, the script will throw an error and abort the execution.
With this early catch, we'll prevent having _KeyNotFound_ errors in the tests.

### Detailed Changes
- Updated `configureConsumers` to add retries for getting the DirectLine secrets from Azure and to throw an error in case it's blank after 3 attempts.

## Testing
This image shows the error being thrown when the script can't set one of the bots' DirectLine secret.
![image](https://user-images.githubusercontent.com/44245136/118177911-b340b600-b409-11eb-96c4-11fc99e738fc.png)