### PR TITLE
[#503] Enable SignIn tests for ComposerSkillBotDotNet

### DIFF
--- a/Bots/DotNet/ComposerSkillBotDotNet/dialogs/AuthDialog/AuthDialog.dialog
+++ b/Bots/DotNet/ComposerSkillBotDotNet/dialogs/AuthDialog/AuthDialog.dialog
@@ -120,6 +120,33 @@
           }
         }
       ]
+    },
+    {
+      "$kind": "Microsoft.OnEventActivity",
+      "$designer": {
+        "id": "7kJtr3",
+        "name": "Event received (Event activity)"
+      },
+      "actions": [
+        {
+          "$kind": "Microsoft.IfCondition",
+          "$designer": {
+            "id": "FpQfAQ"
+          },
+          "actions": [
+            {
+              "$kind": "Microsoft.SetProperty",
+              "$designer": {
+                "id": "ulNzSl"
+              },
+              "property": "dialog.token",
+              "value": "turn.activity.value.token"
+            }
+          ],
+          "condition": "=turn.activity.name==tokens/response"
+        }
+      ],
+      "condition": "=not(empty(turn.activity.value))"
     }
   ],
   "generator": "AuthDialog.lg",

--- a/Bots/DotNet/ComposerSkillBotDotNet/dialogs/AuthDialog/language-generation/en-us/AuthDialog.en-us.lg
+++ b/Bots/DotNet/ComposerSkillBotDotNet/dialogs/AuthDialog/language-generation/en-us/AuthDialog.en-us.lg
@@ -3,6 +3,7 @@
 # SendActivity_kNHtMW()
 [Activity
     Text = ${SendActivity_kNHtMW_text()}
+    InputHint = ignoringInput
 ]
 
 # SendActivity_kNHtMW_text()
@@ -10,6 +11,7 @@
 # ConfirmInput_Prompt_WxLXxu()
 [Activity
     Text = ${ConfirmInput_Prompt_WxLXxu_text()}
+    InputHint = acceptingInput
 ]
 
 # ConfirmInput_Prompt_WxLXxu_text()
@@ -24,6 +26,7 @@
 # SendActivity_oj6Ert()
 [Activity
     Text = ${SendActivity_oj6Ert_text()}
+    InputHint = ignoringInput
 ]
 
 # SendActivity_oj6Ert_text()
@@ -31,6 +34,7 @@
 # ConfirmInput_Prompt_pBqV4a()
 [Activity
     Text = ${ConfirmInput_Prompt_pBqV4a_text()}
+    InputHint = acceptingInput
 ]
 
 # ConfirmInput_Prompt_pBqV4a_text()
@@ -38,6 +42,8 @@
 # SendActivity_ooIaKS()
 [Activity
     Text = ${SendActivity_ooIaKS_text()}
+    Speak = Here is your token:
+    InputHint = ignoringInput
 ]
 
 # SendActivity_ooIaKS_text()

--- a/Tests/Functional/Skills/SignIn/SignInTests.cs
+++ b/Tests/Functional/Skills/SignIn/SignInTests.cs
@@ -46,12 +46,10 @@ namespace SkillFunctionalTests.Skills.SignIn
 
             var targetSkills = new List<string>
             {
+                SkillBotNames.ComposerSkillBotDotNet,
                 SkillBotNames.WaterfallSkillBotDotNet,
                 SkillBotNames.WaterfallSkillBotJS,
                 SkillBotNames.WaterfallSkillBotPython,
-                
-                // TODO: Enable after fixing issue (The test is failing with timeout after the signIn).
-                //SkillBotNames.ComposerSkillBotDotNet
             };
 
             var scripts = new List<string>


### PR DESCRIPTION
Addresses #503

## Description
This PR updates the ComposerSkillBotDotNet to handle the `tokens/response` event activity needed for the Auth test and enables the SignIn scenario for this bot.

### Detailed Changes
- Added event handler in AuthDialog.dialog to set the token from the `tokens/response` event activity.
- Added missing `InputHint` and `Speak` properties in the bot's responses.
- Added _ComposerSkillBotDotNet_ in the list of `targetSkills` in the _SignInTests_ class.

## Testing
This image shows the SignIn tests passing after enabling the _ComposerSkillBotDotNet._
![image](https://user-images.githubusercontent.com/44245136/159354782-1bd2ee2c-d05c-4b51-baeb-0254c95c9676.png)
