### PR TITLE
[#554] Update source code namespaces - Yaml files

### DIFF
--- a/build/yaml/deployBotResources/deployBotResources.yml
+++ b/build/yaml/deployBotResources/deployBotResources.yml
@@ -235,7 +235,7 @@ stages:
           appSecret: $(BFFNSIMPLEHOSTBOTDOTNETAPPSECRET)
           project:
             directory: 'Bots/DotNet/SimpleHostBot'
-            name: "SimpleHostBot.csproj"
+            name: "Microsoft.Bot.Builder.FunctionalTestsBots.SimpleHostBot.csproj"
             netCoreVersion: "3.1.x"
           dependency:
             registry: ${{ parameters.dependenciesRegistryDotNetHosts }}
@@ -249,7 +249,7 @@ stages:
           appSecret: $(BFFNECHOSKILLBOTDOTNETAPPSECRET)
           project: 
             directory: 'Bots/DotNet/EchoSkillBot'
-            name: "EchoSkillBot.csproj"
+            name: "Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBot.csproj"
             netCoreVersion: "3.1.x"
           dependency:
             registry: ${{ parameters.dependenciesRegistryDotNetSkills }}
@@ -264,7 +264,7 @@ stages:
           appSecret: $(BFFNECHOSKILLBOTDOTNETV3APPSECRET)
           project:
             directory: 'Bots/DotNet/EchoSkillBot-v3'
-            name: "EchoSkillBot-v3.csproj"
+            name: "Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBot-v3.csproj"
           dependency:
             registry: ${{ parameters.dependenciesRegistryDotNetSkillsV3 }}
             version: ${{ parameters.dependenciesVersionDotNetSkillsV3 }}
@@ -277,7 +277,7 @@ stages:
           appSecret: $(BFFNWATERFALLHOSTBOTDOTNETAPPSECRET)
           project:
             directory: 'Bots/DotNet/WaterfallHostBot'
-            name: "WaterfallHostBot.csproj"
+            name: "Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallHostBot.csproj"
             netCoreVersion: "3.1.x"
           dependency:
             registry: ${{ parameters.dependenciesRegistryDotNetHosts }}
@@ -291,7 +291,7 @@ stages:
           appSecret: $(BFFNWATERFALLSKILLBOTDOTNETAPPSECRET)
           project: 
             directory: 'Bots/DotNet/WaterfallSkillBot'
-            name: "WaterfallSkillBot.csproj"
+            name: "Microsoft.Bot.Builder.FunctionalTestsBots.WaterfallSkillBot.csproj"
             netCoreVersion: "3.1.x"
           dependency:
             registry: ${{ parameters.dependenciesRegistryDotNetSkills }}
@@ -306,7 +306,7 @@ stages:
           appSecret: $(BFFNSIMPLEHOSTBOTCOMPOSERDOTNETAPPSECRET)
           project: 
             directory: 'Bots/DotNet/SimpleHostBotComposer'
-            name: "SimpleHostBotComposer.csproj"
+            name: "Microsoft.Bot.Builder.FunctionalTestsBots.SimpleHostBotComposer.csproj"
             netCoreVersion: "3.1.x"
           dependency:
             registry: ${{ parameters.dependenciesRegistryDotNetHosts }}
@@ -320,7 +320,7 @@ stages:
           appSecret: $(BFFNECHOSKILLBOTCOMPOSERDOTNETAPPSECRET)
           project: 
             directory: 'Bots/DotNet/EchoSkillBotComposer'
-            name: "EchoSkillBotComposer.csproj"
+            name: "Microsoft.Bot.Builder.FunctionalTestsBots.EchoSkillBotComposer.csproj"
             netCoreVersion: "3.1.x"
           dependency:
             registry: ${{ parameters.dependenciesRegistryDotNetSkills }}
@@ -334,7 +334,7 @@ stages:
           appSecret: $(BFFNCOMPOSERSKILLBOTDOTNETAPPSECRET)
           project: 
             directory: 'Bots/DotNet/ComposerSkillBotDotNet'
-            name: "ComposerSkillBotDotNet.csproj"
+            name: "Microsoft.Bot.Builder.FunctionalTestsBots.ComposerSkillBotDotNet.csproj"
             netCoreVersion: "3.1.x"
           dependency:
             registry: ${{ parameters.dependenciesRegistryDotNetSkills }}

--- a/build/yaml/dotnetBotsBuild-CI.yml
+++ b/build/yaml/dotnetBotsBuild-CI.yml
@@ -28,13 +28,13 @@ steps:
 - task: NuGetCommand@2
   displayName: "NuGet restore"
   inputs:
-    restoreSolution: "Bots/DotNet/FunctionalTestsBots.sln"
+    restoreSolution: "Bots/DotNet/Microsoft.Bot.Builder.FunctionalTestsBots.sln"
     restoreDirectory: "${{ parameters.solutionDir }}packages"
 
 - task: MSBuild@1
   displayName: "Build"
   inputs:
-    solution: "Bots/DotNet/FunctionalTestsBots.sln"
+    solution: "Bots/DotNet/Microsoft.Bot.Builder.FunctionalTestsBots.sln"
     vsVersion: 16.0
     platform: "${{ parameters.buildPlatform }}"
     configuration: "${{ parameters.buildConfiguration }}"

--- a/build/yaml/functionalTestsBuild-CI.yml
+++ b/build/yaml/functionalTestsBuild-CI.yml
@@ -24,12 +24,12 @@ steps:
 - task: NuGetCommand@2
   displayName: "NuGet restore"
   inputs:
-    restoreSolution: FunctionalTests.sln
+    restoreSolution: Tests.sln
 
 - task: MSBuild@1
   displayName: "Build"
   inputs:
-    solution: "FunctionalTests.sln"
+    solution: "Tests.sln"
     vsVersion: 16.0
     platform: "${{ parameters.buildPlatform }}"
     configuration: "${{ parameters.buildConfiguration }}"
@@ -38,7 +38,7 @@ steps:
   displayName: 'Run Unit Tests'
   inputs:
     command: test
-    projects: 'Libraries/TranscriptTestRunner.Tests/TranscriptTestRunner.Tests.csproj'
+    projects: 'Libraries/TranscriptTestRunner.Tests/Microsoft.Bot.Builder.Testing.TestRunner.Tests.csproj'
     testRunTitle: 'FunctionalTests-CI-Results-$(BUILD.BUILDNUMBER)'
     arguments: '-v n --configuration ${{ parameters.buildConfiguration }} --no-build --no-restore --collect "Code Coverage" --logger "trx;LogFileName=FunctionalTests-CI-Results-$(BUILD.BUILDNUMBER).trx"'
 

--- a/build/yaml/testScenarios/runScenario.yml
+++ b/build/yaml/testScenarios/runScenario.yml
@@ -71,7 +71,7 @@ stages:
               inputs:
                 command: build
                 publishWebProjects: false
-                projects: "Tests/Functional/FunctionalTests.csproj"
+                projects: "Tests/Functional/Microsoft.Bot.Builder.Tests.Functional.csproj"
                 arguments: "-v n --configuration ${{ parameters.buildConfiguration }}"
 
             - task: DotNetCoreCLI@2
@@ -79,5 +79,5 @@ stages:
               inputs:
                 command: test
                 testRunTitle: "FunctionalTests-${{ scenario.name }}-$(BUILD.BUILDNUMBER)"
-                projects: "Tests/Functional/FunctionalTests.csproj"
+                projects: "Tests/Functional/Microsoft.Bot.Builder.Tests.Functional.csproj"
                 arguments: "-v n --configuration ${{ parameters.buildConfiguration }} --no-build --no-restore --logger trx;LogFileName=FunctionalTests-${{ scenario.name }}-$(BUILD.BUILDNUMBER).trx --filter TestCategory!=IgnoreInAutomatedBuild&TestCategory=${{ join('|TestCategory=', scenario.testCategories) }}"


### PR DESCRIPTION
Addresses #554

> **Note: The CI-PR pipeline will fail until all this issue's PRs are merged.**

## Description
This PR updates the projects' names in the YAML files of the pipelines to be aligned with the Bot Framework namespaces.

### Detailed description
- Updated yamls of **_02.A. Deploy skill bots_** pipeline to reference the new bots projects' names.
- Updated yamls of **_02.B. Run skill test scenarios_** pipeline to reference the new test projects' names.
- Updated yamls of the **_functionalTestsBuild-CI_** pipeline to reference the new dotnet solution's names.

## Testing
These images show the pipelines running after the changes.
![image](https://user-images.githubusercontent.com/44245136/156376330-914bcb00-9718-4e28-b2c4-31589a601681.png)