### PR TITLE
[CI-Pipeline] Skip JS EchoSkillBot-v3 from CI pipeline

### DIFF
--- a/Bots/JavaScript/package.json
+++ b/Bots/JavaScript/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "workspaces": {
     "packages": [
-      "*/*/*"
+      "*/*/*",
+      "!*/*/EchoSkillBot-v3"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

This PR excludes JS **_EchoSkillBot-v3_** from the build in the CI pipeline to avoid the error thrown by yarn after the upgrade of the NodeJS version in the [pipelines' virtual environment](https://github.com/actions/virtual-environments/releases/tag/win19%2F20211229.2).
This is a workaround until we review the yarn implementation and find a better solution.

![image](https://user-images.githubusercontent.com/44245136/144436010-3b78a4a2-a80a-488f-8073-f6e37ec256c3.png)

### Detailed Changes
- Excluded **_EchoSkillBot-v3_** project from yarn workspaces in the `Bots/JavaScript/package.json` file.

## Testing
Here we can see the pipeline before and after applying the workaround.
![image](https://user-images.githubusercontent.com/44245136/144436229-c924df6c-5066-4dc0-bb54-26443e61bd32.png)
