### PR TITLE
[#562][DotNet] Add AzureStorageQueues tests to the test solution

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>
 
-  <PropertyGroup>    
+  <PropertyGroup>
     <RepositoryUrl>https://github.com/microsoft/BotFramework-FunctionalTests</RepositoryUrl>
     <LicenseUrl>https://github.com/microsoft/BotFramework-FunctionalTests/blob/main/LICENSE</LicenseUrl>
     <RepositoryType />
@@ -36,4 +36,22 @@
     <BotBuilderVersion Condition="'$(BotBuilderVersion)' != ''">$(BotBuilderVersion)</BotBuilderVersion>
     <RestoreAdditionalProjectSources>$(BotBuilderRegistry)</RestoreAdditionalProjectSources>
   </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(BotBuilderVersion.Contains('daily'))">
+      <PropertyGroup>
+        <BotBuilderVersionPreview>$(BotBuilderVersion.Replace('daily', 'daily.preview'))</BotBuilderVersionPreview>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(BotBuilderVersion.Contains('rc'))">
+      <PropertyGroup>
+        <BotBuilderVersionPreview>$(BotBuilderVersion).preview</BotBuilderVersionPreview>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <BotBuilderVersionPreview>$(BotBuilderVersion)-preview</BotBuilderVersionPreview>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 </Project>

--- a/Tests.sln
+++ b/Tests.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29806.167
@@ -14,19 +14,19 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TranscriptConverter", "Libraries\TranscriptConverter\Microsoft.Bot.Builder.Testing.TranscriptConverter.csproj", "{EF963904-79CB-4222-811A-E24B73E5DC1A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Testing.TranscriptConverter", "Libraries\TranscriptConverter\Microsoft.Bot.Builder.Testing.TranscriptConverter.csproj", "{EF963904-79CB-4222-811A-E24B73E5DC1A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{B5E35C94-0880-4AEB-8F3C-940FECA7A8C7}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{5A0C68F1-6CA7-43D7-8F01-70A484D8D412}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TranscriptTestRunner.Tests", "Libraries\TranscriptTestRunner.Tests\Microsoft.Bot.Builder.Testing.TestRunner.Tests.csproj", "{5CAE9F80-9BD3-480C-8504-552B31B265E0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Testing.TestRunner.Tests", "Libraries\TranscriptTestRunner.Tests\Microsoft.Bot.Builder.Testing.TestRunner.Tests.csproj", "{5CAE9F80-9BD3-480C-8504-552B31B265E0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Functional", "Functional", "{DDEE53CF-F094-4009-B198-AA656CB7A009}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Integration", "Integration", "{9027483A-C2FD-48FF-922A-9050ED490B03}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntegrationTests", "Tests\Integration\DotNet\IntegrationTests.csproj", "{BF885B2E-942C-43F3-BECA-64EFBB0598F4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Tests.Integration", "Tests\Integration\DotNet\Microsoft.Bot.Builder.Tests.Integration.csproj", "{BF885B2E-942C-43F3-BECA-64EFBB0598F4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbAttribute.cs
+++ b/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbAttribute.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace IntegrationTests.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
 {
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     public class CosmosDbAttribute : Attribute

--- a/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbBaseFixture.cs
+++ b/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbBaseFixture.cs
@@ -8,7 +8,7 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Documents.Client;
 using Xunit;
 
-namespace IntegrationTests.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
 {
     public abstract class CosmosDbBaseFixture : ConfigurationFixture, IAsyncLifetime
     {

--- a/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbBaseTests.cs
+++ b/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbBaseTests.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Xunit;
 
-namespace IntegrationTests.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
 {
     public class CosmosDbBaseTests
     {

--- a/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbPartitionedStorageFixture.cs
+++ b/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbPartitionedStorageFixture.cs
@@ -6,7 +6,7 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Azure;
 using Xunit;
 
-namespace IntegrationTests.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
 {
     [CosmosDb(databaseId: "CosmosDbPartitionedStorageTests")]
     public class CosmosDbPartitionedStorageFixture : CosmosDbBaseFixture, IAsyncLifetime

--- a/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbPartitionedStorageTests.cs
+++ b/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbPartitionedStorageTests.cs
@@ -11,7 +11,7 @@ using Microsoft.Bot.Schema;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace IntegrationTests.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
 {
     public class CosmosDbPartitionedStorageTests : CosmosDbBaseTests, IClassFixture<CosmosDbPartitionedStorageFixture>
     {

--- a/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbStorageFixture.cs
+++ b/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbStorageFixture.cs
@@ -10,7 +10,7 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Azure;
 using Xunit;
 
-namespace IntegrationTests.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
 {
     [CosmosDb(databaseId: "CosmosDbStorageTests")]
     public class CosmosDbStorageFixture : CosmosDbBaseFixture, IAsyncLifetime

--- a/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbStorageTests.cs
+++ b/Tests/Integration/DotNet/Azure/Cosmos/CosmosDbStorageTests.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Xunit;
 
-namespace IntegrationTests.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
 {
     [Trait("TestCategory", "Deprecated")]
     public class CosmosDbStorageTests : CosmosDbBaseTests, IClassFixture<CosmosDbStorageFixture>

--- a/Tests/Integration/DotNet/Azure/Storage/Queues/AzureQueueBaseFixture.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/Queues/AzureQueueBaseFixture.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.Queues;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage.Queues
+{
+    public class AzureQueueBaseFixture : ConfigurationFixture, IAsyncLifetime
+    {
+        public AzureQueueBaseFixture()
+        {
+            ConnectionString = Configuration["Azure:Storage:ConnectionString"];
+        }
+
+        public string ConnectionString { get; private set; }
+
+        protected bool IsRunning { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            IsRunning = await IsServiceRunning();
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        protected async Task<bool> IsServiceRunning()
+        {
+            try
+            {
+                using var cancellation = new CancellationTokenSource(Timeout);
+                await new QueueServiceClient(ConnectionString).GetPropertiesAsync(cancellation.Token);
+                return true;
+            }
+            catch (TaskCanceledException ex)
+            {
+                const string message = "Storage: Unable to connect to the 'Queues' endpoint.";
+                throw new TaskCanceledException(message, ex);
+            }
+        }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/Queues/AzureQueueStorageTests.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/Queues/AzureQueueStorageTests.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Azure.Queues;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage.Queues
+{
+    public class AzureQueueStorageTests : IClassFixture<AzureQueueBaseFixture>, IAsyncLifetime
+    {
+        private readonly AzureQueueBaseFixture _azureQueueFixture;
+        private readonly ITestOutputHelper _outputHandler;
+
+        private readonly Activity _welcomeSample = new Activity { Type = ActivityTypes.Message, Text = "Welcome!" };
+        private readonly Activity _greetingsSample = new Activity { Type = ActivityTypes.Message, Text = "Greetings!" };
+
+        public AzureQueueStorageTests(ITestOutputHelper outputHandler, AzureQueueBaseFixture azureQueueFixture)
+        {
+            _azureQueueFixture = azureQueueFixture;
+            _outputHandler = outputHandler;
+        }
+
+        private QueueClient Client { get; set; }
+
+        private QueueStorage Storage { get; set; }
+
+        public async Task InitializeAsync()
+        {
+            // Use each test method name to create a different container.
+            var testMember = _outputHandler.GetType().GetField("test", BindingFlags.Instance | BindingFlags.NonPublic);
+            var test = (ITest)testMember.GetValue(_outputHandler);
+            var containerName = test.TestCase.TestMethod.Method.Name.ToLower();
+
+            Storage = new AzureQueueStorage(_azureQueueFixture.ConnectionString, containerName);
+            Client = new QueueClient(_azureQueueFixture.ConnectionString, containerName);
+
+            await Client.CreateIfNotExistsAsync();
+            await Client.ClearMessagesAsync();
+        }
+
+        public async Task DisposeAsync()
+        {
+            await Client?.DeleteIfExistsAsync();
+        }
+
+        [Fact]
+        public async Task QueueActivity()
+        {
+            await Storage.QueueActivityAsync(_welcomeSample);
+
+            var messages = await Client.ReceiveMessagesAsync();
+            var activity = DeserializeQueueMessage(messages.Value.First());
+
+            Assert.Equal(ActivityTypes.Message, activity.Type);
+            Assert.Equal(_welcomeSample.Text, activity.Text);
+        }
+
+        [Fact]
+        public async Task QueueMultipleActivities()
+        {
+            await Storage.QueueActivityAsync(_welcomeSample);
+            await Storage.QueueActivityAsync(_greetingsSample);
+
+            var initialMessages = (await Client.PeekMessagesAsync(3)).Value;
+
+            var messages = await Client.ReceiveMessagesAsync();
+            var welcomeActivity = DeserializeQueueMessage(messages.Value.First());
+
+            messages = await Client.ReceiveMessagesAsync();
+            var greetingsActivity = DeserializeQueueMessage(messages.Value.First());
+
+            var finalMessages = (await Client.PeekMessagesAsync()).Value;
+
+            Assert.Equal(2, initialMessages.Length);
+            Assert.Empty(finalMessages);
+
+            Assert.Equal(ActivityTypes.Message, welcomeActivity.Type);
+            Assert.Equal(_welcomeSample.Text, welcomeActivity.Text);
+
+            Assert.Equal(ActivityTypes.Message, greetingsActivity.Type);
+            Assert.Equal(_greetingsSample.Text, greetingsActivity.Text);
+        }
+
+        [Fact]
+        public async Task QueueActivityWithExpiration()
+        {
+            await Storage.QueueActivityAsync(_welcomeSample, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+
+            await Task.Delay(1000);
+
+            var messages = await Client.ReceiveMessagesAsync();
+
+            Assert.Empty(messages.Value);
+        }
+
+        [Fact]
+        public async Task QueueActivityWithVisibility()
+        {
+            await Storage.QueueActivityAsync(_welcomeSample, TimeSpan.FromSeconds(1));
+
+            var messages = await Client.ReceiveMessagesAsync();
+
+            Assert.Empty(messages.Value);
+        }
+
+        [Fact]
+        public async Task QueueContinueConversationLater()
+        {
+            var cr = TestAdapter.CreateConversation(nameof(QueueContinueConversationLater));
+            var adapter = new TestAdapter(cr)
+                   .UseStorage(new MemoryStorage())
+                   .UseBotState(new ConversationState(new MemoryStorage()), new UserState(new MemoryStorage()));
+
+            var dm = new DialogManager(new ContinueConversationLater()
+            {
+                Date = "=addSeconds(utcNow(), 1)",
+                Value = "foo"
+            });
+
+            dm.InitialTurnState.Set(Storage);
+
+            await new TestFlow((TestAdapter)adapter, dm.OnTurnAsync)
+                .Send("hi")
+                .StartTestAsync();
+
+            var messages = await Client.ReceiveMessagesAsync();
+            var activity = DeserializeQueueMessage(messages.Value.First());
+
+            var cr2 = activity.GetConversationReference();
+            cr.ActivityId = null;
+            cr2.ActivityId = null;
+
+            Assert.Equal(ActivityTypes.Event, activity.Type);
+            Assert.Equal(ActivityEventNames.ContinueConversation, activity.Name);
+            Assert.Equal("foo", activity.Value);
+            Assert.NotNull(activity.RelatesTo);
+            Assert.Equal(JsonConvert.SerializeObject(cr), JsonConvert.SerializeObject(cr2));
+        }
+
+        private static Activity DeserializeQueueMessage(QueueMessage message)
+        {
+            var messageJson = Encoding.UTF8.GetString(Convert.FromBase64String(message.MessageText));
+            var activity = JsonConvert.DeserializeObject<Activity>(messageJson);
+            return activity;
+        }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/StorageBaseTests.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/StorageBaseTests.cs
@@ -1,0 +1,259 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage
+{
+    public abstract class StorageBaseTests
+    {
+        public StorageBaseTests()
+        {
+            Sample = new StorageItem() { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
+        }
+
+        public StorageItem Sample { get; private set; }
+
+        public IDictionary<StorageCase, IStorage> Storages { get; private set; }
+
+        protected void UseStorages(IDictionary<StorageCase, IStorage> storages)
+        {
+            Storages = storages;
+        }
+
+        [Fact]
+        protected virtual async Task ReadUnknownItem()
+        {
+            var storage = Storages[StorageCase.Default];
+            var result = await storage.ReadAsync(new[] { "unknown" });
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        protected virtual async Task DeleteUnknownItem()
+        {
+            var storage = Storages[StorageCase.Default];
+            await storage.DeleteAsync(new[] { "unknown" });
+        }
+
+        [Fact]
+
+        protected virtual async Task CreateItem()
+        {
+            var storage = Storages[StorageCase.Default];
+            var dict = new Dictionary<string, object>
+            {
+                { "createItem", Sample },
+            };
+
+            await storage.WriteAsync(dict);
+
+            var createdItems = await storage.ReadAsync<StorageItem>(dict.Keys.ToArray());
+            var created = createdItems.FirstOrDefault().Value;
+
+            Assert.Single(createdItems);
+            Assert.NotNull(created);
+            Assert.NotNull(created.ETag);
+            Assert.Equal(Sample.City, created.City);
+            Assert.Equal(Sample.MessageList, created.MessageList);
+        }
+
+        [Fact]
+        protected virtual async Task CreateItemWithSpecialCharacters()
+        {
+            var storage = Storages[StorageCase.Default];
+            const string key = "!@#$%^&*()~/\\><,.?';\"`~";
+            var dict = new Dictionary<string, object>
+            {
+                { key, Sample },
+            };
+
+            await storage.WriteAsync(dict);
+
+            var createdItems = await storage.ReadAsync<StorageItem>(dict.Keys.ToArray());
+            var created = createdItems.FirstOrDefault().Value;
+
+            Assert.Single(createdItems);
+            Assert.NotNull(created);
+            Assert.NotNull(created.ETag);
+            Assert.Equal(Sample.City, created.City);
+            Assert.Equal(Sample.MessageList, created.MessageList);
+        }
+
+        [Fact]
+        protected virtual async Task UpdateItem()
+        {
+            var storage = Storages[StorageCase.Default];
+            var dict = new Dictionary<string, object>
+            {
+                { "updateItem", Sample },
+            };
+
+            await storage.WriteAsync(dict);
+
+            var createdItems = await storage.ReadAsync(dict.Keys.ToArray());
+            var created = createdItems.FirstOrDefault().Value as StorageItem;
+
+            // Update store item
+            created.MessageList = new string[] { "new message" };
+
+            await storage.WriteAsync(createdItems);
+
+            var updatedItems = await storage.ReadAsync(dict.Keys.ToArray());
+            var updated = updatedItems.FirstOrDefault().Value as StorageItem;
+
+            Assert.NotEqual(created.ETag, updated.ETag);
+            Assert.Single(updated.MessageList);
+            Assert.Equal(created.MessageList, updated.MessageList);
+        }
+
+        [Fact]
+        protected virtual async Task DeleteItem()
+        {
+            var storage = Storages[StorageCase.Default];
+            var dict = new Dictionary<string, object>
+            {
+                { "deleteItem", Sample },
+            };
+
+            await storage.WriteAsync(dict);
+
+            var createdItems = await storage.ReadAsync<StorageItem>(dict.Keys.ToArray());
+            var created = createdItems.FirstOrDefault().Value;
+
+            // Delete store item
+            await storage.DeleteAsync(dict.Keys.ToArray());
+
+            var deleted = await storage.ReadAsync(dict.Keys.ToArray());
+
+            Assert.NotNull(created);
+            Assert.Empty(deleted);
+        }
+
+        [Theory]
+        [InlineData(StorageCase.Default)]
+        [InlineData(StorageCase.TypeNameHandlingNone)]
+        protected virtual async Task CreateItemFromConversationState(StorageCase storageCase)
+        {
+            var storage = Storages[storageCase];
+            var conversationState = new ConversationState(storage);
+            var prop = conversationState.CreateProperty<StorageItem>(nameof(CreateItemFromConversationState));
+
+            var adapter = new TestAdapter();
+            var activity = adapter.MakeActivity();
+            activity.ChannelId = nameof(CreateItemFromConversationState);
+
+            // Created
+            var createdContext = new TurnContext(adapter, activity);
+            var created = await prop.GetAsync(createdContext, () => Sample);
+            await conversationState.SaveChangesAsync(createdContext, force: true);
+
+            // Read
+            var resultContext = new TurnContext(adapter, activity);
+            var result = await prop.GetAsync(resultContext);
+
+            Assert.NotNull(result);
+            Assert.Equal(created.City, result.City);
+            Assert.Equal(created.MessageList, result.MessageList);
+        }
+
+        [Fact]
+        protected virtual async Task UpdateItemFromConversationState()
+        {
+            var storage = Storages[StorageCase.Default];
+            var conversationState = new ConversationState(storage);
+            var prop = conversationState.CreateProperty<StorageItem>(nameof(UpdateItemFromConversationState));
+
+            var adapter = new TestAdapter();
+            var activity = adapter.MakeActivity();
+            activity.ChannelId = nameof(UpdateItemFromConversationState);
+
+            // Create
+            var createdContext = new TurnContext(adapter, activity);
+            var created = await prop.GetAsync(createdContext, () => Sample);
+            await conversationState.SaveChangesAsync(createdContext, force: true);
+
+            // Update
+            var updatedContext = new TurnContext(adapter, activity);
+            var updated = await prop.GetAsync(updatedContext);
+            updated.MessageList = new string[] { "new message" };
+            await conversationState.SaveChangesAsync(updatedContext, force: true);
+
+            // Read
+            var resultContext = new TurnContext(adapter, activity);
+            var result = await prop.GetAsync(resultContext);
+
+            Assert.NotNull(result);
+            Assert.NotEqual(created.MessageList, result.MessageList);
+            Assert.Equal(updated.MessageList, result.MessageList);
+        }
+
+        [Fact]
+        protected virtual async Task DeleteItemFromConversationState()
+        {
+            var storage = Storages[StorageCase.Default];
+            var conversationState = new ConversationState(storage);
+            var prop = conversationState.CreateProperty<StorageItem>(nameof(DeleteItemFromConversationState));
+
+            var adapter = new TestAdapter();
+            var activity = adapter.MakeActivity();
+            activity.ChannelId = nameof(DeleteItemFromConversationState);
+
+            // Create
+            var createdContext = new TurnContext(adapter, activity);
+            var created = await prop.GetAsync(createdContext, () => Sample);
+
+            // Delete
+            await prop.DeleteAsync(createdContext);
+            await conversationState.SaveChangesAsync(createdContext, force: true);
+
+            // Read
+            var resultContext = new TurnContext(adapter, activity);
+            var result = await prop.GetAsync(resultContext);
+
+            Assert.NotNull(created);
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(StorageCase.Default)]
+        [InlineData(StorageCase.TypeNameHandlingNone)]
+        protected virtual async Task StatePersistsThroughMultiTurn(StorageCase storageCase)
+        {
+            var storage = Storages[storageCase];
+            var userState = new UserState(storage);
+            var prop = userState.CreateProperty<StorageItem>("item");
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(userState));
+
+            var messageList = new string[] { "new message" };
+
+            await new TestFlow(
+                adapter,
+                async (context, cancellationToken) =>
+                {
+                    var state = await prop.GetAsync(context, () => Sample);
+                    Assert.NotNull(state);
+                    switch (context.Activity.Text)
+                    {
+                        case "set value":
+                            state.MessageList = messageList;
+                            await context.SendActivityAsync("value saved");
+                            break;
+                        case "get value":
+                            var message = string.Join(",", state.MessageList);
+                            await context.SendActivityAsync(message);
+                            break;
+                    }
+                })
+                .Test("set value", "value saved")
+                .Test("get value", string.Join(",", messageList))
+                .StartTestAsync();
+        }
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/StorageCase.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/StorageCase.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage
+{
+    public enum StorageCase
+    {
+        /// <summary>
+        /// Storage instance with default configuration.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Storage instance with JsonSerializer.TypeNameHandling equals to None configuration.
+        /// </summary>
+        TypeNameHandlingNone,
+    }
+}

--- a/Tests/Integration/DotNet/Azure/Storage/StorageItem.cs
+++ b/Tests/Integration/DotNet/Azure/Storage/StorageItem.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Bot.Builder;
 using Newtonsoft.Json;
 
-namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Cosmos
+namespace Microsoft.Bot.Builder.Tests.Integration.Azure.Storage
 {
-    public class CosmosDbStorageItem : IStoreItem
+    public class StorageItem : IStoreItem
     {
         [JsonProperty(PropertyName = "messageList")]
         public string[] MessageList { get; set; }

--- a/Tests/Integration/DotNet/ConfigurationFixture.cs
+++ b/Tests/Integration/DotNet/ConfigurationFixture.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Extensions.Configuration;
 
-namespace IntegrationTests
+namespace Microsoft.Bot.Builder.Tests.Integration
 {
     public class ConfigurationFixture
     {
@@ -14,8 +15,12 @@ namespace IntegrationTests
                 .AddJsonFile("appsettings.Development.json", true, true)
                 .AddEnvironmentVariables()
                 .Build();
+
+            Timeout = TimeSpan.FromSeconds(3);
         }
 
         public IConfigurationRoot Configuration { get; private set; }
+
+        public TimeSpan Timeout { get; private set; }
     }
 }

--- a/Tests/Integration/DotNet/Microsoft.Bot.Builder.Tests.Integration.csproj
+++ b/Tests/Integration/DotNet/Microsoft.Bot.Builder.Tests.Integration.csproj
@@ -12,11 +12,16 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="$(BotBuilderVersion)" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="$(BotBuilderVersion)">
+      <NoWarn>NU1605</NoWarn>
+    </PackageReference>
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="$(BotBuilderVersion)" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="$(BotBuilderVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="$(BotBuilderVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure.Queues" Version="$(BotBuilderVersionPreview)"/>
+    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="$(BotBuilderVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.22" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.22" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Integration/DotNet/appsettings.json
+++ b/Tests/Integration/DotNet/appsettings.json
@@ -5,6 +5,11 @@
       // See https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator?tabs=ssl-netstd21#authenticate-requests for details on the well known key being used.
       "ServiceEndpoint": "https://localhost:8081",
       "AuthKey": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+    },
+    "Storage": {
+      // Connection string shortcut to connect to the local Storage Emulator.
+      // See https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string for details on how to configure the connection string.
+      "ConnectionString": "UseDevelopmentStorage=true"
     }
   }
 }


### PR DESCRIPTION
Addresses #562

> **Note:** This PR depends on the commit 05e9916, which is already integrated into this branch.

## Description
This PR adds the `Azure Storage Queue` tests to the new `Integration` test project.

### Detailed Changes
- Added `Microsoft.Bot.Builder.Dialogs.Adaptive` and `Microsoft.Bot.Builder.Azure.Queues` dependencies to the `Integration.csproj`.
- Added the `Storage` section with the `ConnectionString` to the `appsettings.json` file, which will be used to connect to the Emulator or Storage Account resource.
- Added the `AzureQueueBaseFixture.cs` file that will be in charge of corroborating if the Storage service is up and running, otherwise, the tests will fail.
- Added `AzureQueueStorageTests.cs` file with 5 new tests that execute the `QueueActivityAsync` method under different situations.
  - Each test will create its own Queue container to prevent collisions.

## Testing
The following images show the new Storage Queue tests added to the Integration project, alongside the configuration and folder structure. 
![image](https://user-images.githubusercontent.com/62260472/153074174-ed69c780-3ac2-46c9-8706-af6658c524e3.png)