### PR TITLE
[#430][Test Scenarios Pipeline] System.AggregateException: An error occurred while writing to logger

### DIFF
--- a/Libraries/TranscriptTestRunner/TestClients/DirectLineTestClient.cs
+++ b/Libraries/TranscriptTestRunner/TestClients/DirectLineTestClient.cs
@@ -296,6 +296,24 @@ namespace TranscriptTestRunner.TestClients
                     }
                 }
             }
+            catch (AggregateException aggEx)
+            {
+                aggEx.Handle(ex =>
+                {
+                    if (ex is InvalidOperationException && ex.Message.Contains("There is no currently active test"))
+                    {
+                        _logger.LogWarning($"Warning: {ex.Message} This issue will be fixed once a stable v3 is available for 'xunit' and 'Divergic.Logging.Xunit' NuGet packages.");
+                    }
+                    else
+                    {
+                        _logger.LogError(ex, "Error in ListenAsync");
+                    }
+
+                    return true;
+                });
+
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error in ListenAsync");


### PR DESCRIPTION
Fixes #430

## Description
This PR adds a catch statement specifically for exceptions of type _AggregateException_. The issue is caused by an error on v2 of _xunit_ and _Divergix.Logging.Xunit_ NuGet packages. The error does not affect pipelines or tests, but it prints many stack traces in each run that may be source of confusion while debugging other issues.

After some research, we found an [issue](https://github.com/roryprimrose/Divergic.Logging.Xunit/issues/16) where it is mentioned that this is supposed to be fixed on v3 of these packages, but it is still on alpha, so we are temporary catching the exception and logging a warning instead.

Once a v3 stable version is available, the warning will be removed.

The following images show the before and after error message.
![image](https://user-images.githubusercontent.com/54330145/124133482-3f5d7a00-da58-11eb-8f3d-f1c1842a8b0a.png)

![image](https://user-images.githubusercontent.com/54330145/123996669-f0efa300-d9a5-11eb-80ed-84968e5e5f0a.png)