### PR TITLE
Skill bots functional test pipeline tweaks

### DIFF
--- a/build/yaml/common/getCosmosDbConnectionVariables.yml
+++ b/build/yaml/common/getCosmosDbConnectionVariables.yml
@@ -18,7 +18,7 @@ steps:
       azureSubscription: "${{ parameters.azureSubscription }}"
       scriptType: pscore
       scriptLocation: inlineScript
-      failOnStderr: true
+      failOnStandardError: true
       inlineScript: |
         $connection, $rest = az cosmosdb keys list --name ${{ parameters.resourceName }} --resource-group ${{ parameters.resourceGroup }} --type connection-strings | ConvertFrom-Json | Select-Object -ExpandProperty connectionStrings | Select-Object -ExpandProperty connectionString;
 

--- a/build/yaml/deployBotResources/js/deploy.yml
+++ b/build/yaml/deployBotResources/js/deploy.yml
@@ -137,7 +137,7 @@ stages:
             inputs:
               azureSubscription: "${{ parameters.azureSubscription }}"
               addSpnToEnvironment: true
-              failOnStderr: true
+              failOnStandardError: true
               scriptType: pscore
               scriptLocation: inlineScript
               workingDirectory: $(SYSTEM.DEFAULTWORKINGDIRECTORY)/${{ bot.project.directory }}

--- a/build/yaml/deployBotResources/python/deploy.yml
+++ b/build/yaml/deployBotResources/python/deploy.yml
@@ -122,7 +122,7 @@ stages:
             inputs:
               azureSubscription: "${{ parameters.azureSubscription }}"
               addSpnToEnvironment: true
-              failOnStderr: true
+              failOnStandardError: true
               scriptType: pscore
               scriptLocation: inlineScript
               workingDirectory: $(SYSTEM.DEFAULTWORKINGDIRECTORY)/${{ bot.project.directory }}

--- a/build/yaml/testScenarios/configureConsumers.yml
+++ b/build/yaml/testScenarios/configureConsumers.yml
@@ -38,7 +38,7 @@ steps:
       azureSubscription: ${{ parameters.azureSubscription }}
       scriptType: pscore
       scriptLocation: inlineScript
-      failOnStderr: true
+      failOnStandardError: true
       inlineScript: |
         # Global Variables
         $resourceGroup = "${{ parameters.resourceGroup }}";

--- a/build/yaml/testScenarios/functional.yml
+++ b/build/yaml/testScenarios/functional.yml
@@ -73,6 +73,7 @@ stages:
     jobs:
       - job: "Test_Skills_CardActions"
         displayName: "Test Skills.CardActions"
+        timeoutInMinutes: 20
         steps:
           - checkout: none
           - template: test.yml
@@ -84,6 +85,7 @@ stages:
               zip: "$(ZIP)"
       - job: "Test_Skills_FileUpload"
         displayName: "Test Skills.FileUpload"
+        timeoutInMinutes: 20
         steps:
           - checkout: none
           - template: test.yml
@@ -95,6 +97,7 @@ stages:
               zip: "$(ZIP)"
       - job: "Test_Skills_MessageWithAttachment"
         displayName: "Test Skills.MessageWithAttachment"
+        timeoutInMinutes: 20
         steps:
           - checkout: none
           - template: test.yml
@@ -106,6 +109,7 @@ stages:
               zip: "$(ZIP)"
       - job: "Test_Skills_ProactiveMessages"
         displayName: "Test Skills.ProactiveMessages"
+        timeoutInMinutes: 20
         steps:
           - checkout: none
           - template: test.yml
@@ -117,6 +121,7 @@ stages:
               zip: "$(ZIP)"
       - job: "Test_Skills_SignIn"
         displayName: "Test Skills.SignIn"
+        timeoutInMinutes: 20
         steps:
           - checkout: none
           - template: test.yml
@@ -128,6 +133,7 @@ stages:
               zip: "$(ZIP)"
       - job: "Test_Skills_SingleTurn"
         displayName: "Test Skills.SingleTurn"
+        timeoutInMinutes: 20
         steps:
           - checkout: none
           - template: test.yml

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -32,12 +32,13 @@ steps:
     continueOnError: true
     inputs:
       script: |
-        Write-Host "tests dll: [ ${{ parameters.dll }} ]";
-        Write-Host "tests filter: [ ${{ parameters.namespace }} ]";
-        Write-Host "trx output: [ ${{ parameters.trx }} ]";
-        Write-Host "project zip: [ ${{ parameters.zip }} ]";
-        Write-Host "appsettings: [ ${{ parameters.appsettings }} ]";
-        Write-Host "env vars: [ ${{ parameters.env }} ]";
+        Write-Host "tests dll: [${{ parameters.dll }}]";
+        Write-Host "tests filter: [${{ parameters.namespace }}]";
+        Write-Host "trx output: [${{ parameters.trx }}]";
+        Write-Host "project zip: [${{ parameters.zip }}]";
+        Write-Host "appsettings: [${{ parameters.appsettings }}]";
+        $env = Out-String -InputObject ${{ parameters.env }};
+        Write-Host "env vars: [$env]";
 
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build"

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -37,6 +37,7 @@ steps:
         Write-Host "trx output: [${{ parameters.trx }}]";
         Write-Host "project zip: [${{ parameters.zip }}]";
         Write-Host "appsettings: [${{ parameters.appsettings }}]";
+        $x = Out-String -InputObject ${{ parameters.env }};
 
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build"

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -32,8 +32,8 @@ steps:
     continueOnError: true
     inputs:
       script: |
-        $x = "${{ parameters.dll }}";
-        #Write-Host 'tests dll:' $x;
+        Write-Host 'tests dll: ' -NoNewline;
+        Write-Host ${{ parameters.dll }};
         #Write-Host "tests filter:" "${{ parameters.namespace }}";
         #Write-Host "trx output:" "${{ parameters.trx }}";
         #Write-Host "project zip:" "${{ parameters.zip }}";

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -33,6 +33,10 @@ steps:
     inputs:
       script: |
         Write-Host "tests dll: [${{ parameters.dll }}]";
+        Write-Host "tests filter: [${{ parameters.namespace }}]";
+        Write-Host "trx output: [${{ parameters.trx }}]";
+        Write-Host "project zip: [${{ parameters.zip }}]";
+        Write-Host "appsettings: [${{ parameters.appsettings }}]";
 
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build"

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -37,8 +37,8 @@ steps:
         Write-Host "trx output: [${{ parameters.trx }}]";
         Write-Host "project zip: [${{ parameters.zip }}]";
         Write-Host "appsettings: [${{ parameters.appsettings }}]";
-        $env = Out-String -InputObject ${{ parameters.env }};
-        Write-Host "env vars: [$env]";
+        #$env = Out-String -InputObject ${{ parameters.env }};
+        #Write-Host "env vars: [$env]";
 
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build"

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -37,7 +37,6 @@ steps:
         Write-Host "trx output: [${{ parameters.trx }}]";
         Write-Host "project zip: [${{ parameters.zip }}]";
         Write-Host "appsettings: [${{ parameters.appsettings }}]";
-        $x = Out-String -InputObject ${{ parameters.env }};
 
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build"

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -33,7 +33,7 @@ steps:
     inputs:
       script: |
         #Write-Host 'tests dll: ' -NoNewline;
-        ${{ parameters.dll }};
+        #${{ parameters.dll }};
         #Write-Host "tests filter:" "${{ parameters.namespace }}";
         #Write-Host "trx output:" "${{ parameters.trx }}";
         #Write-Host "project zip:" "${{ parameters.zip }}";

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -32,8 +32,7 @@ steps:
     continueOnError: true
     inputs:
       script: |
-        Write-Host 'tests dll: ' -NoNewline;
-        ${{ parameters.dll }};
+        Write-Host "tests dll: [${{ parameters.dll }}]";
 
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build"

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -32,7 +32,8 @@ steps:
     continueOnError: true
     inputs:
       script: |
-        Write-Host "tests dll:" "${{ parameters.dll }}";
+        $x = "tests dll:" + "${{ parameters.dll }}";
+        Write-Host $x";
         #Write-Host "tests filter:" "${{ parameters.namespace }}";
         #Write-Host "trx output:" "${{ parameters.trx }}";
         #Write-Host "project zip:" "${{ parameters.zip }}";

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -26,6 +26,19 @@ parameters:
     default: {}
 
 steps:
+  - task: PowerShell@2
+    displayName: "Show parameters"
+    condition: succeededOrFailed()
+    inputs:
+      targetType: inline
+      script: |
+        Write-Host "tests dll: [${{ parameters.dll }}]";
+        Write-Host "tests filter: [${{ parameters.namespace }}]";
+        Write-Host "trx output: [${{ parameters.trx }}]";
+        Write-Host "project zip: [${{ parameters.zip }}]";
+        Write-Host "appsettings: [${{ parameters.appsettings }}]";
+        Write-Host "env vars: [${{ parameters.env }}]";
+
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build"
     inputs:

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -31,6 +31,7 @@ steps:
     condition: succeededOrFailed()
     continueOnError: true
     inputs:
+      targetType: inline
       script: |
         Write-Host "tests dll: [${{ parameters.dll }}]";
         Write-Host "tests filter: [${{ parameters.namespace }}]";

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -32,14 +32,6 @@ steps:
     continueOnError: true
     inputs:
       script: |
-        #Write-Host 'tests dll: ' -NoNewline;
-        #${{ parameters.dll }};
-        #Write-Host "tests filter:" "${{ parameters.namespace }}";
-        #Write-Host "trx output:" "${{ parameters.trx }}";
-        #Write-Host "project zip:" "${{ parameters.zip }}";
-        #Write-Host "appsettings:" "${{ parameters.appsettings }}";
-        #$env = Out-String -InputObject ${{ parameters.env }};
-        #Write-Host "env vars: [$env]";
 
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build"

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -32,6 +32,7 @@ steps:
     continueOnError: true
     inputs:
       script: |
+        Write-Host 'tests dll: ' -NoNewline;
 
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build"

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -32,8 +32,8 @@ steps:
     continueOnError: true
     inputs:
       script: |
-        $x = "${{ parameters.dll }}"";
-        Write-Host 'tests dll:' $x;
+        $x = "${{ parameters.dll }}";
+        #Write-Host 'tests dll:' $x;
         #Write-Host "tests filter:" "${{ parameters.namespace }}";
         #Write-Host "trx output:" "${{ parameters.trx }}";
         #Write-Host "project zip:" "${{ parameters.zip }}";

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -32,8 +32,8 @@ steps:
     continueOnError: true
     inputs:
       script: |
-        Write-Host 'tests dll: ' -NoNewline;
-        Write-Host ${{ parameters.dll }};
+        #Write-Host 'tests dll: ' -NoNewline;
+        ${{ parameters.dll }};
         #Write-Host "tests filter:" "${{ parameters.namespace }}";
         #Write-Host "trx output:" "${{ parameters.trx }}";
         #Write-Host "project zip:" "${{ parameters.zip }}";

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -33,10 +33,10 @@ steps:
     inputs:
       script: |
         Write-Host "tests dll:" "${{ parameters.dll }}";
-        Write-Host "tests filter:" "${{ parameters.namespace }}";
-        Write-Host "trx output:" "${{ parameters.trx }}";
-        Write-Host "project zip:" "${{ parameters.zip }}";
-        Write-Host "appsettings:" "${{ parameters.appsettings }}";
+        #Write-Host "tests filter:" "${{ parameters.namespace }}";
+        #Write-Host "trx output:" "${{ parameters.trx }}";
+        #Write-Host "project zip:" "${{ parameters.zip }}";
+        #Write-Host "appsettings:" "${{ parameters.appsettings }}";
         #$env = Out-String -InputObject ${{ parameters.env }};
         #Write-Host "env vars: [$env]";
 

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -29,15 +29,15 @@ steps:
   - task: PowerShell@2
     displayName: "Show parameters"
     condition: succeededOrFailed()
+    continueOnError: true
     inputs:
-      targetType: inline
       script: |
-        Write-Host "tests dll: [${{ parameters.dll }}]";
-        Write-Host "tests filter: [${{ parameters.namespace }}]";
-        Write-Host "trx output: [${{ parameters.trx }}]";
-        Write-Host "project zip: [${{ parameters.zip }}]";
-        Write-Host "appsettings: [${{ parameters.appsettings }}]";
-        Write-Host "env vars: [${{ parameters.env }}]";
+        Write-Host "tests dll: [ ${{ parameters.dll }} ]";
+        Write-Host "tests filter: [ ${{ parameters.namespace }} ]";
+        Write-Host "trx output: [ ${{ parameters.trx }} ]";
+        Write-Host "project zip: [ ${{ parameters.zip }} ]";
+        Write-Host "appsettings: [ ${{ parameters.appsettings }} ]";
+        Write-Host "env vars: [ ${{ parameters.env }} ]";
 
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build"

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -32,8 +32,8 @@ steps:
     continueOnError: true
     inputs:
       script: |
-        #$x = ${{ parameters.dll }};
-        Write-Host 'tests dll:' ${{ parameters.dll }};
+        $x = ${{ parameters.dll }};
+        Write-Host 'tests dll:' $x;
         #Write-Host "tests filter:" "${{ parameters.namespace }}";
         #Write-Host "trx output:" "${{ parameters.trx }}";
         #Write-Host "project zip:" "${{ parameters.zip }}";

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -32,11 +32,11 @@ steps:
     continueOnError: true
     inputs:
       script: |
-        Write-Host "tests dll: [${{ parameters.dll }}]";
-        Write-Host "tests filter: [${{ parameters.namespace }}]";
-        Write-Host "trx output: [${{ parameters.trx }}]";
-        Write-Host "project zip: [${{ parameters.zip }}]";
-        Write-Host "appsettings: [${{ parameters.appsettings }}]";
+        Write-Host "tests dll:" "${{ parameters.dll }}";
+        Write-Host "tests filter:" "${{ parameters.namespace }}";
+        Write-Host "trx output:" "${{ parameters.trx }}";
+        Write-Host "project zip:" "${{ parameters.zip }}";
+        Write-Host "appsettings:" "${{ parameters.appsettings }}";
         #$env = Out-String -InputObject ${{ parameters.env }};
         #Write-Host "env vars: [$env]";
 

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -33,6 +33,7 @@ steps:
     inputs:
       script: |
         Write-Host 'tests dll: ' -NoNewline;
+        ${{ parameters.dll }};
 
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build"

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -32,7 +32,7 @@ steps:
     continueOnError: true
     inputs:
       script: |
-        $x = ${{ parameters.dll }};
+        $x = "${{ parameters.dll }}"";
         Write-Host 'tests dll:' $x;
         #Write-Host "tests filter:" "${{ parameters.namespace }}";
         #Write-Host "trx output:" "${{ parameters.trx }}";

--- a/build/yaml/testScenarios/test.yml
+++ b/build/yaml/testScenarios/test.yml
@@ -32,8 +32,8 @@ steps:
     continueOnError: true
     inputs:
       script: |
-        $x = "tests dll:" + "${{ parameters.dll }}";
-        Write-Host $x";
+        #$x = ${{ parameters.dll }};
+        Write-Host 'tests dll:' ${{ parameters.dll }};
         #Write-Host "tests filter:" "${{ parameters.namespace }}";
         #Write-Host "trx output:" "${{ parameters.trx }}";
         #Write-Host "project zip:" "${{ parameters.zip }}";


### PR DESCRIPTION
Fixes #minor

Fix AzureCLI@2: change failOnStderr to failOnStandardError. Documentation does not support the former syntax. (Former syntax is used in powershell and command line tasks, but not this one.) Hoping this will fix cases like the silent failure pushing the bffnsimplehostbotjs container to the container registry in 02.A. Deploy skill bots (daily)/314010. It had a "500 Internal Server Error", but the task remained green.

Shorten test timeouts from 60 to 20 minutes. The test jobs when succeeding take less than 7 minutes. When failing they can run out the clock.

Add "Show parameters" task to make troubleshooting easier.

This build exhibits the above tweaks: https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=314091&view=results