### PR TITLE
[#528] Fix WaterfallSkillJS ServerUrl not being assigned properly

### DIFF
--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/config.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/config.js
@@ -18,7 +18,6 @@ class DefaultConfig {
       PORT
     } = process.env;
 
-    this.ServerUrl = '';
     this.Port = port || PORT || 36420;
     this.MicrosoftAppId = MicrosoftAppId;
     this.MicrosoftAppPassword = MicrosoftAppPassword;
@@ -35,19 +34,14 @@ class DefaultConfig {
       appId: process.env.EchoSkillInfo_appId,
       skillEndpoint: process.env.EchoSkillInfo_skillEndpoint
     };
-  }
 
-  /**
-   * @param {import('restify').Request} request
-   */
-  configureServerUrl (request) {
     // Workaround for Restify known issues to construct the server.url.
     // Restify:
     //   [#1029](https://github.com/restify/node-restify/issues/1029)
     //   [#1274](https://github.com/restify/node-restify/issues/1274)
-    const protocol = request.headers['x-appservice-proto'] ?? 'http';
-    const url = process.env.WEBSITE_HOSTNAME ?? request.headers.host;
-    this.ServerUrl = `${protocol}://${url}`;
+    const { WEBSITE_HOSTNAME } = process.env;
+    const url = WEBSITE_HOSTNAME ? `https://${WEBSITE_HOSTNAME}` : `http://localhost:${this.Port}`;
+    this.ServerUrl = new URL(url).origin;
   }
 }
 

--- a/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/index.js
+++ b/Bots/JavaScript/Skills/CodeFirst/WaterfallSkillBot/index.js
@@ -163,8 +163,6 @@ server.get('/images/*', restify.plugins.serveStatic({ directory: './images', app
 
 // Listen for incoming requests.
 server.post('/api/messages', async (req, res) => {
-  config.configureServerUrl(req);
-
   await adapter.process(req, res, async (context) => {
     // Route to main dialog.
     await bot.run(context);


### PR DESCRIPTION
Fixes #528

## Description
This PR fixes an issue where the `ServerUrl` comes empty for Proactive, Audio, and MessageWithAttachments functionalities.

## Specific Changes
- Removed `configureServerUrl` method to configure the `ServerUrl` when accessed through the `/api/messages` endpoint in favor of just obtain the `WEBSITE_HOSTNAME` when deployed, otherwise `localhost`.

## Testing
The following images show the error when the `ServerUrl` was empty and how it's working after the changes.
![image](https://user-images.githubusercontent.com/62260472/146405122-db5d0435-53bc-4aee-9550-9e5593fe5386.png)