### PR TITLE
[#502] Update Bots and Tests Project to 4.15.x

### DIFF
--- a/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot-2.1.csproj
+++ b/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot-2.1.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.14.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.15.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj
+++ b/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot/SimpleHostBot.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.14.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.15.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/WaterfallHostBot.csproj
+++ b/Bots/DotNet/Consumers/CodeFirst/WaterfallHostBot/WaterfallHostBot.csproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.14.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.15.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0" />
   </ItemGroup>
 
 </Project>

--- a/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/SimpleHostBotComposer.csproj
+++ b/Bots/DotNet/Consumers/Composer/SimpleHostBotComposer/SimpleHostBotComposer.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.15.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.15.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.15.0" />
   </ItemGroup>
 </Project>

--- a/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot-2.1.csproj
+++ b/Bots/DotNet/Skills/CodeFirst/EchoSkillBot-2.1/EchoSkillBot-2.1.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj
+++ b/Bots/DotNet/Skills/CodeFirst/EchoSkillBot/EchoSkillBot.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/WaterfallSkillBot.csproj
+++ b/Bots/DotNet/Skills/CodeFirst/WaterfallSkillBot/WaterfallSkillBot.csproj
@@ -25,9 +25,9 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.14.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.14.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.15.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.15.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
   </ItemGroup>
 

--- a/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/EchoSkillBotComposer.csproj
+++ b/Bots/DotNet/Skills/Composer/EchoSkillBotComposer/EchoSkillBotComposer.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.15.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.15.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.15.0" />
   </ItemGroup>
 </Project>

--- a/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/package.json
+++ b/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot/package.json
@@ -9,8 +9,8 @@
     "watch": "nodemon index.js"
   },
   "dependencies": {
-    "botbuilder": "~4.14.1",
-    "botbuilder-dialogs": "~4.14.1",
+    "botbuilder": "~4.15.0",
+    "botbuilder-dialogs": "~4.15.0",
     "dotenv": "^10.0.0",
     "restify": "^8.5.1"
   },

--- a/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/package.json
+++ b/Bots/JavaScript/Consumers/CodeFirst/WaterfallHostBot/package.json
@@ -14,8 +14,8 @@
     "url": "https://github.com"
   },
   "dependencies": {
-    "botbuilder": "~4.14.1",
-    "botbuilder-dialogs": "~4.14.1",
+    "botbuilder": "~4.15.0",
+    "botbuilder-dialogs": "~4.15.0",
     "dotenv": "^10.0.0",
     "restify": "^8.5.1"
   },

--- a/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/package.json
+++ b/Bots/JavaScript/Skills/CodeFirst/EchoSkillBot/package.json
@@ -9,8 +9,8 @@
     "watch": "nodemon index.js"
   },
   "dependencies": {
-    "botbuilder": "~4.14.0",
-    "botframework-connector": "~4.14.0",
+    "botbuilder": "~4.15.0",
+    "botframework-connector": "~4.15.0",
     "dotenv": "^10.0.0",
     "restify": "^8.5.1"
   },

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/package.json
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/package.json
@@ -10,8 +10,8 @@
     "watch": "nodemon index.js"
   },
   "dependencies": {
-    "botbuilder": "~4.15.0-dev.20210805.26f7f44",
-    "botbuilder-dialogs": "~4.15.0-dev.20210805.26f7f44",
+    "botbuilder": "~4.15.0",
+    "botbuilder-dialogs": "~4.15.0",
     "dotenv": "^10.0.0",
     "node-fetch": "^2.6.1",
     "restify": "~8.5.1"

--- a/Libraries/TranscriptConverter/TranscriptConverter.csproj
+++ b/Libraries/TranscriptConverter/TranscriptConverter.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.15.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/Libraries/TranscriptTestRunner/TranscriptTestRunner.csproj
+++ b/Libraries/TranscriptTestRunner/TranscriptTestRunner.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveExpressions" Version="4.14.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="AdaptiveExpressions" Version="4.15.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />


### PR DESCRIPTION
Fixes #502

# Summary
This PR updates the bots and test projects to BotBuilder 4.15.0.

## Specific changes
- Updated the .Net and JS bots to use BotBuilder 4.15.0
- Updated _TranscriptTestRunner_ and _TranscriptConverter_ libraries to use BotBuilder 4.15.0

## Testing
These images show the bots working locally and the pipelines running successfully.
![image](https://user-images.githubusercontent.com/44245136/143067674-741d1e90-44f1-4bae-ab28-196a82a5da6e.png)
![image](https://user-images.githubusercontent.com/44245136/143067736-1182f345-32c7-4841-8874-4a875458baf7.png)