### PR TITLE
[#414] Fix SsoMiddleware error in FileUpload tests

### DIFF
--- a/Tests/SkillFunctionalTests/FileUpload/FileUploadTests.cs
+++ b/Tests/SkillFunctionalTests/FileUpload/FileUploadTests.cs
@@ -74,8 +74,8 @@ namespace SkillFunctionalTests.FileUpload
         [MemberData(nameof(TestCases))]
         public async Task RunTestCases(TestCaseDataObject testData)
         {
-            const string fileName = "TestFile.txt";
             var testGuid = Guid.NewGuid().ToString();
+            var fileName = $"TestFile-{testGuid}.txt";
             var testCase = testData.GetObject<TestCase>();
             Logger.LogInformation(JsonConvert.SerializeObject(testCase, Formatting.Indented));
 
@@ -93,14 +93,14 @@ namespace SkillFunctionalTests.FileUpload
 
             await runner.RunTestAsync(Path.Combine(_testScriptsFolder, testCase.Script), testParams);
 
-            // Create or Update testFile.
-            await using var stream = File.OpenWrite(Directory.GetCurrentDirectory() + $"/FileUpload/Media/{fileName}");
+            // Create a new file to upload.
+            await using var stream = File.Create(Directory.GetCurrentDirectory() + $"/FileUpload/{fileName}");
             await using var writer = new StreamWriter(stream);
             await writer.WriteLineAsync($"GUID:{testGuid}");
             writer.Close();
 
             // Upload file.
-            await using var file = File.OpenRead(Directory.GetCurrentDirectory() + $"/FileUpload/Media/{fileName}");
+            await using var file = File.OpenRead(Directory.GetCurrentDirectory() + $"/FileUpload/{fileName}");
             await runner.UploadAsync(file);
 
             // Execute the rest of the conversation.

--- a/Tests/SkillFunctionalTests/FileUpload/Media/TestFile.txt
+++ b/Tests/SkillFunctionalTests/FileUpload/Media/TestFile.txt
@@ -1,1 +1,0 @@
-This is a test file.


### PR DESCRIPTION
Addresses #414

## Description
This PR fixes a concurrency issue in the FileUpload tests that was causing an exception in the pipelines when two tests ran for the same skill bot and tried to access the same file in the server.

### Detailed Changes
- Updated [FileUploadTests](https://github.com/microsoft/BotFramework-FunctionalTests/blob/main/Tests/SkillFunctionalTests/FileUpload/FileUploadTests.cs) class to create and upload a different file for each test case adding a GUID to the file name.
- Deleted the [Media/TestFile.txt](https://github.com/microsoft/BotFramework-FunctionalTests/blob/main/Tests/SkillFunctionalTests/FileUpload/Media/TestFile.txt) file that was no longer needed.

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/122111194-d3430b00-cdf5-11eb-9901-4ecf4a6e4d5e.png)
