### PR TITLE
Disambiguate reference to AllowedSkillsClaimsValidator

### DIFF
--- a/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/Startup.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/Startup.cs
@@ -10,7 +10,6 @@ using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.BotFrameworkFunctionalTests.SimpleHostBot21.Authentication;
 using Microsoft.BotFrameworkFunctionalTests.SimpleHostBot21.Bots;
 using Microsoft.BotFrameworkFunctionalTests.SimpleHostBot21.Dialogs;
 using Microsoft.Extensions.Configuration;
@@ -42,7 +41,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot21
             services.AddSingleton<SkillsConfiguration>();
 
             // Register AuthConfiguration to enable custom claim validation.
-            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
+            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new Microsoft.BotFrameworkFunctionalTests.SimpleHostBot21.Authentication.AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
 
             // Register the Bot Framework Adapter with error handling enabled.
             // Note: some classes use the base BotAdapter so we add an extra registration that pulls the same instance.

--- a/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/Startup.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/Startup.cs
@@ -10,7 +10,6 @@ using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Authentication;
 using Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Bots;
 using Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Dialogs;
 using Microsoft.Extensions.Configuration;
@@ -43,7 +42,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.SimpleHostBot
             services.AddSingleton<SkillsConfiguration>();
 
             // Register AuthConfiguration to enable custom claim validation.
-            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
+            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Authentication.AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
 
             // Register the Bot Framework Adapter with error handling enabled.
             // Note: some classes use the base BotAdapter so we add an extra registration that pulls the same instance.

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Startup.cs
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/Startup.cs
@@ -9,7 +9,6 @@ using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Authentication;
 using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Bots;
 using Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Dialogs;
 using Microsoft.Extensions.Configuration;
@@ -40,7 +39,7 @@ namespace Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot
             services.AddSingleton<SkillsConfiguration>();
 
             // Register AuthConfiguration to enable custom claim validation.
-            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
+            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new Microsoft.BotFrameworkFunctionalTests.WaterfallHostBot.Authentication.AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
 
             // Register the Bot Framework Adapter with error handling enabled.
             // Note: some classes expect a BotAdapter and some expect a BotFrameworkHttpAdapter, so


### PR DESCRIPTION
Updating C# botbuilder to 4.14.0-rc0 breaks the test bots with: 
`
error CS0104: 'AllowedSkillsClaimsValidator' is an ambiguous reference between 'Microsoft.BotFrameworkFunctionalTests.SimpleHostBot.Authentication.AllowedSkillsClaimsValidator' and 'Microsoft.Bot.Connector.Authentication.AllowedSkillsClaimsValidator' 
`