### PR TITLE
[#414][HTTP 500] Implement regional Virtual Network configuration to fix SNAT port exhaustion

### DIFF
--- a/build/templates/template-bot-resources.json
+++ b/build/templates/template-bot-resources.json
@@ -24,6 +24,15 @@
       "type": "string",
       "defaultValue": ""
     },
+    "virtualNetworkName": {
+      "type": "string"
+    },
+    "virtualNetworkResourceGroup": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
     "appServicePlanName": {
       "type": "string"
     },
@@ -88,6 +97,11 @@
             {
               "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
               "value": "[if(empty(parameters('appInsightsName')), '', reference(resourceId(parameters('appServicePlanResourceGroup'),'Microsoft.Insights/components', parameters('appInsightsName')), '2015-05-01', 'Full').properties.ConnectionString)]"
+            },
+            {
+              "name": "WEBSITE_VNET_ROUTE_ALL",
+              "condition": "[not(empty(parameters('virtualNetworkName')))]",
+              "value": "1"
             },
             {
               "name": "ApplicationInsightsAgent_EXTENSION_VERSION",
@@ -204,6 +218,20 @@
         "developerAppInsightKey": "",
         "publishingCredentials": null,
         "storageResourceId": null
+      }
+    },
+    {
+      "condition": "[not(empty(parameters('virtualNetworkName')))]",
+      "name": "[concat(parameters('botName'), '/virtualNetwork')]",
+      "type": "Microsoft.Web/sites/config",
+      "apiVersion": "2018-02-01",
+      "location": "[parameters('botLocation')]",
+      "dependsOn": [
+          "[resourceId('Microsoft.Web/sites', parameters('botName'))]"
+      ],
+      "properties": {
+          "subnetResourceId": "[resourceId(parameters('virtualNetworkResourceGroup'), 'Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnetName'))]",
+          "swiftSupported": true
       }
     }
   ]

--- a/build/templates/template-python-bot-resources.json
+++ b/build/templates/template-python-bot-resources.json
@@ -26,6 +26,16 @@
     "appServicePlanResourceGroup": {
       "type": "string"
     },
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "virtualNetworkResourceGroup": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
     "botSku": {
       "type": "string",
       "defaultValue": "F0",
@@ -67,6 +77,11 @@
           "appSettings": [
             {
               "name": "WEBSITE_RUN_FROM_PACKAGE",
+              "value": "1"
+            },
+            {
+              "name": "WEBSITE_VNET_ROUTE_ALL",
+              "condition": "[not(empty(parameters('virtualNetworkName')))]",
               "value": "1"
             },
             {
@@ -189,6 +204,20 @@
         "developerAppInsightKey": "",
         "publishingCredentials": null,
         "storageResourceId": null
+      }
+    },
+    {
+      "condition": "[not(empty(parameters('virtualNetworkName')))]",
+      "name": "[concat(parameters('botName'), '/virtualNetwork')]",
+      "type": "Microsoft.Web/sites/config",
+      "apiVersion": "2018-02-01",
+      "location": "[parameters('botLocation')]",
+      "dependsOn": [
+          "[resourceId('Microsoft.Web/sites', parameters('botName'))]"
+      ],
+      "properties": {
+          "subnetResourceId": "[resourceId(parameters('virtualNetworkResourceGroup'), 'Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnetName'))]",
+          "swiftSupported": true
       }
     }
   ]

--- a/build/templates/template-virtual-network-resources.json
+++ b/build/templates/template-virtual-network-resources.json
@@ -1,0 +1,198 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "virtualNetworkName": {
+            "type": "string",
+            "defaultValue": "bffnvirtualnetwork",
+            "metadata": {
+                "description": "The name of the Virtual Network instance"
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Specifies the Azure location where the virtual network should be created."
+            }
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Network/virtualNetworks",
+            "apiVersion": "2020-11-01",
+            "name": "[parameters('virtualNetworkName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "10.1.0.0/16"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "javascript",
+                        "properties": {
+                            "addressPrefix": "10.1.0.0/24",
+                            "serviceEndpoints": [
+                                {
+                                    "service": "Microsoft.Web",
+                                    "locations": [
+                                        "*"
+                                    ]
+                                }
+                            ],
+                            "delegations": [
+                                {
+                                    "name": "delegation",
+                                    "properties": {
+                                        "serviceName": "Microsoft.Web/serverfarms"
+                                    }
+                                }
+                            ],
+                            "privateEndpointNetworkPolicies": "Enabled",
+                            "privateLinkServiceNetworkPolicies": "Enabled"
+                        }
+                    },
+                    {
+                        "name": "dotnet",
+                        "properties": {
+                            "addressPrefix": "10.1.1.0/24",
+                            "serviceEndpoints": [
+                                {
+                                    "service": "Microsoft.Web",
+                                    "locations": [
+                                        "*"
+                                    ]
+                                }
+                            ],
+                            "delegations": [
+                                {
+                                    "name": "delegation",
+                                    "properties": {
+                                        "serviceName": "Microsoft.Web/serverfarms"
+                                    }
+                                }
+                            ],
+                            "privateEndpointNetworkPolicies": "Enabled",
+                            "privateLinkServiceNetworkPolicies": "Enabled"
+                        }
+                    },
+                    {
+                        "name": "python",
+                        "properties": {
+                            "addressPrefix": "10.1.2.0/24",
+                            "serviceEndpoints": [
+                                {
+                                    "service": "Microsoft.Web",
+                                    "locations": [
+                                        "*"
+                                    ]
+                                }
+                            ],
+                            "delegations": [
+                                {
+                                    "name": "delegation",
+                                    "properties": {
+                                        "serviceName": "Microsoft.Web/serverfarms"
+                                    }
+                                }
+                            ],
+                            "privateEndpointNetworkPolicies": "Enabled",
+                            "privateLinkServiceNetworkPolicies": "Enabled"
+                        }
+                    }
+                ],
+                "virtualNetworkPeerings": [],
+                "enableDdosProtection": false
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks/subnets",
+            "apiVersion": "2020-11-01",
+            "name": "[concat(parameters('virtualNetworkName'), '/javascript')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+            ],
+            "properties": {
+                "addressPrefix": "10.1.0.0/24",
+                "serviceEndpoints": [
+                    {
+                        "service": "Microsoft.Web",
+                        "locations": [
+                            "*"
+                        ]
+                    }
+                ],
+                "delegations": [
+                    {
+                        "name": "delegation",
+                        "properties": {
+                            "serviceName": "Microsoft.Web/serverfarms"
+                        }
+                    }
+                ],
+                "privateEndpointNetworkPolicies": "Enabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks/subnets",
+            "apiVersion": "2020-11-01",
+            "name": "[concat(parameters('virtualNetworkName'), '/dotnet')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+            ],
+            "properties": {
+                "addressPrefix": "10.1.1.0/24",
+                "serviceEndpoints": [
+                    {
+                        "service": "Microsoft.Web",
+                        "locations": [
+                            "*"
+                        ]
+                    }
+                ],
+                "delegations": [
+                    {
+                        "name": "delegation",
+                        "properties": {
+                            "serviceName": "Microsoft.Web/serverfarms"
+                        }
+                    }
+                ],
+                "privateEndpointNetworkPolicies": "Enabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks/subnets",
+            "apiVersion": "2020-11-01",
+            "name": "[concat(parameters('virtualNetworkName'), '/python')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+            ],
+            "properties": {
+                "addressPrefix": "10.1.2.0/24",
+                "serviceEndpoints": [
+                    {
+                        "service": "Microsoft.Web",
+                        "locations": [
+                            "*"
+                        ]
+                    }
+                ],
+                "delegations": [
+                    {
+                        "name": "delegation",
+                        "properties": {
+                            "serviceName": "Microsoft.Web/serverfarms"
+                        }
+                    }
+                ],
+                "privateEndpointNetworkPolicies": "Enabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+            }
+        }
+    ]
+}

--- a/build/yaml/deployBotResources/common/createAppService.yml
+++ b/build/yaml/deployBotResources/common/createAppService.yml
@@ -44,6 +44,18 @@ parameters:
     displayName: Azure resources' name suffix
     type: string
 
+  - name: virtualNetwork
+    displayName: Virtual Network name
+    type: string
+
+  - name: virtualNetworkRG
+    displayName: Virtual Network Resource Group
+    type: string
+
+  - name: subnetName
+    displayName: Virtual Network Subnet name
+    type: string
+
 steps:
   - task: AzureCLI@2
     displayName: "Create resources"
@@ -56,7 +68,8 @@ steps:
 
         $botPricingTier = if(-not ([string]::IsNullOrEmpty("${{ parameters.botPricingTier }}"))) { "botSku=${{ parameters.botPricingTier }}" };
         $appInsights = if(-not ([string]::IsNullOrEmpty("${{ parameters.appInsight }}"))) { "appInsightsName=${{ parameters.appInsight }}" }
+        $virtualNetwork = if(-not ([string]::IsNullOrEmpty("${{ parameters.virtualNetwork }}"))) { "virtualNetworkName=${{ parameters.virtualNetwork }}" }
 
-        az deployment group create --resource-group "${{ parameters.botGroup }}" --name "${{ parameters.botName }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)" --template-file ${{ parameters.templateFile }} --parameters $botPricingTier botLocation="westus" appId="${{ parameters.appId }}" appSecret="${{ parameters.appSecret }}" botName="${{ parameters.botName }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)" appServicePlanName="${{ parameters.appServicePlan }}" appServicePlanResourceGroup="${{ parameters.appServicePlanRG }}" $appInsights;
+        az deployment group create --resource-group "${{ parameters.botGroup }}" --name "${{ parameters.botName }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)" --template-file ${{ parameters.templateFile }} --parameters $botPricingTier botLocation="westus" appId="${{ parameters.appId }}" appSecret="${{ parameters.appSecret }}" botName="${{ parameters.botName }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)" appServicePlanName="${{ parameters.appServicePlan }}" appServicePlanResourceGroup="${{ parameters.appServicePlanRG }}" virtualNetworkResourceGroup="${{ parameters.virtualNetworkRG }}" subnetName="${{ parameters.subnetName }}" $virtualNetwork $appInsights;
 
         Set-PSDebug -Trace 0

--- a/build/yaml/deployBotResources/deployBotResources.yml
+++ b/build/yaml/deployBotResources/deployBotResources.yml
@@ -131,8 +131,6 @@ variables:
   # BotPricingTier: (optional) Pricing Tier for the bots, default F0.
   # ResourceGroup: (optional) Name of the Resource Group where the bots will be deployed.
   # ResourceSuffix: (optional) Suffix to add to the resources' name to avoid collitions.
-  # VirtualNetworkName: (optional) Name of the Virtual Network.
-  # VirtualNetworkGroup: (optional) Name of the Resource Group where the Virtual Network is located.
 
   ## Bots Configuration (Define these variables in Azure)
   # BffnEchoSkillBotComposerDotNetAppId: (optional) App Id for BffnEchoSkillBotComposerDotNet bot.
@@ -193,8 +191,7 @@ variables:
   InternalKeyVaultName: 'bffnbotkeyvault$(INTERNALRESOURCESUFFIX)'
   InternalResourceGroupName: $[coalesce(variables['RESOURCEGROUP'], 'bffnbots')]
   InternalResourceSuffix: $[coalesce(variables['RESOURCESUFFIX'], '')]
-  InternalVirtualNetworkName: $[coalesce(variables['VIRTUALNETWORKNAME'], '')]
-  InternalVirtualNetworkResourceGroup: $[coalesce(variables['VIRTUALNETWORKGROUP'], 'bffnshared')]
+  InternalVirtualNetworkName: 'bffnvirtualnetwork$(INTERNALRESOURCESUFFIX)'
 
 stages:
 # Resource Groups
@@ -227,7 +224,7 @@ stages:
       resourceGroup: "$(INTERNALRESOURCEGROUPNAME)-DotNet"
       resourceSuffix: $(INTERNALRESOURCESUFFIX)
       virtualNetwork: "$(INTERNALVIRTUALNETWORKNAME)"
-      virtualNetworkRG: "$(INTERNALVIRTUALNETWORKRESOURCEGROUP)"
+      virtualNetworkRG: "$(INTERNALAPPSERVICEPLANWINDOWSRESOURCEGROUP)"
       bots:
         - name: "bffnsimplehostbotdotnet"
           dependsOn: "Prepare_DotNetGroup"
@@ -338,7 +335,7 @@ stages:
       resourceGroup: "$(INTERNALRESOURCEGROUPNAME)-DotNet"
       resourceSuffix: $(INTERNALRESOURCESUFFIX)
       virtualNetwork: "$(INTERNALVIRTUALNETWORKNAME)"
-      virtualNetworkRG: "$(INTERNALVIRTUALNETWORKRESOURCEGROUP)"
+      virtualNetworkRG: "$(INTERNALAPPSERVICEPLANWINDOWSRESOURCEGROUP)"
       bots:
         - name: "bffnsimplehostbotcomposerdotnet"
           dependsOn: "Deploy_bffnechoskillbotdotnet"
@@ -382,7 +379,7 @@ stages:
       resourceGroup: "$(INTERNALRESOURCEGROUPNAME)-JS"
       resourceSuffix: $(INTERNALRESOURCESUFFIX)
       virtualNetwork: "$(INTERNALVIRTUALNETWORKNAME)"
-      virtualNetworkRG: "$(INTERNALVIRTUALNETWORKRESOURCEGROUP)"
+      virtualNetworkRG: "$(INTERNALAPPSERVICEPLANWINDOWSRESOURCEGROUP)"
       bots:
         - name: "bffnsimplehostbotjs"
           type: "Host"
@@ -452,7 +449,7 @@ stages:
       resourceGroup: "$(INTERNALRESOURCEGROUPNAME)-Python"
       resourceSuffix: "$(INTERNALRESOURCESUFFIX)"
       virtualNetwork: "$(INTERNALVIRTUALNETWORKNAME)"
-      virtualNetworkRG: "$(INTERNALVIRTUALNETWORKRESOURCEGROUP)"
+      virtualNetworkRG: "$(INTERNALAPPSERVICEPLANWINDOWSRESOURCEGROUP)"
       bots:
         - name: "bffnsimplehostbotpython"
           type: "Host"

--- a/build/yaml/deployBotResources/deployBotResources.yml
+++ b/build/yaml/deployBotResources/deployBotResources.yml
@@ -131,6 +131,8 @@ variables:
   # BotPricingTier: (optional) Pricing Tier for the bots, default F0.
   # ResourceGroup: (optional) Name of the Resource Group where the bots will be deployed.
   # ResourceSuffix: (optional) Suffix to add to the resources' name to avoid collitions.
+  # VirtualNetworkName: (optional) Name of the Virtual Network.
+  # VirtualNetworkGroup: (optional) Name of the Resource Group where the Virtual Network is located.
 
   ## Bots Configuration (Define these variables in Azure)
   # BffnEchoSkillBotComposerDotNetAppId: (optional) App Id for BffnEchoSkillBotComposerDotNet bot.
@@ -191,6 +193,8 @@ variables:
   InternalKeyVaultName: 'bffnbotkeyvault$(INTERNALRESOURCESUFFIX)'
   InternalResourceGroupName: $[coalesce(variables['RESOURCEGROUP'], 'bffnbots')]
   InternalResourceSuffix: $[coalesce(variables['RESOURCESUFFIX'], '')]
+  InternalVirtualNetworkName: $[coalesce(variables['VIRTUALNETWORKNAME'], '')]
+  InternalVirtualNetworkResourceGroup: $[coalesce(variables['VIRTUALNETWORKGROUP'], 'bffnshared')]
 
 stages:
 # Resource Groups
@@ -222,6 +226,8 @@ stages:
       keyVault: "$(INTERNALKEYVAULTNAME)"
       resourceGroup: "$(INTERNALRESOURCEGROUPNAME)-DotNet"
       resourceSuffix: $(INTERNALRESOURCESUFFIX)
+      virtualNetwork: "$(INTERNALVIRTUALNETWORKNAME)"
+      virtualNetworkRG: "$(INTERNALVIRTUALNETWORKRESOURCEGROUP)"
       bots:
         - name: "bffnsimplehostbotdotnet"
           dependsOn: "Prepare_DotNetGroup"
@@ -331,6 +337,8 @@ stages:
       keyVault: "$(INTERNALKEYVAULTNAME)"
       resourceGroup: "$(INTERNALRESOURCEGROUPNAME)-DotNet"
       resourceSuffix: $(INTERNALRESOURCESUFFIX)
+      virtualNetwork: "$(INTERNALVIRTUALNETWORKNAME)"
+      virtualNetworkRG: "$(INTERNALVIRTUALNETWORKRESOURCEGROUP)"
       bots:
         - name: "bffnsimplehostbotcomposerdotnet"
           dependsOn: "Deploy_bffnechoskillbotdotnet"
@@ -373,6 +381,8 @@ stages:
       keyVault: "$(INTERNALKEYVAULTNAME)"
       resourceGroup: "$(INTERNALRESOURCEGROUPNAME)-JS"
       resourceSuffix: $(INTERNALRESOURCESUFFIX)
+      virtualNetwork: "$(INTERNALVIRTUALNETWORKNAME)"
+      virtualNetworkRG: "$(INTERNALVIRTUALNETWORKRESOURCEGROUP)"
       bots:
         - name: "bffnsimplehostbotjs"
           type: "Host"
@@ -441,6 +451,8 @@ stages:
       keyVault: "$(INTERNALKEYVAULTNAME)"
       resourceGroup: "$(INTERNALRESOURCEGROUPNAME)-Python"
       resourceSuffix: "$(INTERNALRESOURCESUFFIX)"
+      virtualNetwork: "$(INTERNALVIRTUALNETWORKNAME)"
+      virtualNetworkRG: "$(INTERNALVIRTUALNETWORKRESOURCEGROUP)"
       bots:
         - name: "bffnsimplehostbotpython"
           type: "Host"

--- a/build/yaml/deployBotResources/dotnet/deploy.yml
+++ b/build/yaml/deployBotResources/dotnet/deploy.yml
@@ -44,6 +44,14 @@ parameters:
     displayName: Azure resources' name suffix
     type: string
 
+  - name: virtualNetwork
+    displayName: Virtual network name
+    type: string
+
+  - name: virtualNetworkRG
+    displayName: Virtual Network Resource Group
+    type: string
+
 stages:
 - ${{ each bot in parameters.bots }}:
   - stage: "Deploy_${{ bot.name }}"
@@ -226,6 +234,9 @@ stages:
               botName: "${{ bot.name }}"
               botPricingTier: "${{ parameters.botPricingTier }}"
               resourceSuffix: "${{ parameters.resourceSuffix }}"
+              virtualNetwork: "${{ parameters.virtualNetwork }}"
+              virtualNetworkRG: "${{ parameters.virtualNetworkRG }}"
+              subnetName: "dotnet"
               templateFile: "build/templates/template-bot-resources.json"
 
           # Deploy bot

--- a/build/yaml/deployBotResources/dotnet/deployComposer.yml
+++ b/build/yaml/deployBotResources/dotnet/deployComposer.yml
@@ -40,6 +40,14 @@ parameters:
     displayName: Azure resources' name suffix
     type: string
 
+  - name: virtualNetwork
+    displayName: Virtual network name
+    type: string
+
+  - name: virtualNetworkRG
+    displayName: Virtual Network Resource Group
+    type: string
+
 stages:
 - ${{ each bot in parameters.bots }}:
   - stage: "Deploy_${{ bot.name }}"
@@ -145,6 +153,9 @@ stages:
               botName: "${{ bot.name }}"
               botPricingTier: "${{ parameters.botPricingTier }}"
               resourceSuffix: "${{ parameters.resourceSuffix }}"
+              virtualNetwork: "${{ parameters.virtualNetwork }}"
+              virtualNetworkRG: "${{ parameters.virtualNetworkRG }}"
+              subnetName: "dotnet"
               templateFile: "build/templates/template-bot-resources.json"
 
           # Deploy bot

--- a/build/yaml/deployBotResources/js/deploy.yml
+++ b/build/yaml/deployBotResources/js/deploy.yml
@@ -43,6 +43,14 @@ parameters:
     displayName: Azure resources' name suffix
     type: string
 
+  - name: virtualNetwork
+    displayName: Virtual network name
+    type: string
+
+  - name: virtualNetworkRG
+    displayName: Virtual Network Resource Group
+    type: string
+
 stages:
 - ${{ each bot in parameters.bots }}:
   - stage: "Deploy_${{ bot.name }}"
@@ -184,6 +192,9 @@ stages:
               botName: "${{ bot.name }}"
               botPricingTier: "${{ parameters.botPricingTier }}"
               resourceSuffix: "${{ parameters.resourceSuffix }}"
+              virtualNetwork: "${{ parameters.virtualNetwork }}"
+              virtualNetworkRG: "${{ parameters.virtualNetworkRG }}"
+              subnetName: "javascript"
               templateFile: "build/templates/template-bot-resources.json"
 
           # Deploy bot

--- a/build/yaml/deployBotResources/python/deploy.yml
+++ b/build/yaml/deployBotResources/python/deploy.yml
@@ -38,6 +38,14 @@ parameters:
   - name: resourceSuffix
     displayName: Azure resources' name suffix
     type: string
+    
+  - name: virtualNetwork
+    displayName: Virtual network name
+    type: string
+
+  - name: virtualNetworkRG
+    displayName: Virtual Network Resource Group
+    type: string
 
 stages:
 - ${{ each bot in parameters.bots }}:
@@ -115,6 +123,9 @@ stages:
               botGroup: "${{ parameters.resourceGroup }}"
               botPricingTier: "${{ parameters.botPricingTier }}"
               resourceSuffix: "${{ parameters.resourceSuffix }}"
+              virtualNetwork: "${{ parameters.virtualNetwork }}"
+              virtualNetworkRG: "${{ parameters.virtualNetworkRG }}"
+              subnetName: "python"
               templateFile: "build/templates/template-python-bot-resources.json"
 
           # Configure OAuth

--- a/build/yaml/sharedResources/createSharedResources.yml
+++ b/build/yaml/sharedResources/createSharedResources.yml
@@ -25,6 +25,7 @@ variables:
   InternalCosmosDBName: "bffnbotstatedb$($env:RESOURCESUFFIX)"
   InternalKeyVaultName: "bffnbotkeyvault$($env:RESOURCESUFFIX)"
   InternalResourceGroupName: $[coalesce(variables['RESOURCEGROUPNAME'], 'bffnshared')]
+  InternalVirtualNetworkName: "bffnvirtualnetwork$($env:RESOURCESUFFIX)"
 
 stages:
 - stage: Create_Resource_Group_Windows
@@ -57,6 +58,21 @@ stages:
           scriptType: pscore
           scriptLocation: inlineScript
           inlineScript: "az group create --name $(INTERNALRESOURCEGROUPNAME)-linux --location westus"
+
+- stage: Create_Virtual_Network
+  displayName: "Create Virtual Network"
+  dependsOn: Create_Resource_Group_Windows
+  jobs:
+    - job: Create_Virtual_Network
+      displayName: "Create steps"
+      steps:
+        - task: AzureCLI@2
+          displayName: "Deploy Virtual Network"
+          inputs:
+            azureSubscription: $(AZURESUBSCRIPTION)
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: "az deployment group create --name $(INTERNALVIRTUALNETWORKNAME) --resource-group $(INTERNALRESOURCEGROUPNAME) --template-file build/templates/template-virtual-network-resources.json --parameters virtualNetworkName=$(INTERNALVIRTUALNETWORKNAME)"
 
 - stage: Create_CosmosDB
   displayName: "Create CosmosDB"


### PR DESCRIPTION
Addresses #414 

**Note: For these changes to work, it's necessary to execute the new stage _Create Virtual Network_ of the [01-Create Shared Resources](https://github.com/microsoft/BotFramework-FunctionalTests/blob/main/build/yaml/sharedResources/createSharedResources.yml) pipeline.**

## Description
This PR adds an integration with the [Virtual Network](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/Microsoft.VirtualNetwork?tab=Overview) resource for the deployed app services using service endpoints in order to solve the SNAT port exhaustion issue that causes timeouts when running the Test Scenarios pipeline.

We came up with this solution due to an Azure proposal when going to "SNAT Port Exhaustion" within the Availability and Performance section of an Application Service. 
![image (13)](https://user-images.githubusercontent.com/54330145/121710803-4ecc5180-cab0-11eb-949e-ecb00367078f.png)
This proposal redirected us to [this](https://docs.microsoft.com/en-us/azure/app-service/web-sites-integrate-with-vnet#regional-vnet-integration) Microsoft documentation that guided us through the explanation about how and why to implement this, basically adding the resource to our App Services with a _Microsoft.Web_ service endpoint configuration with 3 different subnets configured (one for each language). We've also found [this](https://jan-v.nl/post/2020/vnet-integration-for-your-app-service/) guide for the arm template integration.

## Specific Changes
- Adds the ARM Template for the Virtual Network resource.
- Adds the stage 'Add Virtual Network' for deploying the resource within the Create Shared Resources pipeline.
- Adds the "WEBSITE_VNET_ROUTE_ALL" application setting for all App Services to route all of the outbound traffic into the VNet.

## Testing
The following images show the current status of ports usage when running the Test Scenarios, and the status of the pipelines running successfully.
![image (13)](https://user-images.githubusercontent.com/54330145/121703992-b92dc380-caa9-11eb-9232-75ebf563d600.png)
![image](https://user-images.githubusercontent.com/54330145/121704784-728c9900-caaa-11eb-962f-305a69c703ca.png)
![image](https://user-images.githubusercontent.com/54330145/121705069-b41d4400-caaa-11eb-81ab-2b744663cc29.png)
![image](https://user-images.githubusercontent.com/54330145/121711808-5f30fc00-cab1-11eb-8ae4-8f2d70d38ffc.png)