### PR TITLE
[#452] Add VNet integration and docker container documentation

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -10,3 +10,5 @@
 - [Create WebApp Deployment credentials](./createWebAppDeploymentCredentials.md)
 - [Get the Service Principal's Object ID](./getServicePrincipalObjectID.md)
 - [Setup Pipelines](./setupPipelines.md)
+- [Setup custom Docker container](./setupDockerContainer.md)
+- [Regional Virtual Network integration](./regionalVirtualNetworkIntegration.md)

--- a/Docs/pipelines.md
+++ b/Docs/pipelines.md
@@ -30,7 +30,7 @@
 | **AppServicePlanJSName** | Create Shared Resources | (optional) Name of the JavaScript App Service Plan. |
 | **AppServicePlanPythonName** | Create Shared Resources | (optional) Name of the Python App Service Plan. |
 | **BotPricingTier** | User | (optional) Pricing tier for the Web App resources. ***Default value is F0.** |
-| **ContainerRegistryName** | User | (optional) Pricing tier for the Web App resources. |
+| **ContainerRegistryName** | User | (optional) Name of the container registry. |
 | **ResourceGroup** | User | (optional) Name of the Resource Group where the bots will be deployed. |
 | **ResourceSuffix** | Create Shared Resources | (optional) Suffix to add to the resources' name to avoid collisions. |
 | **SharedResourceGroup** | Create Shared Resources | (optional) Name of the Shared Resource Group where the shared resources are located. |

--- a/Docs/pipelines.md
+++ b/Docs/pipelines.md
@@ -9,8 +9,9 @@
 | Variable Name | Source | Description |
 | - | - | - |
 | **AzureSubscription** | Azure DevOps | Name of the Azure Resource Manager Service Connection configured in the DevOps organization. Click [here](./addARMServiceConnection.md) to see how to set it up. |
-| **KeyVaultObjectId** | Azure | Suscription's Object Id to create the keyvault to store App Registrations in Azure. Click [here](./getServicePrincipalObjectID.md) to see how to get it. |
 | **AppServicePlanPricingTier** | User | (optional) Pricing Tier for App Service Plans. **Default value is F1.** |
+| **ContainerRegistryPricingTier** | User | (optional) Pricing Tier for Container Registry. **Default value is Basic.** |
+| **KeyVaultObjectId** | Azure | Suscription's Object Id to create the keyvault to store App Registrations in Azure. Click [here](./getServicePrincipalObjectID.md) to see how to get it. |
 | **ResourceGroupName** | User | (optional) Name for the resource group that will contain the shared resources. |
 | **ResourceSuffix** | User | (optional) Suffix to add to the resources' name to avoid collisions. |
 
@@ -29,8 +30,11 @@
 | **AppServicePlanJSName** | Create Shared Resources | (optional) Name of the JavaScript App Service Plan. |
 | **AppServicePlanPythonName** | Create Shared Resources | (optional) Name of the Python App Service Plan. |
 | **BotPricingTier** | User | (optional) Pricing tier for the Web App resources. ***Default value is F0.** |
+| **ContainerRegistryName** | User | (optional) Pricing tier for the Web App resources. |
 | **ResourceGroup** | User | (optional) Name of the Resource Group where the bots will be deployed. |
 | **ResourceSuffix** | Create Shared Resources | (optional) Suffix to add to the resources' name to avoid collisions. |
+| **SharedResourceGroup** | Create Shared Resources | (optional) Name of the Shared Resource Group where the shared resources are located. |
+| **VirtualNetworkName** | Create Shared Resources | (optional) Name of the Virtual Network resource. |
 | **[BotName](#botnames) + AppId** | [App Registration Portal](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade) | (optional) App ID to use. If not configured, will be retrieved from the key vault. |
 | **[BotName](#botnames) + AppSecret** | [App Registration Portal](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade) | (optional) App Secret to use. If not configured, will be retrieved from the key vault. |
 

--- a/Docs/regionalVirtualNetworkIntegration.md
+++ b/Docs/regionalVirtualNetworkIntegration.md
@@ -1,0 +1,16 @@
+# Regional Virtual Network integration
+
+The bots deployed in Azure for the functional tests have configured a Virtual Network to communicate with each other to mitigate a port exhaustion issue within the application services.
+
+Documentation about setting the regional VNet integration can be found in the [official documentation](https://docs.microsoft.com/en-us/azure/app-service/web-sites-integrate-with-vnet#regional-vnet-integration).
+
+## VNet implementation
+
+![image](https://user-images.githubusercontent.com/38112957/124790114-46d1c700-df21-11eb-8884-a3591709ca81.png)
+
+As you can see in the image, the Virtual Network resource is configured with 3 subnets, one for each language. All of these are integrated into the corresponding Bot's app service to make use of the available IPs for that subnet.
+Whenever a bot wants to communicate with another bot, the virtual network will recognize the destination address as internal to the VNET and [will route the traffic through it](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-udr-overview). All subnets are interconnected with each other through the VNET. This brings the benefit of increased speed and available ports for connections between the bots. All outbound connections are routed through SNAT to the internet.
+
+![image](https://user-images.githubusercontent.com/38112957/124790693-c19ae200-df21-11eb-8d45-cf70ad57b4ca.png "VNET integration example")
+
+This configuration lowers the experienced networking issues by reducing the amount of SNAT ports needed to communicate between bots. SNAT ports are managed by Azure and [provided in batches of 128](https://docs.microsoft.com/en-us/azure/app-service/troubleshoot-intermittent-outbound-connection-errors#cause). When a resource requires more ports than it currently has, azure auto-provisions another batch for said resource. This process is not instantaneous and, [some connections that are waiting for an available port might fail](https://azure.microsoft.com/de-de/blog/azure-load-balancer-becomes-more-efficient/). When routing the traffic inside Azure with VNET, the resources gain access to all available ports in the running OS (65.000+), increasing reliability.

--- a/Docs/setupDockerContainer.md
+++ b/Docs/setupDockerContainer.md
@@ -1,0 +1,168 @@
+# How to setup custom Docker container
+
+## Summary
+
+The JS and Python bots deployed in Azure for the functional tests are deployed in Docker containers by creating an Azure container registry.
+This guide will show you how to create a custom container with a Linux/Python image and a bot sample, how to use it locally with BotFramework-Emulator, deploy it to a container's registry and create a Web App from the custom container.
+
+![image](https://user-images.githubusercontent.com/38112957/124938561-c70a3200-dfde-11eb-9714-ac1fb28191e8.png "High overview structure to build, push and use a Bot Container in Azure.")
+
+For additional information visit the official [Docker's website](https://www.docker.com/).
+
+## Index
+
+- [Create a Container](#create-a-container)
+- [Deploy a Container](#deploy-a-container)
+- [Create a Container WebApp](#create-a-container-webapp)
+
+## Requirements
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop)
+- [BotFramework-Emulator](https://github.com/microsoft/BotFramework-Emulator/releases)
+- [Ngrok](https://ngrok.com/download)
+- [Active Azure Subscription](https://portal.azure.com/#home)
+- Bot Resources
+  - [Azure App Service Plan](https://portal.azure.com/#create/Microsoft.AppServicePlanCreate) ([guide](https://docs.microsoft.com/en-us/azure/app-service/app-service-plan-manage))
+  - [Bot Channel Registration](https://portal.azure.com/#create/Microsoft.BotServiceConnectivityGalleryPackage) ([guide](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-quickstart-registration?view=azure-bot-service-4.0&tabs=cshap))
+  - [App Registration](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/CreateApplicationBlade/quickStartType//isMSAApp/) ([guide](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app)) (*MicrosoftAppId* and *Microsoft AppPassword* variables)
+
+### Container specs
+
+- Image: [python:3.8-buster](https://hub.docker.com/_/python) ([Dockerfile](https://github.com/docker-library/python/blob/master/3.8/buster/Dockerfile), [Packages](https://github.com/docker-library/repo-info/blob/master/repos/python/local/3.8-buster.md))
+- System: Linux
+
+## Create a container
+
+1. Install docker (if you don't have it already). A restart might be required.
+2. Use a bot sample (eg. [SimpleHostBotPython](https://github.com/microsoft/BotFramework-FunctionalTests/tree/main/Bots/Python/Consumers/CodeFirst/SimpleHostBot)). Clone the repository and move to the sample folder of the bot of your choice.
+
+    > **Note**: when using [aiohttp](https://docs.aiohttp.org/en/stable/) to host the app, ensure the **host** property is empty when the **run_app** method is executed so the library starts broadcasting (0.0.0.0). This can be done by modifyin **app.py** in the source.
+
+    ```python
+    from aiohttp import web
+    web.run_app(web.Application(), host="localhost", port=37000)
+    ```
+
+3. Create a file named **DockerFile** (without extension) inside the bot's folder. Add the following lines in the file.
+
+    ```dockerfile
+    # Specify the base image to use
+    FROM python:3.8-buster
+
+    # Specify the working directory where the bot is located. This will be the default location for all subsequent commands.
+    WORKDIR /app
+
+    # Take all the files located in the current directory and copy them into the image.
+    COPY . .
+
+    # Install bot's dependencies
+    RUN pip3 install -r requirements.txt
+
+    # Execute the bot
+    CMD python app.py
+    ```
+
+4. Execute the [build](https://docs.docker.com/engine/reference/commandline/build/) command in the console to build the container.
+
+    ```docker
+    docker build --tag <Name and optionally a tag in the 'name:tag' format> .
+    ```
+
+    eg.
+
+    ```docker
+    docker build --tag simplehostbotpython .
+    ```
+
+5. Execute the [run](https://docs.docker.com/engine/reference/commandline/run/) command in the console to start the container
+
+    ```docker
+    docker run --publish <Publish a container's port(s) to the host> <Image name assigned in the tag>
+    ```
+
+    eg.
+
+    ```docker
+    docker run --publish 37000:37000 simplehostbotpython
+    ```
+
+    If you are presented with the following error, please refer to the step 2.
+
+    ```docker
+    OSError: [Errno 99] error while attempting to bind on address ('::1', 37000, 0, 0): cannot assign requested address
+    ```
+
+6. When using BotFramework-Emulator, ensure the **"Bypass ngrok from local addresses"** option is disabled.  
+![image](https://user-images.githubusercontent.com/38112957/124956591-84505600-dfee-11eb-84f5-c2791b5ed25f.png)
+
+## Deploy a container
+
+1. Create an [Azure container registry](https://portal.azure.com/#create/Microsoft.ContainerRegistry).  
+Once the resource is created, head over to the **Access Keys** section and enable **Admin user**. This will allow us to login remotely to the registry and push our container.  
+Take note of the **Login server**, **Username**, and **password** values, we will need them later.  
+![image](https://user-images.githubusercontent.com/38112957/124957304-515a9200-dfef-11eb-9e4d-7daee493bd55.png)
+
+2. Login into the Azure container registry by executing the [login](https://docs.microsoft.com/en-us/cli/azure/acr?view=azure-cli-latest#az_acr_login) command in a console.
+
+    ```cmd
+    az acr login --name <Name of the Container Registry>
+    ```
+
+    eg.
+
+    ```cmd
+    az acr login --name bffncontainerregistry
+    ```
+
+    If you are presented with the following error.  
+    ![image](https://user-images.githubusercontent.com/38112957/124957660-b1513880-dfef-11eb-875d-ef1a89539b0c.png)
+
+    run
+
+    ```cmd
+    az login
+    ```
+
+3. Execute the [tag](https://docs.docker.com/engine/reference/commandline/tag/) command in the console to tag the container.
+
+    ```docker
+    docker tag <Image name assigned in the tag> <Container Registry Login server>/<Name and optionally a tag in the 'name:tag' format. Tag defaults to 'latest'>
+    ```
+
+    eg.
+
+    ```docker
+    docker tag simplehostbotpython bffncontainerregistry.azurecr.io/simplehostbotpython:v1
+    ```
+
+4. Execute the [push](https://docs.docker.com/engine/reference/commandline/push/) command in the console to push the container to the registry.
+
+    ```docker
+    docker push <Tag created in the previous step>
+    ```
+
+    eg.
+
+    ```docker
+    push bffncontainerregistry.azurecr.io/simplehostbotpython:v1
+    ```
+
+    If the error `unauthorized: authentication required` shows up, you are either, not logged in, or you used a mix of upper and lower case letters in the console commands. Please repeat tagging and pushing the container using all lowercase letters for the registry names.
+
+    Your container is now deployed, you can check the uploaded containers in the container registry under the Repositories section.
+
+    ![image](https://user-images.githubusercontent.com/38112957/124959801-faa28780-dff1-11eb-9632-a690dcf7092c.png)
+
+## Create a container WebApp
+
+1. Create a [WebApp](https://portal.azure.com/#create/Microsoft.WebSite).  
+![image](https://user-images.githubusercontent.com/38112957/124960037-40f7e680-dff2-11eb-872a-fa01933b9395.png)
+
+2. Access the WebApp configuration and assign the **WEBSITES_PORT** variable with the port to use to communicate with the container. Add the **MicrosoftAppId** and **MicrosoftAppPassword** obtained from the created **AppRegistration**.  
+![image](https://user-images.githubusercontent.com/38112957/124960465-bd8ac500-dff2-11eb-9775-b04614df1f9b.png)
+
+3. Add the WebApp URL in the Bot Channel Registration messaging endpoint. You can obtain the URL from WebApp's summary.  
+![image](https://user-images.githubusercontent.com/38112957/124960921-3a1da380-dff3-11eb-857a-b538ffd55cdb.png)
+
+4. The bot is ready. You can access the Bot Channel Registration and start chatting with the bot.  
+![image](https://user-images.githubusercontent.com/38112957/124961032-5ae5f900-dff3-11eb-933d-04921017d533.png)


### PR DESCRIPTION
Fixes #452

# Summary

This PR adds new documents with information on the Virtual Network and how to set up a docker container integrated with the bots. Also updates existing readmes with the added variables for these integrations.

## Specific changes

- Add `regionalVirtualNetworkIntegration.md`  document with information on the regional virtual network integration.
- Add `setupDockerContainer.md` document with steps to use a custom docker container with the bots.
- Update `README.md` with links to the new documents.
- Update `pipelines.md` adding the variables introduced with the VNet and containers integration.