### PR TITLE
Fix NU1107 error in pipeline 02.A. Deploy skill bots (daily)

### DIFF
--- a/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot-2.1.csproj
+++ b/Bots/DotNet/Consumers/CodeFirst/SimpleHostBot-2.1/SimpleHostBot-2.1.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.15.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
02.A. Deploy skill bots (daily)/281112: Failing.

Error: D:\a\1\s\Bots\DotNet\Consumers\CodeFirst\SimpleHostBot-2.1\SimpleHostBot-2.1.csproj : error NU1107: Version conflict detected for Microsoft.Extensions.Caching.Abstractions. Install/reference Microsoft.Extensions.Caching.Abstractions 2.2.0 directly to project Microsoft.BotFrameworkFunctionalTests.SimpleHostBot21 to resolve this issue. 

Note: I get no repro running the "Build" task's "dotnet publish" command locally. That suggests the problem may lie in the prior Powershell task, "Install dependencies for SimpleHostBot-2.1.csproj" which I did not test.
