### PR TITLE
[#562][DotNet] Add Azure Storage tests to the Test Scenarios pipeline

### DIFF
--- a/Tests/Functional/Skills/CardActions/AnimationCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/AnimationCardTests.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Builder.Tests.Functional.Skills.CardActions
 {
-    [Trait("TestCategory", "CardActions")]
     public class AnimationCardTests : ScriptTestBase
     {
         private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";

--- a/Tests/Functional/Skills/CardActions/AudioCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/AudioCardTests.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Builder.Tests.Functional.Skills.CardActions
 {
-    [Trait("TestCategory", "CardActions")]
     public class AudioCardTests : ScriptTestBase
     {
         private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";

--- a/Tests/Functional/Skills/CardActions/BotActionCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/BotActionCardTests.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Builder.Tests.Functional.Skills.CardActions
 {
-    [Trait("TestCategory", "CardActions")]
     public class BotActionCardTests : ScriptTestBase
     {
         private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";

--- a/Tests/Functional/Skills/CardActions/CarouselCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/CarouselCardTests.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Builder.Tests.Functional.Skills.CardActions
 {
-    [Trait("TestCategory", "CardActions")]
     public class CarouselCardTests : ScriptTestBase
     {
         private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";

--- a/Tests/Functional/Skills/CardActions/HeroCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/HeroCardTests.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Builder.Tests.Functional.Skills.CardActions
 {
-    [Trait("TestCategory", "CardActions")]
     public class HeroCardTests : ScriptTestBase
     {
         private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";

--- a/Tests/Functional/Skills/CardActions/ListCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/ListCardTests.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Builder.Tests.Functional.Skills.CardActions
 {
-    [Trait("TestCategory", "CardActions")]
     public class ListCardTests : ScriptTestBase
     {
         private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";

--- a/Tests/Functional/Skills/CardActions/ReceiptCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/ReceiptCardTests.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Builder.Tests.Functional.Skills.CardActions
 {
-    [Trait("TestCategory", "CardActions")]
     public class ReceiptCardTests : ScriptTestBase
     {
         private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";

--- a/Tests/Functional/Skills/CardActions/SignInCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/SignInCardTests.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Builder.Tests.Functional.Skills.CardActions
 {
-    [Trait("TestCategory", "CardActions")]
     public class SignInCardTests : ScriptTestBase
     {
         private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";

--- a/Tests/Functional/Skills/CardActions/SubmitActionCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/SubmitActionCardTests.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Builder.Tests.Functional.Skills.CardActions
 {
-    [Trait("TestCategory", "CardActions")]
     public class SubmitActionCardTests : ScriptTestBase
     {
         private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";

--- a/Tests/Functional/Skills/CardActions/TaskModuleCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/TaskModuleCardTests.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Builder.Tests.Functional.Skills.CardActions
 {
-    [Trait("TestCategory", "CardActions")]
     public class TaskModuleCardTests : ScriptTestBase
     {
         private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";

--- a/Tests/Functional/Skills/CardActions/ThumbnailCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/ThumbnailCardTests.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Builder.Tests.Functional.Skills.CardActions
 {
-    [Trait("TestCategory", "CardActions")]
     public class ThumbnailCardTests : ScriptTestBase
     {
         private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";

--- a/Tests/Functional/Skills/CardActions/VideoCardTests.cs
+++ b/Tests/Functional/Skills/CardActions/VideoCardTests.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Builder.Tests.Functional.Skills.CardActions
 {
-    [Trait("TestCategory", "CardActions")]
     public class VideoCardTests : ScriptTestBase
     {
         private readonly string _testScriptsFolder = Directory.GetCurrentDirectory() + @"/Skills/CardActions/TestScripts";

--- a/Tests/Integration/DotNet/README.md
+++ b/Tests/Integration/DotNet/README.md
@@ -1,0 +1,45 @@
+# Integration tests
+
+## Requirements
+
+- [Azure Cosmos DB Emulator](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator?tabs=ssl-netstd21) latest version.
+- [Azurite](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=npm) equal or grater than `3.15.0` version.
+  > **Note (02-18-2022):** Visual Studio 2022 is installing Azurite `3.14.1`, which makes some tests to not work properly with expired Queues.
+
+## Tests
+
+| Library                                                                                   | Tests for                                                                                                                                                  | Requirements                                               | Configuration                                                                         |
+| ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [Microsoft.Bot.Builder.Azure](https://www.nuget.org/packages/Microsoft.Bot.Builder.Azure) | Cosmos                                                                                                                                                     | [Azure Cosmos DB Emulator](#requirements) running          | [Cosmos DB Emulator](#using-emulators) <br> [Azure Cosmos DB](#cosmos) |
+| [Microsoft.Bot.Builder.Azure](https://www.nuget.org/packages/Microsoft.Bot.Builder.Azure) | [Blobs](https://www.nuget.org/packages/Microsoft.Bot.Builder.Azure.Blobs) <br> [Queues](https://www.nuget.org/packages/Microsoft.Bot.Builder.Azure.Queues) | [Azurite](#requirements) Blobs and Queues services running | [Azurite](#using-emulators) <br> [Azure Storage Account](#storage)      |
+
+## Configuration
+
+The test project can be configured either by using `Environment variables`, or the [appsettings.json](appsettings.json) and `appsettings.Development.json` files.
+
+> **Note:**
+>
+> - **Order of importance:** `Environment variables` => `appsettings.Development.json` => `appsettings.json`.
+> - **Environment variables syntax**: `e.g. Azure:Cosmos:ServiceEndpoint=https://localhost:8081`.
+
+## Using Emulators
+
+The test project is already configured out of the box to use the supported Azurite and Cosmos DB emulators without any extra configuration to run the tests.<br>
+For more information on how to gather the connection values, use the following links:
+
+- [Azure Cosmos DB Emulator](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator?tabs=ssl-netstd21#authenticate-requests)
+- [Azurite](https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string#configure-a-connection-string-for-azurite)
+
+## Using Azure Resources
+
+### Cosmos DB
+
+Cosmos' tests require the `ServiceEndpoint` and `AuthKey` properties to authenticate the requests when using the service.<br>
+For more information on how to gather the connection values, use this [link](https://docs.microsoft.com/en-us/azure/cosmos-db/sql/manage-with-cli#list-connection-strings).
+
+> **Note:** `ServiceEndpoint` and `AuthKey` properties are equal to `AccountEndpoint` and `AccountKey` respectively.
+
+### Storage Account
+
+Storage's tests require the `ConnectionString` property to authenticate the requests when using the service.<br>
+For more information on how to gather the connection values, use this [link](https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string#configure-a-connection-string-for-an-azure-storage-account).

--- a/build/yaml/common/getStorageAccountConnectionVariables.yml
+++ b/build/yaml/common/getStorageAccountConnectionVariables.yml
@@ -1,0 +1,44 @@
+parameters:
+  - name: azureSubscription
+    displayName: Azure Service Connection
+    type: string
+
+  - name: resourceGroup
+    displayName: Name of the group where the StorageAccount resource is located
+    type: string
+
+  - name: resourceName
+    displayName: Name of the StorageAccount resource
+    type: string
+
+steps:
+  - task: AzureCLI@2
+    displayName: "Set StorageAccount connection variables"
+    inputs:
+      azureSubscription: "${{ parameters.azureSubscription }}"
+      scriptType: pscore
+      scriptLocation: inlineScript
+      failOnStderr: true
+      inlineScript: |
+        $connection = az storage account show-connection-string --name ${{ parameters.resourceName }} --resource-group ${{ parameters.resourceGroup }} | ConvertFrom-Json | Select-Object -ExpandProperty connectionString;
+
+        if ([string]::IsNullOrEmpty($connection)) {
+          Write-Host "##vso[task.logissue type=error]StorageAccount connection string couldn't be retrieved from Azure."
+          exit 1 # Force exit
+        }
+
+        $secretKeys = @("AccountKey");
+        $connectionPreview = $connection.Trim(";") -split ";" | ForEach-Object { 
+          $value = $_;
+          if($value -match $secretKeys){
+            return $value.Substring(0, $value.IndexOf("=") + 4) + "***";
+          }
+          return $value;
+        } | Join-String -Separator ";"
+
+        Write-Host "StorageAccount connection variables:";
+        [PSCustomObject]@{ 
+          ConnectionString = $connectionPreview
+        } | Format-Table -AutoSize
+
+        Write-Host "##vso[task.setvariable variable=StorageAccountConnectionString]$connection";

--- a/build/yaml/testScenarios/functional.yml
+++ b/build/yaml/testScenarios/functional.yml
@@ -40,7 +40,7 @@ stages:
     dependsOn: []
     jobs:
       - job: "Build"
-        displayName: "Build FunctionalTests.csproj"
+        displayName: "Build Microsoft.Bot.Builder.Tests.Functional.csproj"
         steps:
           - template: build.yml
             parameters:

--- a/build/yaml/testScenarios/integration.yml
+++ b/build/yaml/testScenarios/integration.yml
@@ -18,13 +18,17 @@ parameters:
     displayName: Resource Group name
     type: string
 
+  - name: storageAccount
+    displayName: StorageAccount name
+    type: string
+
 stages:
   - stage: "Build_DotNet_Integration"
     displayName: "Build DotNet Integration"
     dependsOn: []
     jobs:
       - job: "Build"
-        displayName: "Build IntegrationTests.csproj"
+        displayName: "Build Microsoft.Bot.Builder.Tests.Integration.csproj"
         steps:
           - template: ../common/dotnet/evaluateDependenciesVariables.yml
             parameters:
@@ -40,15 +44,15 @@ stages:
               env:
                 BotBuilderVersion: "$(DEPENDENCIESVERSIONNUMBER)"
                 BotBuilderRegistry: "$(DEPENDENCIESSOURCE)"
-              project: "Tests/Integration/DotNet/IntegrationTests.csproj"
+              project: "Tests/Integration/DotNet/Microsoft.Bot.Builder.Tests.Integration.csproj"
 
   - stage: "Test_DotNet_Integration"
     displayName: "Test DotNet Integration"
     dependsOn: Build_DotNet_Integration
     variables:
       Zip: "Integration/DotNet.zip"
-      Dll: "IntegrationTests.dll"
-      BaseNamespace: "IntegrationTests.Azure"
+      Dll: "Microsoft.Bot.Builder.Tests.Integration.dll"
+      BaseNamespace: "Microsoft.Bot.Builder.Tests.Integration.Azure"
     jobs:
       - job: "Test_Azure_Cosmos"
         displayName: "Test Azure.Cosmos"
@@ -67,4 +71,21 @@ stages:
                 Azure:Cosmos:AuthKey: "$(COSMOSDBAUTHKEY)"
               namespace: "$(BASENAMESPACE).Cosmos"
               trx: "$(BASENAMESPACE).Cosmos-$(BUILD.BUILDNUMBER).trx"
+              zip: "$(ZIP)"
+      - job: "Test_Azure_Storage"
+        displayName: "Test Azure.Storage"
+        steps:
+          - checkout: none
+          - template: ../common/getStorageAccountConnectionVariables.yml
+            parameters:
+              azureSubscription: "${{ parameters.azureSubscription }}"
+              resourceName: "${{ parameters.storageAccount }}"
+              resourceGroup: "${{ parameters.resourceGroup }}"
+          - template: test.yml
+            parameters:
+              dll: "$(DLL)"
+              env:
+                Azure:Storage:ConnectionString: "$(STORAGEACCOUNTCONNECTIONSTRING)"
+              namespace: "$(BASENAMESPACE).Storage"
+              trx: "$(BASENAMESPACE).Storage-$(BUILD.BUILDNUMBER).trx"
               zip: "$(ZIP)"

--- a/build/yaml/testScenarios/runTestScenarios.yml
+++ b/build/yaml/testScenarios/runTestScenarios.yml
@@ -60,6 +60,7 @@ variables:
   InternalResourceGroupName: $[coalesce(variables['RESOURCEGROUP'], 'BFFN')]
   InternalResourceSuffix: $[coalesce(variables['RESOURCESUFFIX'], '')]
   InternalSharedResourceGroupName: $[coalesce(variables['SHAREDRESOURCEGROUP'], 'BFFN-Shared')]
+  InternalStorageAccountName: "bffnstorageaccount$(INTERNALRESOURCESUFFIX)"
 
 pool:
   vmImage: "windows-2019"
@@ -89,6 +90,7 @@ stages:
       azureSubscription: "$(AZURESUBSCRIPTION)"
       cosmosDb: "$(INTERNALCOSMOSDBNAME)"
       resourceGroup: "$(INTERNALSHAREDRESOURCEGROUPNAME)"
+      storageAccount: "$(INTERNALSTORAGEACCOUNTNAME)"
       dotnet:
         registry: ${{ parameters.dependenciesRegistryDotNet }}
         version: ${{ parameters.dependenciesVersionDotNet }}


### PR DESCRIPTION
Addresses # 562

> **Note:** This PR depends on the PRs #582, #583, and #584.

## Description
This PR updates the Test Scenarios pipeline to add support for the new `Azure Storage` tests.

### Detailed Changes
- Added new documentation for the `Integration/Dotnet` project.
- Added `getStorageAccountConnectionVariables.yml` file to gather the `StorageAccount` connection string.
- Added `Choose` conditions to the root `Directory.Build.props` to handle preview versions.
- Updated the `integration.yml` file including the new `Azure.Storage` job to handle all the Storage namespace tests.
- Removed all `TestCategories` from `CardAction`.

## Testing
The following images show the tests working as expected in the pipelines.
![image](https://user-images.githubusercontent.com/62260472/154758543-61b44f95-9c58-4f4a-b413-d99ea6040f6d.png)