### PR TITLE
Enabled composer expectreplies tests

### DIFF
--- a/Tests/SkillFunctionalTests/SingleTurn/EchoTests.cs
+++ b/Tests/SkillFunctionalTests/SingleTurn/EchoTests.cs
@@ -65,8 +65,7 @@ namespace SkillFunctionalTests.SingleTurn
                 if (testCase.DeliveryMode == DeliveryModes.ExpectReplies)
                 {
                     // Note: ExpectReplies is not supported by DotNetV3 and JSV3 skills.
-                    // BUG: ExpectReplies fails for SimpleHostBotComposerDotNet calls (remove the last OR when https://github.com/microsoft/BotFramework-FunctionalTests/issues/279 is fixed).
-                    if (testCase.TargetSkill == SkillBotNames.EchoSkillBotDotNetV3 || testCase.TargetSkill == SkillBotNames.EchoSkillBotJSV3 || testCase.HostBot == HostBot.SimpleHostBotComposerDotNet)
+                    if (testCase.TargetSkill == SkillBotNames.EchoSkillBotDotNetV3 || testCase.TargetSkill == SkillBotNames.EchoSkillBotJSV3)
                     {
                         return true;
                     }


### PR DESCRIPTION
Fixes #279

The latest composer runtime works fine with expectReplies, this PR removes the exclusion from the tests
