### PR TITLE
Add project tag variable for resources

### DIFF
--- a/build/templates/template-bot-resources.json
+++ b/build/templates/template-bot-resources.json
@@ -37,6 +37,9 @@
         "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
       }
     },
+    "projectTag": {
+      "type": "string"
+    },
     "sharedResourceGroup": {
       "type": "string"
     },
@@ -45,7 +48,7 @@
     },
     "virtualNetworkSubnet": {
       "type": "string"
-    }
+    }    
   },
   "variables": {
     "siteHost": "[concat(parameters('botName'), '.azurewebsites.net')]",
@@ -59,7 +62,7 @@
       "name": "[parameters('botName')]",
       "location": "[parameters('botLocation')]",
       "tags": {
-        "BFFN": "BFFN"
+        "Project": "[parameters('projectTag')]"
       },
       "kind": "app",
       "properties": {

--- a/build/templates/template-bot-resources.json
+++ b/build/templates/template-bot-resources.json
@@ -58,6 +58,9 @@
       "apiVersion": "2020-09-01",
       "name": "[parameters('botName')]",
       "location": "[parameters('botLocation')]",
+      "tags": {
+        "BFFN": "BFFN"
+      },
       "kind": "app",
       "properties": {
         "enabled": true,

--- a/build/templates/template-container-linux-bot-resources.json
+++ b/build/templates/template-container-linux-bot-resources.json
@@ -55,6 +55,9 @@
     "containerCommand": {
       "type": "string"
     },
+    "projectTag": {
+      "type": "string"
+    },
     "sharedResourceGroup": {
       "type": "string"
     },
@@ -80,7 +83,7 @@
       "location": "[parameters('botLocation')]",
       "kind": "app,linux,container",
       "tags": {
-        "BFFN": "BFFN"
+        "Project": "[parameters('projectTag')]"
       },
       "properties": {
         "enabled": true,

--- a/build/templates/template-container-linux-bot-resources.json
+++ b/build/templates/template-container-linux-bot-resources.json
@@ -79,6 +79,9 @@
       "name": "[parameters('botName')]",
       "location": "[parameters('botLocation')]",
       "kind": "app,linux,container",
+      "tags": {
+        "BFFN": "BFFN"
+      },
       "properties": {
         "enabled": true,
         "hostNameSslStates": [

--- a/build/yaml/deployBotResources/common/createAppService.yml
+++ b/build/yaml/deployBotResources/common/createAppService.yml
@@ -46,6 +46,10 @@ parameters:
       port: ""
       command: ""
 
+  - name: projectTag
+    displayName: Tag for bot's application service
+    type: string
+
   - name: templateFile
     displayName: Template File Location
     type: string
@@ -81,6 +85,7 @@ steps:
           @{ key="botName"                      ; value="${{ parameters.botName }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)" }
           @{ key="appServicePlanName"           ; value="${{ parameters.appServicePlan }}" }
           @{ key="appServicePlanResourceGroup"  ; value="${{ parameters.appServicePlanRG }}" }
+          @{ key="projectTag"                   ; value="${{ parameters.projectTag }}" }
           @{ key="sharedResourceGroup"          ; value="${{ parameters.sharedResourceGroup }}" }
           @{ key="botLocation"                  ; value="westus" }
         )

--- a/build/yaml/deployBotResources/deployBotResources.yml
+++ b/build/yaml/deployBotResources/deployBotResources.yml
@@ -192,7 +192,7 @@ variables:
   InternalAppServicePlanJSName: $[coalesce(variables['APPSERVICEPLANJSNAME'], 'bffnbotsappservicejs$(INTERNALRESOURCESUFFIX)')]
   InternalAppServicePlanPythonName: $[coalesce(variables['APPSERVICEPLANPYTHONNAME'], 'bffnbotsappservicepython$(INTERNALRESOURCESUFFIX)')]
   InternalContainerRegistryName: $[coalesce(variables['CONTAINERREGISTRYNAME'], 'bffncontainerregistry$(INTERNALRESOURCESUFFIX)')]
-  InternalProjectTag: $[coalesce(variables['PROJECTTAG'], 'bffn')]
+  InternalProjectTag: $[coalesce(variables['PROJECTTAG'], 'BFFN')]
   InternalKeyVaultName: 'bffnbotkeyvault$(INTERNALRESOURCESUFFIX)'
   InternalResourceGroupName: $[coalesce(variables['RESOURCEGROUP'], 'bffnbots')]
   InternalResourceSuffix: $[coalesce(variables['RESOURCESUFFIX'], '')]

--- a/build/yaml/deployBotResources/deployBotResources.yml
+++ b/build/yaml/deployBotResources/deployBotResources.yml
@@ -192,6 +192,7 @@ variables:
   InternalAppServicePlanJSName: $[coalesce(variables['APPSERVICEPLANJSNAME'], 'bffnbotsappservicejs$(INTERNALRESOURCESUFFIX)')]
   InternalAppServicePlanPythonName: $[coalesce(variables['APPSERVICEPLANPYTHONNAME'], 'bffnbotsappservicepython$(INTERNALRESOURCESUFFIX)')]
   InternalContainerRegistryName: $[coalesce(variables['CONTAINERREGISTRYNAME'], 'bffncontainerregistry$(INTERNALRESOURCESUFFIX)')]
+  InternalProjectTag: $[coalesce(variables['PROJECTTAG'], 'bffn')]
   InternalKeyVaultName: 'bffnbotkeyvault$(INTERNALRESOURCESUFFIX)'
   InternalResourceGroupName: $[coalesce(variables['RESOURCEGROUP'], 'bffnbots')]
   InternalResourceSuffix: $[coalesce(variables['RESOURCESUFFIX'], '')]
@@ -226,6 +227,7 @@ stages:
       botPricingTier: $env:BOTPRICINGTIER
       connectionName: $env:CONNECTIONNAME
       keyVault: "$(INTERNALKEYVAULTNAME)"
+      projectTag: "$(INTERNALPROJECTTAG)"
       resourceGroup: "$(INTERNALRESOURCEGROUPNAME)-DotNet"
       resourceSuffix: $(INTERNALRESOURCESUFFIX)
       sharedResourceGroup: "$(INTERNALSHAREDRESOURCEGROUPNAME)"
@@ -370,6 +372,7 @@ stages:
       connectionName: $env:CONNECTIONNAME
       dependsOn: "Prepare_JSGroup"
       keyVault: "$(INTERNALKEYVAULTNAME)"
+      projectTag: "$(INTERNALPROJECTTAG)"
       resourceGroup: "$(INTERNALRESOURCEGROUPNAME)-JS"
       resourceSuffix: $(INTERNALRESOURCESUFFIX)
       sharedResourceGroup: "$(INTERNALSHAREDRESOURCEGROUPNAME)"
@@ -461,6 +464,7 @@ stages:
       connectionName: $env:CONNECTIONNAME
       dependsOn: "Prepare_PythonGroup"
       keyVault: "$(INTERNALKEYVAULTNAME)"
+      projectTag: "$(INTERNALPROJECTTAG)"
       resourceGroup: "$(INTERNALRESOURCEGROUPNAME)-Python"
       resourceSuffix: "$(INTERNALRESOURCESUFFIX)"
       sharedResourceGroup: "$(INTERNALSHAREDRESOURCEGROUPNAME)"

--- a/build/yaml/deployBotResources/dotnet/deploy.yml
+++ b/build/yaml/deployBotResources/dotnet/deploy.yml
@@ -36,6 +36,10 @@ parameters:
     displayName: Key Vault name
     type: string
 
+  - name: projectTag
+    displayName: Tag for bot's application service
+    type: string
+
   - name: resourceGroup
     displayName: Resource Group
     type: string
@@ -269,6 +273,7 @@ stages:
               botGroup: "${{ parameters.resourceGroup }}"
               botName: "${{ bot.name }}"
               botPricingTier: "${{ parameters.botPricingTier }}"
+              projectTag: "${{ parameters.projectTag }}"
               resourceSuffix: "${{ parameters.resourceSuffix }}"
               sharedResourceGroup: "${{ parameters.sharedResourceGroup }}"
               templateFile: "build/templates/template-bot-resources.json"

--- a/build/yaml/deployBotResources/js/deploy.yml
+++ b/build/yaml/deployBotResources/js/deploy.yml
@@ -35,6 +35,10 @@ parameters:
     displayName: Key Vault name
     type: string
 
+  - name: projectTag
+    displayName: Tag for bot's application service
+    type: string
+
   - name: resourceGroup
     displayName: Resource Group
     type: string
@@ -212,6 +216,7 @@ stages:
                 tag: "v$(DEPENDENCIESVERSIONNUMBER)"
                 port: "${{ bot.container.port }}"
                 command: "${{ bot.container.command }}"
+              projectTag: "${{ parameters.projectTag }}"
               resourceSuffix: "${{ parameters.resourceSuffix }}"
               sharedResourceGroup: "${{ parameters.sharedResourceGroup }}"
               templateFile: "build/templates/template-container-linux-bot-resources.json"

--- a/build/yaml/deployBotResources/python/deploy.yml
+++ b/build/yaml/deployBotResources/python/deploy.yml
@@ -35,6 +35,10 @@ parameters:
     displayName: Key Vault name
     type: string
 
+  - name: projectTag
+    displayName: Tag for bot's application service
+    type: string
+
   - name: resourceGroup
     displayName: Resource Group
     type: string
@@ -184,6 +188,7 @@ stages:
                 tag: "v$(DEPENDENCIESVERSIONNUMBER)"
                 port: "${{ bot.container.port }}"
                 command: "${{ bot.container.command }}"
+              projectTag: "${{ parameters.projectTag }}"
               resourceSuffix: "${{ parameters.resourceSuffix }}"
               sharedResourceGroup: "${{ parameters.sharedResourceGroup }}"
               templateFile: "build/templates/template-container-linux-bot-resources.json"


### PR DESCRIPTION
Fixes # XXX

## Description
This PR adds the optional variable "_ProjectTag_" for setting a tag for the resources deployed within the "Deploy Bot Resources" pipeline. If the variable is not added to the pipeline execution, the default value for the tag will be 'bffn'.

Here you can see the set variable
![image](https://user-images.githubusercontent.com/54330145/123262515-563b2400-d4ce-11eb-922c-0c9e0d4a809c.png)

Example of default 'Project' tag
![image](https://user-images.githubusercontent.com/54330145/123146056-dd878980-d433-11eb-807c-52d5e5c70be2.png)

