### PR TITLE
[Skills Everywhere][#408][.NET] Update bot and test projects to reference 4.13.x from nuget

### DIFF
--- a/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot-2.1.csproj
+++ b/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot-2.1.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot-2.1.csproj
+++ b/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot-2.1.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj
+++ b/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj
+++ b/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/WaterfallHostBot.csproj
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/WaterfallHostBot.csproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/WaterfallHostBot.csproj
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/WaterfallHostBot.csproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurefunctions/Microsoft.BotFramework.Composer.Functions.csproj
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurefunctions/Microsoft.BotFramework.Composer.Functions.csproj
@@ -13,18 +13,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.2-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />

--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurefunctions/Microsoft.BotFramework.Composer.Functions.csproj
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurefunctions/Microsoft.BotFramework.Composer.Functions.csproj
@@ -13,18 +13,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.12.2-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />

--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurefunctions/Startup.cs
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurefunctions/Startup.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.ApplicationInsights.Extensibility;
@@ -25,11 +25,11 @@ using Microsoft.BotFramework.Composer.Core.Settings;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using SkillConversationIdFactory = Microsoft.BotFramework.Composer.Core.SkillConversationIdFactory;
 
 [assembly: FunctionsStartup(typeof(Microsoft.BotFramework.Composer.Functions.Startup))]
 

--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj
@@ -17,18 +17,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.2-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.66">
       <PrivateAssets>all</PrivateAssets>

--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj
@@ -17,18 +17,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.12.2-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.1" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.66">
       <PrivateAssets>all</PrivateAssets>

--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/core/Microsoft.BotFramework.Composer.Core.csproj
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/core/Microsoft.BotFramework.Composer.Core.csproj
@@ -13,19 +13,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.12.2-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.1" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/core/Microsoft.BotFramework.Composer.Core.csproj
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/core/Microsoft.BotFramework.Composer.Core.csproj
@@ -13,19 +13,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.2-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.2" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/customaction/Microsoft.BotFramework.Composer.CustomAction.csproj
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/customaction/Microsoft.BotFramework.Composer.CustomAction.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/customaction/Microsoft.BotFramework.Composer.CustomAction.csproj
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/customaction/Microsoft.BotFramework.Composer.CustomAction.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.2" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/tests/SkillConversationIdFactoryTests.cs
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/runtime/tests/SkillConversationIdFactoryTests.cs
@@ -1,23 +1,16 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Adapters;
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Dialogs.Adaptive;
-using Microsoft.Bot.Builder.Dialogs.Declarative;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.BotFramework.Composer.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using SkillConversationIdFactory = Microsoft.BotFramework.Composer.Core.SkillConversationIdFactory;
 
 namespace Tests
 {

--- a/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot-2.1.csproj
+++ b/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot-2.1.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot-2.1.csproj
+++ b/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot-2.1.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj
+++ b/Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj
+++ b/Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/WaterfallSkillBot.csproj
+++ b/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/WaterfallSkillBot.csproj
@@ -25,9 +25,9 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
   </ItemGroup>
 

--- a/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/WaterfallSkillBot.csproj
+++ b/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/WaterfallSkillBot.csproj
@@ -25,9 +25,9 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
   </ItemGroup>
 

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurefunctions/Microsoft.BotFramework.Composer.Functions.csproj
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurefunctions/Microsoft.BotFramework.Composer.Functions.csproj
@@ -13,18 +13,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.2-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurefunctions/Microsoft.BotFramework.Composer.Functions.csproj
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurefunctions/Microsoft.BotFramework.Composer.Functions.csproj
@@ -13,18 +13,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.12.2-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurefunctions/Startup.cs
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurefunctions/Startup.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.ApplicationInsights.Extensibility;
@@ -25,11 +25,11 @@ using Microsoft.BotFramework.Composer.Core.Settings;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using SkillConversationIdFactory = Microsoft.BotFramework.Composer.Core.SkillConversationIdFactory;
 
 [assembly: FunctionsStartup(typeof(Microsoft.BotFramework.Composer.Functions.Startup))]
 

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj
@@ -17,18 +17,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.2-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.66">
       <PrivateAssets>all</PrivateAssets>

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj
@@ -17,18 +17,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.12.2-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.1" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.66">
       <PrivateAssets>all</PrivateAssets>

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/core/Microsoft.BotFramework.Composer.Core.csproj
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/core/Microsoft.BotFramework.Composer.Core.csproj
@@ -13,19 +13,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.12.2-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.1" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/core/Microsoft.BotFramework.Composer.Core.csproj
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/core/Microsoft.BotFramework.Composer.Core.csproj
@@ -13,19 +13,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.13.2-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.13.2" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/customaction/Microsoft.BotFramework.Composer.CustomAction.csproj
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/customaction/Microsoft.BotFramework.Composer.CustomAction.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/customaction/Microsoft.BotFramework.Composer.CustomAction.csproj
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/customaction/Microsoft.BotFramework.Composer.CustomAction.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.13.2" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/tests/SkillConversationIdFactoryTests.cs
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/runtime/tests/SkillConversationIdFactoryTests.cs
@@ -1,23 +1,16 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Adapters;
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Dialogs.Adaptive;
-using Microsoft.Bot.Builder.Dialogs.Declarative;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.BotFramework.Composer.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using SkillConversationIdFactory = Microsoft.BotFramework.Composer.Core.SkillConversationIdFactory;
 
 namespace Tests
 {

--- a/Libraries/TranscriptConverter/TranscriptConverter.csproj
+++ b/Libraries/TranscriptConverter/TranscriptConverter.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.13.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.13.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/Libraries/TranscriptConverter/TranscriptConverter.csproj
+++ b/Libraries/TranscriptConverter/TranscriptConverter.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.13.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/Libraries/TranscriptTestRunner/TranscriptTestRunner.csproj
+++ b/Libraries/TranscriptTestRunner/TranscriptTestRunner.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveExpressions" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
+    <PackageReference Include="AdaptiveExpressions" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />

--- a/Libraries/TranscriptTestRunner/TranscriptTestRunner.csproj
+++ b/Libraries/TranscriptTestRunner/TranscriptTestRunner.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveExpressions" Version="4.12.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.2" />
+    <PackageReference Include="AdaptiveExpressions" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.1" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />


### PR DESCRIPTION
Addresses #408

## Description
This PR updates the botbuilder packages of .NET bots and TestRunner project to the latest stable version (4.13.2).

## Specific Changes
Updated packages in the following bots:
- SimpleHostBotComposer
- SimpleHostBot-2.1
- SimpleHostBot
- WaterfallHostBot
- EchoSkillBotComposer
- EchoSkillBot-2.1
- EchoSkillBot
- WaterfallSkillBot

Solved ambiguous reference of `SkillConversationIdFactory` class in SimpleHostBotComposer and EchoSkillBotComposer.

Removed unnecessary using statements.

Updated packages in `TranscriptTestRunner` and `TranscriptConverter` projects.

## Testing
These images show the bots working locally and being deployed successfully after the changes.
![image](https://user-images.githubusercontent.com/44245136/117873677-742e2b80-b276-11eb-83af-8b631e5d80a8.png)
![image](https://user-images.githubusercontent.com/44245136/117873758-8ad48280-b276-11eb-9eb9-582fb6793210.png)